### PR TITLE
fix: [ANDROAPP-3109] Removes background from xml and adds it programmatically

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/section/SectionHolder.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/section/SectionHolder.kt
@@ -177,6 +177,10 @@ class SectionHolder(
     }
 
     fun setSectionNumber(sectionNumber: Int) {
-        formBinding.sectionNumber.text = sectionNumber.toString()
+        formBinding.sectionNumber.apply {
+            text = sectionNumber.toString()
+            background =
+                ContextCompat.getDrawable(itemView.context, R.drawable.ic_circle)
+        }
     }
 }

--- a/app/src/main/res/layout/form_section.xml
+++ b/app/src/main/res/layout/form_section.xml
@@ -39,7 +39,6 @@
                 android:layout_width="18dp"
                 android:layout_height="18dp"
                 android:gravity="center"
-                android:background="@drawable/ic_circle"
                 tools:text="99"
                 android:textSize="9sp"
                 android:textColor="?colorAccent"


### PR DESCRIPTION
## Description
 Removes background from xml and adds it programmatically
[ANDROAPP-3109](https://jira.dhis2.org/browse/ANDROAPP-3109)

## Solution description
Removes background from xml and adds it programmatically in the setionHolder using ContextCompat's getDrawable

## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [x] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code