### PR TITLE
chore: remove google api key from strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">Dhis2</string>
     <string name="logo_text">dhis</string>
     <string name="logo_number">2</string>
-    <string name="google_api" translatable="false">AIzaSyATNJAcNH6YB8ZzkJbzh1vWOgMAKi7KEnQ</string>
     <string name="tab" translatable="false">\u0009</string>
     <string name="default_notification_channel_id" translatable="false">20180901</string>
     <!-- Warnings and error messages -->


### PR DESCRIPTION
I just stumbled on this - it appears to be a Google API key (presumably for maps) which isn't used anywhere.  As such I think it should probably be removed? (we shouldn't hard-code API keys anyways)