### PR TITLE
fix: [ANDROAPP-3041] back/close keyboard on the search fields.

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
@@ -18,8 +18,6 @@ import com.crashlytics.android.Crashlytics
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.reactivex.Flowable
-import java.io.File
-import javax.inject.Inject
 import org.dhis2.App
 import org.dhis2.Bindings.isKeyboardOpened
 import org.dhis2.R
@@ -50,6 +48,8 @@ import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
+import java.io.File
+import javax.inject.Inject
 
 class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
 
@@ -122,8 +122,8 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
                 false
             ) { itemPosition ->
                 itemPosition >= 0 &&
-                    itemPosition < adapter.itemCount &&
-                    adapter.getItemViewType(itemPosition) == adapter.sectionViewType()
+                        itemPosition < adapter.itemCount &&
+                        adapter.getItemViewType(itemPosition) == adapter.sectionViewType()
             }
         )
         binding.fieldRecycler.adapter = adapter
@@ -256,10 +256,6 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
         return adapter.asFlowable()
     }
 
-    override fun goBack() {
-        onBackPressed()
-    }
-
     override fun showMissingMandatoryFieldsMessage(
         emptyMandatoryFields: MutableMap<String, String>
     ) {
@@ -278,16 +274,25 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
             .show(supportFragmentManager, AlertBottomDialog::class.java.simpleName)
     }
 
+    override fun goBack() {
+        hideKeyboard()
+        attemptFinish()
+    }
+
     override fun onBackPressed() {
         if (!isKeyboardOpened()) {
-            if (mode == EnrollmentMode.CHECK) {
-                presenter.backIsClicked()
-            } else {
-                showDeleteDialog()
-            }
+            attemptFinish()
         } else {
             currentFocus?.apply { clearFocus() }
             hideKeyboard()
+        }
+    }
+
+    private fun attemptFinish() {
+        if (mode == EnrollmentMode.CHECK) {
+            presenter.backIsClicked()
+        } else {
+            showDeleteDialog()
         }
     }
 

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
@@ -18,6 +18,8 @@ import com.crashlytics.android.Crashlytics
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.reactivex.Flowable
+import java.io.File
+import javax.inject.Inject
 import org.dhis2.App
 import org.dhis2.Bindings.isKeyboardOpened
 import org.dhis2.R
@@ -48,8 +50,6 @@ import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
-import java.io.File
-import javax.inject.Inject
 
 class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
 
@@ -122,8 +122,8 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
                 false
             ) { itemPosition ->
                 itemPosition >= 0 &&
-                        itemPosition < adapter.itemCount &&
-                        adapter.getItemViewType(itemPosition) == adapter.sectionViewType()
+                    itemPosition < adapter.itemCount &&
+                    adapter.getItemViewType(itemPosition) == adapter.sectionViewType()
             }
         )
         binding.fieldRecycler.adapter = adapter

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
@@ -114,33 +114,44 @@ public class EventCaptureActivity extends ActivityGlobalAbstract implements Even
         super.onDestroy();
     }
 
+
+    @Override
+    public void goBack() {
+        hideKeyboard();
+        attemptFinish();
+    }
+
     @Override
     public void onBackPressed() {
-        if(!ExtensionsKt.isKeyboardOpened(this)) {
-            if (eventMode == EventMode.NEW) {
-                new CustomDialog(
-                        this,
-                        getString(R.string.title_delete_go_back),
-                        getString(R.string.delete_go_back),
-                        getString(R.string.cancel),
-                        getString(R.string.missing_mandatory_fields_go_back),
-                        RQ_GO_BACK,
-                        new DialogClickListener() {
-                            @Override
-                            public void onPositive() {
-                            }
-
-                            @Override
-                            public void onNegative() {
-                                presenter.deleteEvent();
-                            }
-                        }
-                ).show();
-            } else {
-                finishDataEntry();
-            }
+        if (!ExtensionsKt.isKeyboardOpened(this)) {
+            attemptFinish();
         } else {
             hideKeyboard();
+        }
+    }
+
+    private void attemptFinish() {
+        if (eventMode == EventMode.NEW) {
+            new CustomDialog(
+                    this,
+                    getString(R.string.title_delete_go_back),
+                    getString(R.string.delete_go_back),
+                    getString(R.string.cancel),
+                    getString(R.string.missing_mandatory_fields_go_back),
+                    RQ_GO_BACK,
+                    new DialogClickListener() {
+                        @Override
+                        public void onPositive() {
+                        }
+
+                        @Override
+                        public void onNegative() {
+                            presenter.deleteEvent();
+                        }
+                    }
+            ).show();
+        } else {
+            finishDataEntry();
         }
     }
 
@@ -444,11 +455,6 @@ public class EventCaptureActivity extends ActivityGlobalAbstract implements Even
                     }
                 }
         ).show();
-    }
-
-    @Override
-    public void goBack() {
-        onBackPressed();
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -748,7 +748,6 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
                 EnrollmentActivity.EnrollmentMode.NEW,
                 fromRelationshipTEI() != null);
         startActivity(intent);
-        finish();
     }
 
     /*region MAP*/

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -59,6 +59,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
 import org.dhis2.App;
+import org.dhis2.Bindings.ExtensionsKt;
 import org.dhis2.R;
 import org.dhis2.data.forms.dataentry.ProgramAdapter;
 import org.dhis2.data.forms.dataentry.fields.RowAction;
@@ -280,6 +281,20 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
         MapLayerManager.Companion.onDestroy();
         presenter.onDestroy();
         super.onDestroy();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if(!ExtensionsKt.isKeyboardOpened(this)) {
+            super.onBackPressed();
+        } else {
+            hideKeyboard();
+        }
+    }
+
+    @Override
+    public void onBackClicked() {
+        onBackPressed();
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -294,7 +294,8 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
 
     @Override
     public void onBackClicked() {
-        onBackPressed();
+        hideKeyboard();
+        finish();
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -95,6 +95,8 @@ public class SearchTEContractsModule {
         void openDashboard(String teiUid, String programUid, String enrollmentUid);
 
         void goToEnrollment(String enrollmentUid, String programUid);
+
+        void onBackClicked();
     }
 
     public interface Presenter {

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -420,7 +420,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
 
     @Override
     public void onBackClick() {
-        view.back();
+        view.onBackClicked();
     }
 
     @Override


### PR DESCRIPTION
## Description
Handles back button and close keyboard on search fields.

[ANDROAPP-3041](https://jira.dhis2.org/browse/ANDROAPP-3041)

## Solution description
Handles back button and close keyboard on search fields by removing the call to AbstractActivity `back` method and override it in the SearchTEActivity class

## Where did you test this issue?
- [ ] Smartphone Emulator
- [x] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [x] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code