### PR TITLE
fix: 2.1.2 androapp 3076

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/ValueStoreImpl.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/ValueStoreImpl.kt
@@ -87,7 +87,6 @@ class ValueStoreImpl(
         } else {
             ""
         }
-
         return if (currentValue != newValue) {
             if (!DhisTextUtils.isEmpty(value)) {
                 valueRepository.blockingSetCheck(d2, uid, newValue)

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/ValueStoreImpl.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/ValueStoreImpl.kt
@@ -5,6 +5,7 @@ import org.dhis2.Bindings.blockingSetCheck
 import org.dhis2.usescases.datasets.dataSetTable.DataSetTableModel
 import org.dhis2.utils.DhisTextUtils
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper
 import org.hisp.dhis.android.core.common.ValueType
 import java.io.File
 
@@ -73,7 +74,7 @@ class ValueStoreImpl(
 
         val valueRepository = d2.trackedEntityModule().trackedEntityAttributeValues()
             .value(uid, recordUid)
-        var newValue = value?:""
+        var newValue = value ?: ""
         if (d2.trackedEntityModule().trackedEntityAttributes().uid(uid).blockingGet().valueType() ==
             ValueType.IMAGE &&
             value != null
@@ -102,7 +103,7 @@ class ValueStoreImpl(
     private fun saveDataElement(uid: String, value: String?): Flowable<StoreResult> {
         val valueRepository = d2.trackedEntityModule().trackedEntityDataValues()
             .value(recordUid, uid)
-        var newValue = value?:""
+        var newValue = value ?: ""
         if (d2.dataElementModule().dataElements().uid(uid).blockingGet().valueType() ==
             ValueType.IMAGE &&
             value != null
@@ -147,7 +148,7 @@ class ValueStoreImpl(
     }
 
     private fun saveFileResource(path: String): String {
-        val file = File(path)
+        val file = FileResizerHelper.resizeFile(File(path), FileResizerHelper.Dimension.MEDIUM)
         return d2.fileResourceModule().fileResources().blockingAdd(file)
     }
 


### PR DESCRIPTION
## Description
Before saving a file, we have to resize to MEDIUM

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3076)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [x] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code