### PR TITLE
fix: fixes calls to sdk modules .withAllChildren()

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/RulesRepository.java
+++ b/app/src/main/java/org/dhis2/data/forms/RulesRepository.java
@@ -556,7 +556,7 @@ public final class RulesRepository {
                                         new ArrayList<>(),
                                         programName));
                     else
-                        return d2.enrollmentModule().enrollments.uid(event.enrollment()).withAllChildren().get()
+                        return d2.enrollmentModule().enrollments.uid(event.enrollment()).get()
                                 .map(enrollment -> RuleEnrollment.create(enrollment.uid(),
                                         enrollment.enrollmentDate(),
                                         enrollment.incidentDate() != null ? enrollment.incidentDate() : new Date(),

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentFormRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentFormRepositoryImpl.kt
@@ -211,7 +211,7 @@ class EnrollmentFormRepositoryImpl(
     }
 
     private fun queryAttributes(): Flowable<List<RuleAttributeValue>> {
-        return programRepository.get()
+        return d2.programModule().programs.withProgramTrackedEntityAttributes().uid(programUid).get()
                 .map { program ->
                     program.programTrackedEntityAttributes()!!.filter {
                         d2.trackedEntityModule().trackedEntityAttributeValues


### PR DESCRIPTION
Fixes issue that didn't get the program's trackedEntityAttribute because the sdk remove the .withAllChildren() method. Removes .withAllChildren() call from the RuleRepository