### PR TITLE
fix(DateTimeCustomView): Resets picker initial value when date picker is shown

### DIFF
--- a/app/src/main/java/org/dhis2/utils/custom_views/DateTimeView.java
+++ b/app/src/main/java/org/dhis2/utils/custom_views/DateTimeView.java
@@ -152,6 +152,7 @@ public class DateTimeView extends FieldLayout implements View.OnClickListener, V
                     public void onNegativeClick() {
                         editText.setText(null);
                         listener.onDateSelected(null);
+                        date = null;
                     }
 
                     @Override
@@ -179,6 +180,7 @@ public class DateTimeView extends FieldLayout implements View.OnClickListener, V
             editText.setText(result);
             listener.onDateSelected(selectedDate);
             nextFocus(view);
+            date = null;
         },
                 hour,
                 minute,

--- a/app/src/main/java/org/dhis2/utils/custom_views/DateView.java
+++ b/app/src/main/java/org/dhis2/utils/custom_views/DateView.java
@@ -161,6 +161,7 @@ public class DateView extends FieldLayout implements View.OnClickListener {
                     public void onNegativeClick() {
                         editText.setText(null);
                         listener.onDateSelected(null);
+                        date = null;
                     }
 
                     @Override
@@ -175,6 +176,7 @@ public class DateView extends FieldLayout implements View.OnClickListener {
                         editText.setText(result);
                         listener.onDateSelected(selectedDate);
                         nextFocus(DateView.this);
+                        date = null;
                     }
                 }).show();
     }

--- a/app/src/main/java/org/dhis2/utils/custom_views/TimeView.java
+++ b/app/src/main/java/org/dhis2/utils/custom_views/TimeView.java
@@ -150,12 +150,14 @@ public class TimeView extends FieldLayout implements View.OnClickListener {
             }
             listener.onDateSelected(selectedDate);
             nextFocus(view);
+            date = null;
         }, hour, minute, is24HourFormat);
         dialog.setTitle(label);
 
         dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getContext().getString(R.string.date_dialog_clear), (timeDialog, which) -> {
             editText.setText(null);
             listener.onDateSelected(null);
+            date=null;
         });
 
         dialog.show();


### PR DESCRIPTION
Fixes the date, datetime and time value type fields to reset picker's initial value when shown.

Jira Issue: [ANDROAPP-2253](https://jira.dhis2.org/browse/ANDROAPP-2253)