### PR TITLE
fix: [ANDROAPP-3037] updates the complete/open status icon and label when a dataset is complete or re-open.

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.java
@@ -369,6 +369,7 @@ public class DataSetSectionFragment extends FragmentGlobalAbstract implements Da
             binding.actionButton.setText(activity.getString(R.string.complete));
         else
             binding.actionButton.setText(activity.getString(R.string.re_open));
+        activity.isDataSetOpen(isCompleted);
     }
 
     @Override


### PR DESCRIPTION
## Description
updates the complete/open status icon and label when a dataset is complete or re-open.

[ANDROAPP-3037](https://jira.dhis2.org/browse/ANDROAPP-3037)

## Solution description
updates the complete/open status icon and label when a dataset is complete or re-open.

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code