### PR TITLE
fix: [ANDROAPP-3108] Saves datetime field without seconds in the database.

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/datetime/DateTimeHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/datetime/DateTimeHolder.java
@@ -124,7 +124,7 @@ public class DateTimeHolder extends FormViewHolder implements OnDateSelected {
             else if (dateTimeViewModel.valueType() == ValueType.TIME)
                 dateFormatted = DateUtils.timeFormat().format(date);
             else {
-                dateFormatted = DateUtils.databaseDateFormatNoMillis().format(date);
+                dateFormatted = DateUtils.databaseDateFormatNoSeconds().format(date);
             }
         }
         RowAction rowAction = RowAction.create(dateTimeViewModel.uid(), date != null ? dateFormatted : null, getAdapterPosition());

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/datetime/DateTimeHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/datetime/DateTimeHolder.java
@@ -134,7 +134,7 @@ public class DateTimeHolder extends FormViewHolder implements OnDateSelected {
             else if (dateTimeViewModel.valueType() == ValueType.TIME)
                 dateFormatted = DateUtils.timeFormat().format(date);
             else {
-                dateFormatted = DateUtils.databaseDateFormatNoMillis().format(date);
+                dateFormatted = DateUtils.databaseDateFormatNoSeconds().format(date);
             }
         processor.onNext(
                 RowAction.create(dateTimeViewModel.uid(), date != null ? dateFormatted : null, dateTimeViewModel.dataElement(), dateTimeViewModel.categoryOptionCombo(), dateTimeViewModel.catCombo(), dateTimeViewModel.row(), dateTimeViewModel.column())


### PR DESCRIPTION
## Description
Saves datetime field without seconds in the database.

[ANDROAPP-3108](https://jira.dhis2.org/browse/ANDROAPP-3108)

## Solution description
We format the date object as a string with this pattern `"yyyy-MM-dd HH:mm"`

## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [x ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code