### PR TITLE
fix: [ANDROAPP-2845] Missing import in ContextExtension

### DIFF
--- a/app/src/dhisNoSMS/java/org.dhis2.Bindings/ContextExtensions.kt
+++ b/app/src/dhisNoSMS/java/org.dhis2.Bindings/ContextExtensions.kt
@@ -1,6 +1,7 @@
 package org.dhis2.Bindings
 
 import android.content.Context
+import androidx.fragment.app.Fragment
 import hu.supercluster.paperwork.Paperwork
 import org.dhis2.BuildConfig
 


### PR DESCRIPTION
[issue](https://jira.dhis2.org/browse/ANDROAPP-2845)