### PR TITLE
chore: [ANDROAPP-2908] Separates QR code formats depending ValueTypeRenderingType

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/qrScanner/ScanActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/qrScanner/ScanActivity.kt
@@ -58,7 +58,7 @@ class ScanActivity : ActivityGlobalAbstract(), ZXingScannerView.ResultHandler {
             ?.inject(this)
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_scan)
-        renderingType = intent.getSerializableExtra(Constants.SCAN_RENDERING_TYPE) as ValueTypeRenderingType
+        renderingType = intent.getSerializableExtra(Constants.SCAN_RENDERING_TYPE) as ValueTypeRenderingType?
         mScannerView = binding.scannerView
         mScannerView.apply {
             setAutoFocus(true)
@@ -74,7 +74,7 @@ class ScanActivity : ActivityGlobalAbstract(), ZXingScannerView.ResultHandler {
                 ValueTypeRenderingType.QR_CODE -> {
                     setFormats(listOf(QR_CODE, DATA_MATRIX, MAXICODE, AZTEC))
                 }
-                else -> throw IllegalArgumentException("ValueTypeRenderingType is not implemented")
+                else -> setFormats(ZXingScannerView.ALL_FORMATS)
             }
         }
     }

--- a/app/src/main/java/org/dhis2/usescases/qrScanner/ScanActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/qrScanner/ScanActivity.kt
@@ -8,6 +8,23 @@ import android.os.Bundle
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
+import com.google.zxing.BarcodeFormat.AZTEC
+import com.google.zxing.BarcodeFormat.CODABAR
+import com.google.zxing.BarcodeFormat.CODE_39
+import com.google.zxing.BarcodeFormat.CODE_93
+import com.google.zxing.BarcodeFormat.CODE_128
+import com.google.zxing.BarcodeFormat.DATA_MATRIX
+import com.google.zxing.BarcodeFormat.EAN_13
+import com.google.zxing.BarcodeFormat.EAN_8
+import com.google.zxing.BarcodeFormat.ITF
+import com.google.zxing.BarcodeFormat.MAXICODE
+import com.google.zxing.BarcodeFormat.PDF_417
+import com.google.zxing.BarcodeFormat.QR_CODE
+import com.google.zxing.BarcodeFormat.RSS_14
+import com.google.zxing.BarcodeFormat.RSS_EXPANDED
+import com.google.zxing.BarcodeFormat.UPC_A
+import com.google.zxing.BarcodeFormat.UPC_E
+import com.google.zxing.BarcodeFormat.UPC_EAN_EXTENSION
 import com.google.zxing.Result
 import me.dm7.barcodescanner.zxing.ZXingScannerView
 import org.dhis2.App
@@ -15,6 +32,7 @@ import org.dhis2.R
 import org.dhis2.databinding.ActivityScanBinding
 import org.dhis2.usescases.general.ActivityGlobalAbstract
 import org.dhis2.utils.Constants
+import org.hisp.dhis.android.core.common.ValueTypeRenderingType
 import javax.inject.Inject
 
 class ScanActivity : ActivityGlobalAbstract(), ZXingScannerView.ResultHandler {
@@ -22,6 +40,7 @@ class ScanActivity : ActivityGlobalAbstract(), ZXingScannerView.ResultHandler {
     private lateinit var mScannerView: ZXingScannerView
     private var isPermissionRequested = false
     private var optionSetUid: String? = null
+    private var renderingType: ValueTypeRenderingType? = null
 
     @Inject
     lateinit var scanRepository: ScanRepository
@@ -39,9 +58,25 @@ class ScanActivity : ActivityGlobalAbstract(), ZXingScannerView.ResultHandler {
             ?.inject(this)
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_scan)
+        renderingType = intent.getSerializableExtra(Constants.SCAN_RENDERING_TYPE) as ValueTypeRenderingType
         mScannerView = binding.scannerView
-        mScannerView.setAutoFocus(true)
-        mScannerView.setFormats(ZXingScannerView.ALL_FORMATS)
+        mScannerView.apply {
+            setAutoFocus(true)
+            when(renderingType) {
+                ValueTypeRenderingType.BAR_CODE -> {
+                    setFormats(
+                        listOf(
+                            CODE_39, CODE_128, CODE_93, CODABAR,
+                            EAN_13, EAN_8, UPC_A, UPC_E, UPC_EAN_EXTENSION,
+                            ITF, PDF_417, RSS_14, RSS_EXPANDED)
+                    )
+                }
+                ValueTypeRenderingType.QR_CODE -> {
+                    setFormats(listOf(QR_CODE, DATA_MATRIX, MAXICODE, AZTEC))
+                }
+                else -> throw IllegalArgumentException("ValueTypeRenderingType is not implemented")
+            }
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/dhis2/utils/Constants.java
+++ b/app/src/main/java/org/dhis2/utils/Constants.java
@@ -133,6 +133,8 @@ public class Constants {
     public static final String NOTE_TYPE = "NOTE_TYPE";
 
     public static final String OPTION_SET = "OPTION_SET";
+    @Nullable
+    public static final String SCAN_RENDERING_TYPE = "SCAN_RENDERING_TYPE";
 
     private Constants() {
         // hide public constructor

--- a/app/src/main/java/org/dhis2/utils/customviews/ScanTextView.kt
+++ b/app/src/main/java/org/dhis2/utils/customviews/ScanTextView.kt
@@ -37,6 +37,7 @@ class ScanTextView @JvmOverloads constructor(
     private lateinit var onScanClick: OnScanClick
     private lateinit var onScanResult: (String?) -> Unit
     var optionSet: String? = null
+    private var renderingType: ValueTypeRenderingType? = null
 
     init {
         init(context)
@@ -67,6 +68,7 @@ class ScanTextView @JvmOverloads constructor(
         ) {
             val intent = Intent(context, ScanActivity::class.java)
             intent.putExtra(Constants.OPTION_SET, optionSet)
+            intent.putExtra(Constants.SCAN_RENDERING_TYPE, renderingType)
             this.onScanClick.onsScanClicked(intent, this)
         }
     }
@@ -133,6 +135,7 @@ class ScanTextView @JvmOverloads constructor(
     }
 
     fun setRenderingType(type: ValueTypeRenderingType?) {
+        renderingType = type
         when (type) {
             ValueTypeRenderingType.BAR_CODE -> {
                 descIcon.setImageResource(R.drawable.ic_form_barcode)


### PR DESCRIPTION
This PR was already tested and merged to the develop branch in PR #1349, but it's needed in 2.1.1.