### PR TITLE
fix: [ANDROAPP-3038] Wrong behaviour when selecting a non visible cell in the table

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
@@ -26,13 +26,9 @@ import org.hisp.dhis.android.core.common.ValueType;
 
 import io.reactivex.processors.FlowableProcessor;
 
-
-/**
- * QUADRAM. Created by frodriguez on 18/01/2018..
- */
-
 final class EditTextCellCustomHolder extends FormViewHolder {
 
+    private static final int DEFAULT_CELL_OFFSET = 3;
     private EditText editText;
     private EditTextModel editTextModel;
     private boolean accessDataWrite;
@@ -72,8 +68,8 @@ final class EditTextCellCustomHolder extends FormViewHolder {
                 );
             }
 
-            if (hasFocus && itemView.getLeft() > 5) {
-                tableView.scrollToColumnPosition(getAdapterPosition(),3);
+            if (hasFocus) {
+                tableView.scrollToColumnPosition(getAdapterPosition(),DEFAULT_CELL_OFFSET);
             }
         });
     }
@@ -274,7 +270,6 @@ final class EditTextCellCustomHolder extends FormViewHolder {
     public void selectNext() {
         if (tableView.getColumnHeaderRecyclerView().get(tableView.getColumnHeaderRecyclerView().size() - 1).getAdapter().getItemCount() > tableView.getSelectedColumn() + 1) {
             tableView.setSelectedCell(tableView.getSelectedColumn() + 1, tableView.getSelectedRow());
-//            tableView.scrollToNextField();
         } else if (tableView.getRowHeaderRecyclerView().getAdapter().getItemCount() > tableView.getSelectedRow() + 1) {
             tableView.scrollToStart();
             tableView.setSelectedCell(0, tableView.getSelectedRow() + 1);

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
@@ -57,7 +57,7 @@ final class EditTextCellCustomHolder extends FormViewHolder {
         });
 
         editText.setOnFocusChangeListener((v, hasFocus) -> {
-            if (!hasFocus  && editTextModel != null && editTextModel.editable() &&
+            if (!hasFocus && editTextModel != null && editTextModel.editable() &&
                     !editText.getText().toString().equals(editTextModel.value()) && validate()) {
                 processor.onNext(
                         RowAction.create(
@@ -70,6 +70,10 @@ final class EditTextCellCustomHolder extends FormViewHolder {
                                 editTextModel.column()
                         )
                 );
+            }
+
+            if (hasFocus && itemView.getLeft() > 5) {
+                tableView.scrollToColumnPosition(getAdapterPosition(),3);
             }
         });
     }
@@ -101,10 +105,10 @@ final class EditTextCellCustomHolder extends FormViewHolder {
 
         customBinding.executePendingBindings();
 
-        if(tableView.getSelectedRow() == SelectionHandler.UNSELECTED_POSITION){
+        if (tableView.getSelectedRow() == SelectionHandler.UNSELECTED_POSITION) {
             closeKeyboard(editText);
             editText.clearFocus();
-        } else if(editTextModel.column() == tableView.getSelectedColumn() && editTextModel.row() == tableView.getSelectedRow())
+        } else if (editTextModel.column() == tableView.getSelectedColumn() && editTextModel.row() == tableView.getSelectedRow())
             setSelected(SelectionState.SELECTED);
     }
 
@@ -270,7 +274,9 @@ final class EditTextCellCustomHolder extends FormViewHolder {
     public void selectNext() {
         if (tableView.getColumnHeaderRecyclerView().get(tableView.getColumnHeaderRecyclerView().size() - 1).getAdapter().getItemCount() > tableView.getSelectedColumn() + 1) {
             tableView.setSelectedCell(tableView.getSelectedColumn() + 1, tableView.getSelectedRow());
+//            tableView.scrollToNextField();
         } else if (tableView.getRowHeaderRecyclerView().getAdapter().getItemCount() > tableView.getSelectedRow() + 1) {
+            tableView.scrollToStart();
             tableView.setSelectedCell(0, tableView.getSelectedRow() + 1);
         } else {
             setSelected(SelectionState.UNSELECTED);

--- a/app/src/main/res/layout/custom_text_view_cell.xml
+++ b/app/src/main/res/layout/custom_text_view_cell.xml
@@ -26,6 +26,8 @@
         android:layout_height="@dimen/default_cell_height">
 
         <EditText
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:id="@+id/input_editText"
             android:layout_width="0dp"
             android:layout_height="0dp"

--- a/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
@@ -77,6 +77,8 @@ public interface ITableView {
 
     ITableViewListener getTableViewListener();
 
+    int getSelectedRow();
+
     SelectionHandler getSelectionHandler();
 
     ColumnSortHandler getColumnSortHandler();
@@ -90,6 +92,8 @@ public interface ITableView {
     SortState getRowHeaderSortingStatus();
 
     void scrollToColumnPosition(int column);
+
+    void scrollToNextField();
 
     void scrollToColumnPosition(int column, int offset);
 
@@ -166,4 +170,5 @@ public interface ITableView {
 
     List<CellRecyclerView> getBackupHeaders();
 
+    void scrollToStart();
 }

--- a/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
@@ -228,6 +228,7 @@ public class TableView extends FrameLayout implements ITableView {
 
         // It handles Horizontal scroll listener
         mHorizontalRecyclerViewListener = new HorizontalRecyclerViewListener(this);
+
         // Set scroll listener to be able to scroll all rows synchrony.
         for (int i = 0; i < mHeaderCount; i++) {
             mColumnHeaderRecyclerViews.get(i).addOnItemTouchListener(mHorizontalRecyclerViewListener);
@@ -590,6 +591,16 @@ public class TableView extends FrameLayout implements ITableView {
     }
 
     @Override
+    public void scrollToNextField(){
+        mScrollHandler.scrollToNextField();
+    }
+
+    @Override
+    public void scrollToStart() {
+        mScrollHandler.scrollToColumnPosition(0);
+    }
+
+    @Override
     public void scrollToColumnPosition(int column, int offset) {
         mScrollHandler.scrollToColumnPosition(column, offset);
     }
@@ -671,6 +682,7 @@ public class TableView extends FrameLayout implements ITableView {
     /**
      * Returns the index of the selected row, -1 if no row is selected.
      */
+    @Override
     public int getSelectedRow() {
         return mSelectionHandler.getSelectedRowPosition();
     }

--- a/tableview/src/main/java/com/evrencoskun/tableview/handler/SelectionHandler.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/handler/SelectionHandler.java
@@ -185,26 +185,6 @@ public class SelectionHandler {
         // Change background color of the column header which is located on X Position of the cell
         // view.
         setHeaderSelection(SelectionState.SHADOWED, shadowColor);
-       /* AbstractViewHolder columnHeader = (AbstractViewHolder) mColumnHeaderRecyclerView
-                .findViewHolderForAdapterPosition(mSelectedColumnPosition);
-
-        AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(mTableView.getHeaderCount() - 1)
-                .findViewHolderForAdapterPosition(mSelectedColumnPosition);
-
-        if (columnHeader != null) {
-            // Change color
-            columnHeader.setBackgroundColor(shadowColor);
-            // Change state
-            columnHeader.setSelected(SelectionState.SHADOWED);
-        }
-
-        if (columnBackUpHeader != null) {
-            // Change color
-            columnBackUpHeader.setBackgroundColor(shadowColor);
-            // Change state
-            columnBackUpHeader.setSelected(SelectionState.SHADOWED);
-        }*/
-
     }
 
     private void setHeaderSelection(SelectionState selectionState, int shadowColor) {
@@ -251,25 +231,6 @@ public class SelectionHandler {
         // Change background color of the column header which is located on X Position of the cell
         // view.
         setHeaderSelection(SelectionState.UNSELECTED, unSelectedColor);
-       /* AbstractViewHolder columnHeader = (AbstractViewHolder) mColumnHeaderRecyclerView
-                .findViewHolderForAdapterPosition(mSelectedColumnPosition);
-
-        AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(mTableView.getHeaderCount() - 1)
-                .findViewHolderForAdapterPosition(mSelectedColumnPosition);
-
-        if (columnHeader != null) {
-            // Change color
-            columnHeader.setBackgroundColor(unSelectedColor);
-            // Change state
-            columnHeader.setSelected(SelectionState.UNSELECTED);
-        }
-
-        if (columnBackUpHeader != null) {
-            // Change color
-            columnBackUpHeader.setBackgroundColor(unSelectedColor);
-            // Change state
-            columnBackUpHeader.setSelected(SelectionState.UNSELECTED);
-        }*/
     }
 
     private void selectedColumnHeader() {

--- a/tableview/src/main/java/com/evrencoskun/tableview/handler/SelectionHandler.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/handler/SelectionHandler.java
@@ -47,7 +47,7 @@ public class SelectionHandler {
 
     public SelectionHandler(ITableView tableView) {
         this.mTableView = tableView;
-        this.mColumnHeaderRecyclerView = mTableView.getColumnHeaderRecyclerView(tableView.getHeaderCount()-1);
+        this.mColumnHeaderRecyclerView = mTableView.getColumnHeaderRecyclerView(tableView.getHeaderCount() - 1);
         this.mRowHeaderRecyclerView = mTableView.getRowHeaderRecyclerView();
         this.mCellLayoutManager = mTableView.getCellLayoutManager();
     }
@@ -70,10 +70,10 @@ public class SelectionHandler {
         this.mPreviousSelectedViewHolder = selectedViewHolder;
 
         // Change color
-        if(mTableView != null && mPreviousSelectedViewHolder != null)
+        if (mTableView != null && mPreviousSelectedViewHolder != null)
             mPreviousSelectedViewHolder.setBackgroundColor(mTableView.getSelectedColor());
         // Change state
-        if(mPreviousSelectedViewHolder != null)
+        if (mPreviousSelectedViewHolder != null)
             mPreviousSelectedViewHolder.setSelected(SelectionState.SELECTED);
 
         if (shadowEnabled) {
@@ -184,10 +184,11 @@ public class SelectionHandler {
 
         // Change background color of the column header which is located on X Position of the cell
         // view.
-        AbstractViewHolder columnHeader = (AbstractViewHolder) mColumnHeaderRecyclerView
+        setHeaderSelection(SelectionState.SHADOWED, shadowColor);
+       /* AbstractViewHolder columnHeader = (AbstractViewHolder) mColumnHeaderRecyclerView
                 .findViewHolderForAdapterPosition(mSelectedColumnPosition);
 
-        AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(mTableView.getHeaderCount()-1)
+        AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(mTableView.getHeaderCount() - 1)
                 .findViewHolderForAdapterPosition(mSelectedColumnPosition);
 
         if (columnHeader != null) {
@@ -202,8 +203,33 @@ public class SelectionHandler {
             columnBackUpHeader.setBackgroundColor(shadowColor);
             // Change state
             columnBackUpHeader.setSelected(SelectionState.SHADOWED);
-        }
+        }*/
 
+    }
+
+    private void setHeaderSelection(SelectionState selectionState, int shadowColor) {
+        int totalCorrection = mTableView.getAdapter().hasTotal() ? 1 : 0;
+        for (int i = 0; i < mTableView.getHeaderCount(); i++) {
+            int step = (mTableView.getBackupHeaders().get(mTableView.getHeaderCount() - 1).getAdapter().getItemCount() - totalCorrection) /
+                    (mTableView.getBackupHeaders().get(i).getAdapter().getItemCount() - totalCorrection);
+
+            int correctedColumn = mSelectedColumnPosition / step;
+
+            AbstractViewHolder columnHeader = (AbstractViewHolder) mTableView.getColumnHeaderRecyclerView(i)
+                    .findViewHolderForAdapterPosition(correctedColumn);
+
+            AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(i)
+                    .findViewHolderForAdapterPosition(correctedColumn);
+
+            if (columnBackUpHeader != null && columnHeader != null) {
+                // Change color
+                columnHeader.setBackgroundColor(shadowColor);
+                columnBackUpHeader.setBackgroundColor(shadowColor);
+                // Change state
+                columnBackUpHeader.setSelected(selectionState);
+                columnBackUpHeader.setSelected(selectionState);
+            }
+        }
     }
 
     private void unselectedCellView() {
@@ -224,10 +250,11 @@ public class SelectionHandler {
 
         // Change background color of the column header which is located on X Position of the cell
         // view.
-        AbstractViewHolder columnHeader = (AbstractViewHolder) mColumnHeaderRecyclerView
+        setHeaderSelection(SelectionState.UNSELECTED, unSelectedColor);
+       /* AbstractViewHolder columnHeader = (AbstractViewHolder) mColumnHeaderRecyclerView
                 .findViewHolderForAdapterPosition(mSelectedColumnPosition);
 
-        AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(mTableView.getHeaderCount()-1)
+        AbstractViewHolder columnBackUpHeader = (AbstractViewHolder) mTableView.getBackupHeaders().get(mTableView.getHeaderCount() - 1)
                 .findViewHolderForAdapterPosition(mSelectedColumnPosition);
 
         if (columnHeader != null) {
@@ -242,7 +269,7 @@ public class SelectionHandler {
             columnBackUpHeader.setBackgroundColor(unSelectedColor);
             // Change state
             columnBackUpHeader.setSelected(SelectionState.UNSELECTED);
-        }
+        }*/
     }
 
     private void selectedColumnHeader() {
@@ -426,7 +453,7 @@ public class SelectionHandler {
     public void clearSelection() {
         unselectedCellView();
         mSelectedColumnPosition = UNSELECTED_POSITION;
-        mSelectedRowPosition= UNSELECTED_POSITION;
+        mSelectedRowPosition = UNSELECTED_POSITION;
     }
 
     public void setSelectedRowPosition(int row) {


### PR DESCRIPTION
## Description
[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3038)

## Solution description
One a cell is selected, the whole table scrolls to that column position.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [x] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code