### PR TITLE
docs: Update dhis2_android_capture_app_INDEX.md [skip ci]

### DIFF
--- a/docs/src/commonmark/en/dhis2_android_capture_app_INDEX.md
+++ b/docs/src/commonmark/en/dhis2_android_capture_app_INDEX.md
@@ -2,7 +2,6 @@
 title: 'DHIS 2 configuration guide for the Android capture app'
 ---
 
-!INCLUDE "content/common/about-this-android-guide.md" 
 !INCLUDE "content/capture-app/introduction.md"
 !INCLUDE "content/capture-app/recommendations-for-a-dhis2-mobile-deployment.md"
 !INCLUDE "content/capture-app/contribute-to-the-app.md"


### PR DESCRIPTION
The index is using now the common section from the main repository in dhis2-docs