### PR TITLE
Androapp 1794 - Fixes alert's buttons not showing

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -131,6 +131,7 @@
 
     <style name="CustomDialog" parent="Base.AlertDialog.AppCompat.Light">
         <item name="android:textColor">?colorPrimary</item>
+        <item name="colorAccent">?colorPrimary</item>
     </style>
 
     <style name="ButtonRoundedGrey" parent="Base.TextAppearance.AppCompat.Button">


### PR DESCRIPTION
Fixes issue when on some devices the dialog alert button were colored white and couldn't be seen.