### PR TITLE
fix: [ANDROAPP-3093] Adds section title when there is only one section

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.java
@@ -241,7 +241,7 @@ public class EventCapturePresenterImpl implements EventCaptureContract.Presenter
                                                     List<FieldViewModel> finalFieldList = new ArrayList<>();
 
                                                     for (FormSectionViewModel sectionModel : sectionList) {
-                                                        if (sectionList.size() > 1 && !sectionsToHide.contains(sectionModel.sectionUid())) {
+                                                        if (sectionList.size() >= 1 && !sectionModel.sectionUid().isEmpty() && !sectionsToHide.contains(sectionModel.sectionUid())) {
                                                             List<FieldViewModel> fieldViewModels = new ArrayList<>();
                                                             if (fieldMap.get(sectionModel.sectionUid()) != null)
                                                                 fieldViewModels.addAll(fieldMap.get(sectionModel.sectionUid()));
@@ -276,7 +276,7 @@ public class EventCapturePresenterImpl implements EventCaptureContract.Presenter
                                                                 finalFieldList.addAll(fieldMap.get(sectionModel.sectionUid()));
                                                             }
 
-                                                        } else if (sectionList.size() == 1) {
+                                                        } else if (sectionList.size() == 1 && sectionModel.sectionUid().isEmpty()) {
                                                             int cont = 0;
                                                             HashMap<String, Boolean> finalFields = new HashMap<>();
                                                             for (FieldViewModel fieldViewModel : fields) {
@@ -296,7 +296,9 @@ public class EventCapturePresenterImpl implements EventCaptureContract.Presenter
                                                         }
                                                     }
 
-                                                    finalFieldList.add(SectionViewModel.createClosingSection());
+                                                    if(!eventSectionModels.get(0).sectionName().equals("NO_SECTION")) {
+                                                        finalFieldList.add(SectionViewModel.createClosingSection());
+                                                    }
 
                                                     if (fieldMap.containsKey("display") && fieldMap.get("display") != null) {
                                                         finalFieldList.addAll(fieldMap.get("display"));


### PR DESCRIPTION
## Description
Adds section title when there is only one section and removes bottom section shadow when the form has no section

[ANDROAPP-3093](https://jira.dhis2.org/browse/ANDROAPP-3093)

## Solution description
We need to make sure the the sectionList has an sectionUid not empty to determine that it has a section. If the sectionUid is empty it mean it a form with no section.
## Covered unit test cases
WIP
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code