### PR TITLE
fix: [ANDROAPP-3104] Scrolls open section to the top of the RecyclerView

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
@@ -105,6 +105,7 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
     List<Integer> sectionPositions;
     private String rendering = ProgramStageSectionRenderingType.LISTING.name();
     private Integer totalFields = 0;
+    private int openSectionPos = 0;
 
     public DataEntryAdapter(@NonNull LayoutInflater layoutInflater,
                             @NonNull FragmentManager fragmentManager,
@@ -289,6 +290,7 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
                 if (((SectionViewModel) fieldViewModel).isOpen()) {
                     rendering = ((SectionViewModel) fieldViewModel).rendering();
                     totalFields = ((SectionViewModel) fieldViewModel).totalFields();
+                    setOpenSectionPos(updates.indexOf(fieldViewModel));
                 }
             } else if (fieldViewModel instanceof ImageViewModel) {
                 imageFields++;
@@ -365,5 +367,13 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
 
     public int sectionViewType() {
         return SECTION;
+    }
+
+    private void setOpenSectionPos(int sectionOpened) {
+        openSectionPos = sectionOpened;
+    }
+
+    public int getOpenSectionPos() {
+        return openSectionPos;
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
@@ -417,17 +417,10 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
 
         val myLayoutManager: LinearLayoutManager =
             binding.fieldRecycler.layoutManager as LinearLayoutManager
-        val myFirstPositionIndex = myLayoutManager.findFirstVisibleItemPosition()
-        val myFirstPositionView = myLayoutManager.findViewByPosition(myFirstPositionIndex)
 
-        var offset = 0
-        myFirstPositionView?.let {
-            offset = it.top
+        adapter.swap(fields) {
+            myLayoutManager.scrollToPositionWithOffset(adapter.openSectionPos, 0)
         }
-
-        adapter.swap(fields) { }
-
-        myLayoutManager.scrollToPositionWithOffset(myFirstPositionIndex, offset)
     }
 
     /*endregion*/

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureFragment/EventCaptureFormFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureFragment/EventCaptureFormFragment.java
@@ -23,7 +23,6 @@ import org.dhis2.data.forms.dataentry.DataEntryArguments;
 import org.dhis2.data.forms.dataentry.fields.FieldViewModel;
 import org.dhis2.data.forms.dataentry.fields.RowAction;
 import org.dhis2.data.forms.dataentry.fields.section.SectionHolder;
-import org.dhis2.data.forms.dataentry.fields.section.SectionViewModel;
 import org.dhis2.data.tuples.Trio;
 import org.dhis2.databinding.FormSectionBinding;
 import org.dhis2.databinding.SectionSelectorFragmentBinding;
@@ -38,11 +37,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Flowable;
 import io.reactivex.processors.FlowableProcessor;
 import io.reactivex.processors.PublishProcessor;
-import kotlin.jvm.functions.Function1;
-import timber.log.Timber;
 
 import static android.text.TextUtils.isEmpty;
 
@@ -57,8 +53,6 @@ public class EventCaptureFormFragment extends FragmentGlobalAbstract implements 
     private FlowableProcessor<RowAction> flowableProcessor;
     private FlowableProcessor<String> sectionProcessor;
     private FlowableProcessor<Trio<String, String, Integer>> flowableOptions;
-    private FormSectionBinding headerBinding;
-    private SectionHolder headerHolder;
 
     public static EventCaptureFormFragment newInstance(String eventUid) {
         EventCaptureFormFragment fragment = new EventCaptureFormFragment();
@@ -122,22 +116,15 @@ public class EventCaptureFormFragment extends FragmentGlobalAbstract implements 
             dataEntryAdapter.setLastFocusItem(lastFocusItem);
         }
 
-        LinearLayoutManager myLayoutManager = (LinearLayoutManager) binding.formRecycler.getLayoutManager();
-        int myFirstPositionIndex = myLayoutManager.findFirstVisibleItemPosition();
-        View myFirstPositionView = myLayoutManager.findViewByPosition(myFirstPositionIndex);
-        int offset = 0;
-        if (myFirstPositionView != null) {
-            offset = myFirstPositionView.getTop();
-        }
-
         if (dataEntryAdapter == null) {
             createDataEntry();
         }
 
-        dataEntryAdapter.swap(updates, () -> { });
-
-        myLayoutManager.scrollToPositionWithOffset(myFirstPositionIndex, offset);
-
+        LinearLayoutManager myLayoutManager = (LinearLayoutManager) binding.formRecycler.getLayoutManager();
+        dataEntryAdapter.swap(updates, () -> {
+            if (myLayoutManager != null)
+                myLayoutManager.scrollToPositionWithOffset(dataEntryAdapter.getOpenSectionPos(), 0);
+        });
     }
 
     @Override


### PR DESCRIPTION
## Description
Scrolls open section to the top of the RecyclerViewhe related jira issue if it exists.

[ANDROAPP-3104](https://jira.dhis2.org/browse/ANDROAPP-3104)

## Solution description
Adds a method to get the open section position in the adapter and scrolls to that position 

## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code