### PR TITLE
feat: [ANDROAPP-2335] Preselect org unit when adding sequential events to a program

### DIFF
--- a/app/src/main/java/org/dhis2/data/prefs/Preference.kt
+++ b/app/src/main/java/org/dhis2/data/prefs/Preference.kt
@@ -37,5 +37,7 @@ class Preference {
         const val DEFAULT_NUMBER_RV = 100
 
         const val GROUPING = "GROUPING"
+
+        const val CURRENT_ORG_UNIT = "CURRENT_ORG_UNIT"
     }
 }

--- a/app/src/main/java/org/dhis2/uicomponents/map/managers/MapManager.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/managers/MapManager.kt
@@ -19,7 +19,7 @@ abstract class MapManager {
     lateinit var map: MapboxMap
     open lateinit var featureType: FeatureType
     lateinit var mapLayerManager: MapLayerManager
-    lateinit var markerViewManager: MarkerViewManager
+    var markerViewManager: MarkerViewManager? = null
     var symbolManager: SymbolManager? = null
     var onMapClickListener: MapboxMap.OnMapClickListener? = null
     val style: Style?

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -4,7 +4,6 @@ import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.SparseBooleanArray;
@@ -19,8 +18,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.databinding.DataBindingUtil;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.jakewharton.rxbinding2.view.RxView;
 
 import org.dhis2.App;
@@ -31,7 +28,6 @@ import org.dhis2.data.forms.dataentry.fields.unsupported.UnsupportedViewModel;
 import org.dhis2.databinding.ActivityEventInitialBinding;
 import org.dhis2.databinding.CategorySelectorBinding;
 import org.dhis2.databinding.WidgetDatepickerBinding;
-import org.dhis2.uicomponents.map.views.MapSelectorActivity;
 import org.dhis2.usescases.coodinates.CoordinatesView;
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity;
 import org.dhis2.usescases.general.ActivityGlobalAbstract;
@@ -49,7 +45,6 @@ import org.dhis2.utils.customviews.CustomDialog;
 import org.dhis2.utils.customviews.OrgUnitDialog;
 import org.dhis2.utils.customviews.PeriodDialog;
 import org.dhis2.utils.resources.ResourceManager;
-import org.hisp.dhis.android.core.arch.helpers.GeometryHelper;
 import org.hisp.dhis.android.core.category.Category;
 import org.hisp.dhis.android.core.category.CategoryCombo;
 import org.hisp.dhis.android.core.category.CategoryOption;
@@ -67,7 +62,6 @@ import org.hisp.dhis.android.core.program.ProgramStage;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -99,11 +93,6 @@ import static org.dhis2.utils.analytics.AnalyticsConstants.CLICK;
 import static org.dhis2.utils.analytics.AnalyticsConstants.CREATE_EVENT;
 import static org.dhis2.utils.analytics.AnalyticsConstants.DELETE_EVENT;
 import static org.dhis2.utils.analytics.AnalyticsConstants.SHOW_HELP;
-
-
-/**
- * QUADRAM. Created by Cristian on 01/03/2018.
- */
 
 public class EventInitialActivity extends ActivityGlobalAbstract implements EventInitialContract.View, DatePickerDialog.OnDateSetListener {
 
@@ -139,15 +128,13 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     private boolean fixedOrgUnit;
     private String catOptionComboUid;
     private CategoryCombo catCombo;
-    private Map<String, CategoryOption> selectedCatOption;
+    private Map<String, CategoryOption> selectedCatOption = new HashMap<>();
     private OrgUnitDialog orgUnitDialog;
     private Program program;
-    private String savedLat;
-    private String savedLon;
     private ArrayList<String> sectionsToHide;
     private Boolean accessData;
 
-    private CompositeDisposable disposable;
+    private CompositeDisposable disposable = new CompositeDisposable();
     private Geometry newGeometry;
 
     public static Bundle getBundle(String programUid, String eventUid, String eventCreationType,
@@ -167,8 +154,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         return bundle;
     }
 
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
+    private void initVariables() {
         programUid = getIntent().getStringExtra(PROGRAM_UID);
         eventUid = getIntent().getStringExtra(Constants.EVENT_UID);
         eventCreationType = getIntent().getStringExtra(EVENT_CREATION_TYPE) != null ?
@@ -181,87 +167,85 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         programStageUid = getIntent().getStringExtra(Constants.PROGRAM_STAGE_UID);
         enrollmentStatus = (EnrollmentStatus) getIntent().getSerializableExtra(Constants.ENROLLMENT_STATUS);
         eventScheduleInterval = getIntent().getIntExtra(Constants.EVENT_SCHEDULE_INTERVAL, 0);
-        setScreenName(this.getLocalClassName());
-        ((App) getApplicationContext()).userComponent().plus(new EventInitialModule(eventUid)).inject(this);
-        super.onCreate(savedInstanceState);
+    }
 
-        disposable = new CompositeDisposable();
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        initVariables();
+        setScreenName(this.getLocalClassName());
+        ((App) getApplicationContext()).userComponent().plus(
+                new EventInitialModule(this,
+                        eventUid)
+        ).inject(this);
+        super.onCreate(savedInstanceState);
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_event_initial);
         binding.setPresenter(presenter);
-        this.selectedCatOption = new HashMap<>();
-
-        setUpScrenByCreatinType(eventCreationType);
 
         initProgressBar();
 
-        if (eventUid == null) {
-            binding.shareContainer.setVisibility(View.GONE);
-            if (binding.actionButton != null)
-                binding.actionButton.setText(R.string.next);
-        } else {
-            if (binding.actionButton != null)
-                binding.actionButton.setText(R.string.update);
-        }
+        setUpScreenByCreationType();
 
-        if (binding.actionButton != null) {
-            disposable.add(RxView.clicks(binding.actionButton)
-                    .debounce(500, TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
-                    .subscribe(v -> {
-                                binding.actionButton.setEnabled(false);
-                                String programStageModelUid = programStage == null ? "" : programStage.uid();
-                                if (eventUid == null) { // This is a new Event
-                                    analyticsHelper().setEvent(CREATE_EVENT, AnalyticsConstants.DATA_CREATION, CREATE_EVENT);
-                                    if (eventCreationType == EventCreationType.REFERAL && tempCreate.equals(PERMANENT)) {
-                                        presenter.scheduleEventPermanent(
-                                                enrollmentUid,
-                                                getTrackedEntityInstance,
-                                                programStageModelUid,
-                                                selectedDate,
-                                                selectedOrgUnit,
-                                                null,
-                                                catOptionComboUid,
-                                                newGeometry
-                                        );
-                                    } else if (eventCreationType == EventCreationType.SCHEDULE || eventCreationType == EventCreationType.REFERAL) {
-                                        presenter.scheduleEvent(
-                                                enrollmentUid,
-                                                programStageModelUid,
-                                                selectedDate,
-                                                selectedOrgUnit,
-                                                null,
-                                                catOptionComboUid,
-                                                newGeometry
-                                        );
-                                    } else {
-                                        presenter.createEvent(
-                                                enrollmentUid,
-                                                programStageModelUid,
-                                                selectedDate,
-                                                selectedOrgUnit,
-                                                null,
-                                                catOptionComboUid,
-                                                newGeometry,
-                                                getTrackedEntityInstance);
-                                    }
-                                } else {
-                                    presenter.editEvent(getTrackedEntityInstance,
+        initActionButton();
+        binding.actionButton.setEnabled(true);
+        presenter.init(programUid, eventUid, selectedOrgUnit, programStageUid);
+    }
+
+    private void initActionButton(){
+
+        disposable.add(RxView.clicks(binding.actionButton)
+                .debounce(500, TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
+                .subscribe(v -> {
+                            binding.actionButton.setEnabled(false);
+                            String programStageModelUid = programStage == null ? "" : programStage.uid();
+                            if (eventUid == null) { // This is a new Event
+                                analyticsHelper().setEvent(CREATE_EVENT, AnalyticsConstants.DATA_CREATION, CREATE_EVENT);
+                                if (eventCreationType == EventCreationType.REFERAL && tempCreate.equals(PERMANENT)) {
+                                    presenter.scheduleEventPermanent(
+                                            enrollmentUid,
+                                            getTrackedEntityInstance,
                                             programStageModelUid,
-                                            eventUid,
-                                            DateUtils.databaseDateFormat().format(selectedDate), selectedOrgUnit, null,
+                                            selectedDate,
+                                            selectedOrgUnit,
+                                            null,
                                             catOptionComboUid,
                                             newGeometry
                                     );
+                                } else if (eventCreationType == EventCreationType.SCHEDULE || eventCreationType == EventCreationType.REFERAL) {
+                                    presenter.scheduleEvent(
+                                            enrollmentUid,
+                                            programStageModelUid,
+                                            selectedDate,
+                                            selectedOrgUnit,
+                                            null,
+                                            catOptionComboUid,
+                                            newGeometry
+                                    );
+                                } else {
+                                    presenter.createEvent(
+                                            enrollmentUid,
+                                            programStageModelUid,
+                                            selectedDate,
+                                            selectedOrgUnit,
+                                            null,
+                                            catOptionComboUid,
+                                            newGeometry,
+                                            getTrackedEntityInstance);
                                 }
-                            },
-                            Timber::e));
-        }
-
-        binding.actionButton.setEnabled(true);
-        presenter.init(this, programUid, eventUid, selectedOrgUnit, programStageUid);
+                            } else {
+                                presenter.editEvent(getTrackedEntityInstance,
+                                        programStageModelUid,
+                                        eventUid,
+                                        DateUtils.databaseDateFormat().format(selectedDate), selectedOrgUnit, null,
+                                        catOptionComboUid,
+                                        newGeometry
+                                );
+                            }
+                        },
+                        Timber::e));
     }
 
-    private void setUpScrenByCreatinType(EventCreationType eventCreationType) {
+    private void setUpScreenByCreationType() {
 
         if (eventCreationType == EventCreationType.REFERAL) {
             binding.temp.setVisibility(View.VISIBLE);
@@ -293,17 +277,13 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
             });
         }
 
-    }
+        if (eventUid == null) {
+            binding.shareContainer.setVisibility(View.GONE);
+            binding.actionButton.setText(R.string.next);
+        } else {
+            binding.actionButton.setText(R.string.update);
+        }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
     }
 
     @Override
@@ -366,18 +346,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     public void setProgram(@NonNull Program program) {
         this.program = program;
 
-        String activityTitle;
-        if (eventCreationType == EventCreationType.REFERAL) {
-            activityTitle = program.displayName() + " - " + getString(R.string.referral);
-        } else {
-            if (eventModel != null && !isEmpty(eventModel.enrollment()) && eventCreationType != EventCreationType.ADDNEW) {
-                binding.orgUnit.setEnabled(false);
-                binding.orgUnitLayout.setVisibility(View.GONE);
-            }
-
-            activityTitle = eventUid == null ? program.displayName() + " - " + getString(R.string.new_event) : program.displayName();
-        }
-        binding.setName(activityTitle);
+        setUpActivityTitle();
 
         if (eventModel == null) {
             Calendar now = DateUtils.getInstance().getCalendar();
@@ -455,6 +424,21 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
 
         }
 
+    }
+
+    private void setUpActivityTitle(){
+        String activityTitle;
+        if (eventCreationType == EventCreationType.REFERAL) {
+            activityTitle = program.displayName() + " - " + getString(R.string.referral);
+        } else {
+            if (eventModel != null && !isEmpty(eventModel.enrollment()) && eventCreationType != EventCreationType.ADDNEW) {
+                binding.orgUnit.setEnabled(false);
+                binding.orgUnitLayout.setVisibility(View.GONE);
+            }
+
+            activityTitle = eventUid == null ? program.displayName() + " - " + getString(R.string.new_event) : program.displayName();
+        }
+        binding.setName(activityTitle);
     }
 
     @Override
@@ -695,42 +679,6 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case EventInitialPresenter.ACCESS_LOCATION_PERMISSION_REQUEST: {
-                // If request is cancelled, the result arrays are empty.
-                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    presenter.onLocationClick();
-                }
-            }
-        }
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == Constants.RQ_MAP_LOCATION && resultCode == RESULT_OK) {
-            FeatureType locationType = FeatureType.valueOf(data.getStringExtra(MapSelectorActivity.LOCATION_TYPE_EXTRA));
-            String dataExtra = data.getStringExtra(MapSelectorActivity.DATA_EXTRA);
-            Geometry geometry;
-            if (locationType == FeatureType.POINT) {
-                Type type = new TypeToken<List<Double>>() {
-                }.getType();
-                geometry = GeometryHelper.createPointGeometry(new Gson().fromJson(dataExtra, type));
-            } else if (locationType == FeatureType.POLYGON) {
-                Type type = new TypeToken<List<List<List<Double>>>>() {
-                }.getType();
-                geometry = GeometryHelper.createPolygonGeometry(new Gson().fromJson(dataExtra, type));
-            } else {
-                Type type = new TypeToken<List<List<List<List<Double>>>>>() {
-                }.getType();
-                geometry = GeometryHelper.createMultiPolygonGeometry(new Gson().fromJson(dataExtra, type));
-            }
-//            setLocation(geometry);
-        }
-    }
-
-    @Override
     public void onEventSections(List<FormSectionViewModel> formSectionViewModels) {
         for (FormSectionViewModel formSectionViewModel : formSectionViewModels) {
             presenter.getSectionCompletion(formSectionViewModel.sectionUid());
@@ -805,7 +753,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
         if (organisationUnit != null) {
             this.selectedOrgUnit = organisationUnit.uid();
             binding.orgUnit.setText(organisationUnit.displayName());
-            binding.orgUnit.setEnabled(false);
+            binding.orgUnit.setEnabled(eventUid == null);
         } else
             binding.orgUnit.setText("");
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialComponent.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialComponent.java
@@ -4,11 +4,6 @@ import org.dhis2.data.dagger.PerActivity;
 
 import dagger.Subcomponent;
 
-/**
- * Created by Cristian on 13/02/2018.
- *
- */
-
 @PerActivity
 @Subcomponent(modules = EventInitialModule.class)
 public interface EventInitialComponent {

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialContract.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialContract.java
@@ -4,6 +4,7 @@ import android.app.DatePickerDialog;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import org.dhis2.data.forms.FormSectionViewModel;
 import org.dhis2.data.forms.dataentry.fields.FieldViewModel;
@@ -24,10 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.reactivex.functions.Consumer;
-
-/**
- * QUADRAM. Created by Cristian on 01/03/2018.
- */
 
 public class EventInitialContract {
 
@@ -81,7 +78,7 @@ public class EventInitialContract {
     }
 
     public interface Presenter extends AbstractActivityContracts.Presenter {
-        void init(EventInitialContract.View view, String programId, String eventId, String orgUnitId, String programStageId);
+        void init(String programId, String eventId, String orgUnitId, String programStageId);
 
         void getProgramStage(String programStageUid);
 
@@ -107,15 +104,14 @@ public class EventInitialContract {
 
         void onOrgUnitButtonClick();
 
-        void onLocationClick();
-
         void onFieldChanged(CharSequence s, int start, int before, int count);
 
         void getSectionCompletion(@Nullable String sectionUid);
 
-        void getEventSections(@NonNull String eventId);
+        @VisibleForTesting
+        String getCurrentOrgUnit(String orgUnitUid);
 
-        List<OrganisationUnit> getOrgUnits();
+        void getEventSections(@NonNull String eventId);
 
         void onShareClick(android.view.View mView);
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialModule.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialModule.java
@@ -12,41 +12,47 @@ import org.dhis2.data.forms.FormRepository;
 import org.dhis2.data.forms.RulesRepository;
 import org.dhis2.data.forms.dataentry.fields.FieldViewModelFactory;
 import org.dhis2.data.forms.dataentry.fields.FieldViewModelFactoryImpl;
+import org.dhis2.data.prefs.PreferenceProvider;
 import org.dhis2.data.schedulers.SchedulerProvider;
 import org.dhis2.usescases.eventsWithoutRegistration.eventSummary.EventSummaryRepository;
 import org.dhis2.usescases.eventsWithoutRegistration.eventSummary.EventSummaryRepositoryImpl;
+import org.dhis2.utils.analytics.AnalyticsHelper;
 import org.hisp.dhis.android.core.D2;
 import org.hisp.dhis.rules.RuleExpressionEvaluator;
+
+import javax.annotation.Nonnull;
 
 import dagger.Module;
 import dagger.Provides;
 
-/**
- * QUADRAM. Created by Cristian on 13/02/2018.
- */
 @PerActivity
 @Module
 public class EventInitialModule {
 
+    private final EventInitialContract.View view;
     @Nullable
     private String eventUid;
 
-    public EventInitialModule(@Nullable String eventUid) {
+    public EventInitialModule(@Nonnull EventInitialContract.View view,
+                              @Nullable String eventUid) {
+        this.view = view;
         this.eventUid = eventUid;
-    }
-
-    @Provides
-    @PerActivity
-    EventInitialContract.View provideView(EventInitialContract.View activity) {
-        return activity;
     }
 
     @Provides
     @PerActivity
     EventInitialContract.Presenter providesPresenter(@NonNull EventSummaryRepository eventSummaryRepository,
                                                      @NonNull EventInitialRepository eventInitialRepository,
-                                                     @NonNull SchedulerProvider schedulerProvider) {
-        return new EventInitialPresenter(eventSummaryRepository, eventInitialRepository, schedulerProvider);
+                                                     @NonNull SchedulerProvider schedulerProvider,
+                                                     @Nonnull PreferenceProvider preferenceProvider,
+                                                     @Nonnull AnalyticsHelper analyticsHelper) {
+        return new EventInitialPresenter(
+                view,
+                eventSummaryRepository,
+                eventInitialRepository,
+                schedulerProvider,
+                preferenceProvider,
+                analyticsHelper);
     }
 
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepository.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepository.java
@@ -1,7 +1,5 @@
 package org.dhis2.usescases.eventsWithoutRegistration.eventInitial;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -22,10 +20,6 @@ import java.util.Map;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
 
-/**
- * QUADRAM. Created by Cristian E. on 02/11/2017.
- */
-
 public interface EventInitialRepository {
 
     @NonNull
@@ -41,13 +35,13 @@ public interface EventInitialRepository {
     Observable<List<OrganisationUnit>> filteredOrgUnits(String date, String programId, String parentId);
 
     Observable<String> createEvent(String enrollmentUid, @Nullable String trackedEntityInstanceUid,
-                                   @NonNull Context context, @NonNull String program,
+                                   @NonNull String program,
                                    @NonNull String programStage, @NonNull Date date,
                                    @NonNull String orgUnitUid, @NonNull String catComboUid,
                                    @NonNull String catOptionUid, @NonNull Geometry coordinates);
 
     Observable<String> scheduleEvent(String enrollmentUid, @Nullable String trackedEntityInstanceUid,
-                                     @NonNull Context context, @NonNull String program,
+                                     @NonNull String program,
                                      @NonNull String programStage, @NonNull Date dueDate,
                                      @NonNull String orgUnitUid, @NonNull String catComboUid,
                                      @NonNull String catOptionUid, @NonNull Geometry coordinates);
@@ -69,9 +63,9 @@ public interface EventInitialRepository {
 
     Observable<List<CategoryOptionCombo>> catOptionCombos(String catOptionComboUid);
 
-    Flowable<Map<String,CategoryOption>> getOptionsFromCatOptionCombo(String eventId);
+    Flowable<Map<String, CategoryOption>> getOptionsFromCatOptionCombo(String eventId);
 
-    Date getStageLastDate(String programStageUid,String enrollmentUid);
+    Date getStageLastDate(String programStageUid, String enrollmentUid);
 
     Observable<Program> getProgramWithId(String programUid);
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepositoryImpl.java
@@ -1,7 +1,5 @@
 package org.dhis2.usescases.eventsWithoutRegistration.eventInitial;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -40,10 +38,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import timber.log.Timber;
 
-/**
- * QUADRAM. Created by Cristian on 22/03/2018.
- */
-
 public class EventInitialRepositoryImpl implements EventInitialRepository {
 
     private final String eventUid;
@@ -63,27 +57,30 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
     @NonNull
     @Override
     public Observable<List<OrganisationUnit>> filteredOrgUnits(String date, String programId, String parentId) {
-        if (date == null)
-            return parentId == null ? orgUnits(programId) : orgUnits(programId, parentId);
-        else
-            return (parentId == null ? orgUnits(programId) : orgUnits(programId, parentId))
-                    .map(organisationUnits -> {
-                        Iterator<OrganisationUnit> iterator = organisationUnits.iterator();
-                        while (iterator.hasNext()) {
-                            OrganisationUnit organisationUnit = iterator.next();
-                            if (organisationUnit.openingDate() != null && organisationUnit.openingDate().after(DateUtils.uiDateFormat().parse(date))
-                                    || organisationUnit.closedDate() != null && organisationUnit.closedDate().before(DateUtils.uiDateFormat().parse(date)))
-                                iterator.remove();
-                        }
+        return (parentId == null ? orgUnits(programId) : orgUnits(programId, parentId))
+                .map(organisationUnits -> {
+                    if (date == null) {
                         return organisationUnits;
-                    });
+                    }
+                    Iterator<OrganisationUnit> iterator = organisationUnits.iterator();
+                    while (iterator.hasNext()) {
+                        OrganisationUnit organisationUnit = iterator.next();
+                        if (organisationUnit.openingDate() != null && organisationUnit.openingDate().after(DateUtils.uiDateFormat().parse(date))
+                                || organisationUnit.closedDate() != null && organisationUnit.closedDate().before(DateUtils.uiDateFormat().parse(date)))
+                            iterator.remove();
+                    }
+                    return organisationUnits;
+                });
     }
 
     @NonNull
     @Override
     public Observable<List<OrganisationUnit>> orgUnits(String programId) {
-        return d2.organisationUnitModule().organisationUnits().byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
-                .byProgramUids(Collections.singletonList(programId)).get().toObservable();
+        return d2.organisationUnitModule().organisationUnits()
+                .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
+                .byProgramUids(Collections.singletonList(programId))
+                .get()
+                .toObservable();
     }
 
     public Observable<List<OrganisationUnit>> orgUnits(String programId, String parentUid) {
@@ -168,7 +165,7 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
 
     @Override
     public Observable<String> createEvent(String enrollmentUid, @Nullable String trackedEntityInstanceUid,
-                                          @NonNull Context context, @NonNull String programUid,
+                                          @NonNull String programUid,
                                           @NonNull String programStage, @NonNull Date date,
                                           @NonNull String orgUnitUid, @Nullable String categoryOptionsUid,
                                           @Nullable String categoryOptionComboUid, @NonNull Geometry geometry) {
@@ -195,8 +192,6 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
             eventRepository.setEventDate(cal.getTime());
             if (d2.programModule().programStages().uid(eventRepository.blockingGet().programStage()).blockingGet().featureType() != null)
                 switch (d2.programModule().programStages().uid(eventRepository.blockingGet().programStage()).blockingGet().featureType()) {
-                    case NONE:
-                        break;
                     case POINT:
                     case POLYGON:
                     case MULTI_POLYGON:
@@ -211,7 +206,7 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
 
     @Override
     public Observable<String> scheduleEvent(String enrollmentUid, @Nullable String trackedEntityInstanceUid,
-                                            @NonNull Context context, @NonNull String programUid, @NonNull String programStage,
+                                            @NonNull String programUid, @NonNull String programStage,
                                             @NonNull Date dueDate, @NonNull String orgUnitUid, @Nullable String categoryOptionsUid,
                                             @Nullable String categoryOptionComboUid, @NonNull Geometry geometry) {
         Calendar cal = Calendar.getInstance();
@@ -237,8 +232,6 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
             eventRepository.setStatus(EventStatus.SCHEDULE);
             if (d2.programModule().programStages().uid(eventRepository.blockingGet().programStage()).blockingGet().featureType() != null)
                 switch (d2.programModule().programStages().uid(eventRepository.blockingGet().programStage()).blockingGet().featureType()) {
-                    case NONE:
-                        break;
                     case POINT:
                     case POLYGON:
                     case MULTI_POLYGON:

--- a/app/src/main/java/org/dhis2/usescases/main/MainPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainPresenter.kt
@@ -2,6 +2,7 @@ package org.dhis2.usescases.main
 
 import android.view.Gravity
 import io.reactivex.disposables.CompositeDisposable
+import org.dhis2.data.prefs.Preference
 import org.dhis2.data.prefs.Preference.Companion.DEFAULT_CAT_COMBO
 import org.dhis2.data.prefs.Preference.Companion.PREF_DEFAULT_CAT_OPTION_COMBO
 import org.dhis2.data.prefs.PreferenceProvider
@@ -27,6 +28,7 @@ class MainPresenter(
     var disposable: CompositeDisposable = CompositeDisposable()
 
     fun init() {
+        preferences.removeValue(Preference.CURRENT_ORG_UNIT)
         disposable.add(
             d2.userModule().user().get()
                 .map { username(it) }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEModule.java
@@ -3,6 +3,7 @@ package org.dhis2.usescases.searchTrackEntity;
 import androidx.annotation.NonNull;
 
 import org.dhis2.data.dagger.PerActivity;
+import org.dhis2.data.prefs.PreferenceProvider;
 import org.dhis2.data.schedulers.SchedulerProvider;
 import org.dhis2.uicomponents.map.geometry.bound.BoundsGeometry;
 import org.dhis2.uicomponents.map.geometry.mapper.MapTeisToFeatureCollection;
@@ -43,9 +44,11 @@ public class SearchTEModule {
                                                        SearchRepository searchRepository,
                                                        SchedulerProvider schedulerProvider,
                                                        AnalyticsHelper analyticsHelper,
-                                                       MapTeisToFeatureCollection mapTeisToFeatureCollection) {
+                                                       MapTeisToFeatureCollection mapTeisToFeatureCollection,
+                                                       PreferenceProvider preferenceProvider) {
         return new SearchTEPresenter(view, d2, searchRepository, schedulerProvider,
-                analyticsHelper, initialProgram, mapTeisToFeatureCollection);
+                analyticsHelper, initialProgram, mapTeisToFeatureCollection,
+                preferenceProvider);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -15,6 +15,8 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.paging.PagedList;
 
 import org.dhis2.R;
+import org.dhis2.data.prefs.Preference;
+import org.dhis2.data.prefs.PreferenceProvider;
 import org.dhis2.data.schedulers.SchedulerProvider;
 import org.dhis2.data.tuples.Pair;
 import org.dhis2.data.tuples.Trio;
@@ -74,6 +76,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     private final SearchTEContractsModule.View view;
     private final AnalyticsHelper analyticsHelper;
     private final BehaviorSubject<String> currentProgram;
+    private final PreferenceProvider preferences;
     private Program selectedProgram;
 
     private CompositeDisposable compositeDisposable;
@@ -97,8 +100,10 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
                              SchedulerProvider schedulerProvider,
                              AnalyticsHelper analyticsHelper,
                              @Nullable String initialProgram,
-                             MapTeisToFeatureCollection mapTeisToFeatureCollection) {
+                             MapTeisToFeatureCollection mapTeisToFeatureCollection,
+                             PreferenceProvider preferenceProvider) {
         this.view = view;
+        this.preferences = preferenceProvider;
         this.searchRepository = searchRepository;
         this.d2 = d2;
         this.schedulerProvider = schedulerProvider;
@@ -399,6 +404,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
         showList = true;
 
         if (otherProgramSelected) {
+            preferences.removeValue(Preference.CURRENT_ORG_UNIT);
             queryData.clear();
         }
 

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/teiProgramList/TeiProgramListModule.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/teiProgramList/TeiProgramListModule.java
@@ -3,7 +3,8 @@ package org.dhis2.usescases.teiDashboard.teiProgramList;
 import androidx.annotation.NonNull;
 
 import org.dhis2.data.dagger.PerActivity;
-import org.dhis2.utils.CodeGenerator;
+import org.dhis2.data.prefs.PreferenceProvider;
+import org.dhis2.utils.analytics.AnalyticsHelper;
 import org.hisp.dhis.android.core.D2;
 
 import dagger.Module;
@@ -31,8 +32,10 @@ public class TeiProgramListModule {
 
     @Provides
     @PerActivity
-    TeiProgramListContract.Presenter providesPresenter(TeiProgramListContract.Interactor interactor) {
-        return new TeiProgramListPresenter(interactor, teiUid);
+    TeiProgramListContract.Presenter providesPresenter(TeiProgramListContract.Interactor interactor,
+                                                       PreferenceProvider preferenceProvider,
+                                                       AnalyticsHelper analyticsHelper) {
+        return new TeiProgramListPresenter(interactor, teiUid, preferenceProvider, analyticsHelper);
     }
 
     @Provides

--- a/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenterTest.kt
@@ -1,0 +1,62 @@
+package org.dhis2.usescases.eventsWithoutRegistration.eventInitial
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.dhis2.data.prefs.Preference
+import org.dhis2.data.prefs.PreferenceProvider
+import org.dhis2.data.schedulers.SchedulerProvider
+import org.dhis2.data.schedulers.TrampolineSchedulerProvider
+import org.dhis2.usescases.eventsWithoutRegistration.eventSummary.EventSummaryRepository
+import org.dhis2.utils.analytics.AnalyticsHelper
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class EventInitialPresenterTest {
+    lateinit var presenter: EventInitialPresenter
+    val view: EventInitialContract.View = mock()
+    private val eventRepository: EventSummaryRepository = mock()
+    private val eventInitialRepository: EventInitialRepository = mock()
+    val schedulers: SchedulerProvider = TrampolineSchedulerProvider()
+    val preferences: PreferenceProvider = mock()
+    val analyticsHelper: AnalyticsHelper = mock()
+
+    @Before
+    fun setUp() {
+        presenter = EventInitialPresenter(
+            view,
+            eventRepository,
+            eventInitialRepository,
+            schedulers,
+            preferences,
+            analyticsHelper
+        )
+    }
+
+    @Test
+    fun `Should init previous org unit if exist and no one is selected`() {
+        whenever(preferences.contains(Preference.CURRENT_ORG_UNIT)) doReturn true
+        whenever(preferences.getString(Preference.CURRENT_ORG_UNIT, null)) doReturn "prevOrgUnit"
+        assertTrue(presenter.getCurrentOrgUnit(null) == "prevOrgUnit")
+    }
+
+    @Test
+    fun `Should init previous org unit if exist and one is selected`() {
+        whenever(preferences.contains(Preference.CURRENT_ORG_UNIT)) doReturn true
+        whenever(preferences.getString(Preference.CURRENT_ORG_UNIT, null)) doReturn "prevOrgUnit"
+        assertTrue(presenter.getCurrentOrgUnit("orgUnit") == "prevOrgUnit")
+    }
+
+    @Test
+    fun `Should init given org unit if previous does not exist`() {
+        whenever(preferences.contains(Preference.CURRENT_ORG_UNIT)) doReturn false
+        assertTrue(presenter.getCurrentOrgUnit("orgUnit") == "orgUnit")
+    }
+
+    @Test
+    fun `Should init null org unit if previous does not exist`() {
+        whenever(preferences.contains(Preference.CURRENT_ORG_UNIT)) doReturn false
+        assertTrue(presenter.getCurrentOrgUnit(null).isNullOrEmpty())
+    }
+}

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenterTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.schedulers.TestScheduler
 import junit.framework.TestCase.assertTrue
+import org.dhis2.data.prefs.PreferenceProvider
 import org.dhis2.data.schedulers.TestSchedulerProvider
 import org.dhis2.uicomponents.map.geometry.mapper.MapTeisToFeatureCollection
 import org.dhis2.utils.analytics.AnalyticsHelper
@@ -28,6 +29,7 @@ class SearchTEPresenterTest {
     private val analyticsHelper: AnalyticsHelper = mock()
     private val mapTeisToFeatureCollection: MapTeisToFeatureCollection = mock()
     private val initialProgram = "programUid"
+    private val preferenceProvider: PreferenceProvider = mock()
 
     @Before
     fun setUp() {
@@ -44,7 +46,8 @@ class SearchTEPresenterTest {
             schedulers,
             analyticsHelper,
             initialProgram,
-            mapTeisToFeatureCollection
+            mapTeisToFeatureCollection,
+            preferenceProvider
         )
     }
 


### PR DESCRIPTION
## Description

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-2335)

## Covered unit test cases
Added test to check that the returned org unit is the correct one in event initial screen.
Due to the fact that this activity is going to dissapear in the near future I have decided not to include any more tests.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [x] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [x] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code