### PR TITLE
fix: when wrong patters remove the dataelement value

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/EditTextCustomHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/EditTextCustomHolder.java
@@ -87,7 +87,7 @@ final class EditTextCustomHolder extends FormViewHolder {
     }
 
     private void sendAction() {
-        if (!isEmpty(binding.customEdittext.getEditText().getText()) && editTextModel.error() == null) {
+        if (!isEmpty(binding.customEdittext.getEditText().getText())) {
             checkAutocompleteRendering();
             editTextModel.withValue(binding.customEdittext.getEditText().getText().toString());
             String value = ValidationUtils.validate(editTextModel.valueType(), binding.customEdittext.getEditText().getText().toString());
@@ -154,7 +154,7 @@ final class EditTextCustomHolder extends FormViewHolder {
                     !binding.customEdittext.getEditText().getText().toString().matches(editTextModel.fieldMask()))
                 binding.customEdittext.setWarning(binding.getRoot().getContext().getString(R.string.wrong_pattern), "");
             else
-                binding.customEdittext.setWarning("", "");
+                binding.customEdittext.setWarning(editTextModel.warning(), editTextModel.error());
     }
 
     @NonNull

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.java
@@ -772,6 +772,7 @@ public class EventCapturePresenterImpl implements EventCaptureContract.Presenter
     public void setShowError(@NonNull RuleActionShowError showError, @Nullable FieldViewModel model) {
         canComplete = false;
         errors.put(eventCaptureRepository.getSectionFor(showError.field()), showError.field());
+        save(showError.field(), null);
     }
 
     @Override


### PR DESCRIPTION
This commit fixes a bug when wrong pattern appears and changes another field and returns the focus of previous field.

https://jira.dhis2.org/browse/ANDROAPP-2342