### PR TITLE
fix: [ANDROAPP-3020] Tint event initial icon with the same colors as in home screen

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -779,12 +779,12 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
 
     @Override
     public void renderObjectStyle(ObjectStyle data) {
-
+        int color = ColorUtils.getColorFrom(data.color(),
+                ColorUtils.getPrimaryColor(this, ColorUtils.ColorType.PRIMARY_LIGHT));
         binding.programStageIcon.setBackground(
                 ColorUtils.tintDrawableWithColor(
                         binding.programStageIcon.getBackground(),
-                        ColorUtils.getColorFrom(data.color(),
-                                ColorUtils.getPrimaryColor(this, ColorUtils.ColorType.PRIMARY_LIGHT))
+                        color
                 )
         );
         binding.programStageIcon.setImageResource(
@@ -793,6 +793,8 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
                         R.drawable.ic_program_default
                 )
         );
+        binding.programStageIcon.setColorFilter(ColorUtils.getContrastColor(color));
+
     }
 
     @Override

--- a/app/src/main/res/layout/activity_event_initial.xml
+++ b/app/src/main/res/layout/activity_event_initial.xml
@@ -124,7 +124,6 @@
                                 android:layout_height="48dp"
                                 android:contentDescription='@{name}'
                                 android:padding="4dp"
-                                android:tint="?colorPrimaryDark"
                                 android:background="@drawable/rounded_square"
                                 app:srcCompat="@drawable/ic_clinical_f_outline" />
 


### PR DESCRIPTION
[issue](https://jira.dhis2.org/browse/ANDROAPP-3020)