### PR TITLE
fix: [ANDROAPP-3077] Show complete text in dataset column header

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetRHeaderHeader.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetRHeaderHeader.java
@@ -22,5 +22,6 @@ public class DataSetRHeaderHeader extends AbstractViewHolder {
     public void bind(String rowHeaderTitle, ObservableField<DataSetTableAdapter.TableScale> tableScale) {
         binding.setTableScale(tableScale);
         binding.title.setText(rowHeaderTitle);
+        binding.title.setSelected(true);
     }
 }

--- a/app/src/main/res/layout/item_dataset_header.xml
+++ b/app/src/main/res/layout/item_dataset_header.xml
@@ -20,17 +20,21 @@
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:ellipsize="end"
-            android:maxLines="1"
+            android:ellipsize="marquee"
+            android:gravity="center"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:scrollHorizontally="true"
+            android:singleLine="true"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:textColor="@color/table_view_default_text_color"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:gravity="center"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            tools:textColor="@color/red_060"
-            app:tableScaleTextSize="@{tableScale}"
-            tools:text="DATA ELEMENT TEXT" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:textSize="12sp"
+            tools:text="DATA ELEMENT TEXT"
+            tools:textColor="@color/red_060" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## Description
Allow text to autoscroll if it does not fit in the column header
[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3077)

## Solution description
Set the ellipsize mode of the textview to marquee
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [x] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code