### PR TITLE
fix(EventCapturePresenterImpl): Fixes that a re-opened event showed the finish and complete bottom sheet

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.java
@@ -596,6 +596,7 @@ public class EventCapturePresenterImpl implements EventCaptureContract.Presenter
     @Override
     public void reopenEvent() {
         if (eventCaptureRepository.reopenEvent()) {
+            currentPosition = 0;
             currentSectionPosition.onNext(0);
             view.showSnackBar(R.string.event_reopened);
             eventStatus = EventStatus.ACTIVE;


### PR DESCRIPTION
Fixes that a re-opened event showed the finish and complete bottom sheet and did't allowed a user to move to different sections.