### PR TITLE
fix: [ANDROAPP-3104] Open section scroll to top

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
@@ -106,6 +106,8 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
     private String rendering = ProgramStageSectionRenderingType.LISTING.name();
     private Integer totalFields = 0;
     private int openSectionPos = 0;
+    private boolean sectionAlreadyOpen = false;
+    private String lastOpenedSectionUid = "";
 
     public DataEntryAdapter(@NonNull LayoutInflater layoutInflater,
                             @NonNull FragmentManager fragmentManager,
@@ -290,7 +292,9 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
                 if (((SectionViewModel) fieldViewModel).isOpen()) {
                     rendering = ((SectionViewModel) fieldViewModel).rendering();
                     totalFields = ((SectionViewModel) fieldViewModel).totalFields();
-                    setOpenSectionPos(updates.indexOf(fieldViewModel));
+                    setOpenSectionPos(updates.indexOf(fieldViewModel), fieldViewModel.uid());
+                } else if (fieldViewModel.uid().equals(lastOpenedSectionUid)){
+                    openSectionPos = -1;
                 }
             } else if (fieldViewModel instanceof ImageViewModel) {
                 imageFields++;
@@ -369,11 +373,17 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
         return SECTION;
     }
 
-    private void setOpenSectionPos(int sectionOpened) {
+    private void setOpenSectionPos(int sectionOpened, String openSectionUid) {
+        lastOpenedSectionUid = openSectionUid;
+        sectionAlreadyOpen = openSectionPos == sectionOpened;
         openSectionPos = sectionOpened;
     }
 
     public int getOpenSectionPos() {
         return openSectionPos;
+    }
+
+    public boolean isSectionAlreadyOpen() {
+        return sectionAlreadyOpen;
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
@@ -419,7 +419,9 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
             binding.fieldRecycler.layoutManager as LinearLayoutManager
 
         adapter.swap(fields) {
-            myLayoutManager.scrollToPositionWithOffset(adapter.openSectionPos, 0)
+            if (!adapter.isSectionAlreadyOpen) {
+                myLayoutManager.scrollToPositionWithOffset(adapter.openSectionPos, 0)
+            }
         }
     }
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureFragment/EventCaptureFormFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureFragment/EventCaptureFormFragment.java
@@ -22,9 +22,7 @@ import org.dhis2.data.forms.dataentry.DataEntryAdapter;
 import org.dhis2.data.forms.dataentry.DataEntryArguments;
 import org.dhis2.data.forms.dataentry.fields.FieldViewModel;
 import org.dhis2.data.forms.dataentry.fields.RowAction;
-import org.dhis2.data.forms.dataentry.fields.section.SectionHolder;
 import org.dhis2.data.tuples.Trio;
-import org.dhis2.databinding.FormSectionBinding;
 import org.dhis2.databinding.SectionSelectorFragmentBinding;
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity;
 import org.dhis2.usescases.general.FragmentGlobalAbstract;
@@ -123,8 +121,11 @@ public class EventCaptureFormFragment extends FragmentGlobalAbstract implements 
 
         LinearLayoutManager myLayoutManager = (LinearLayoutManager) binding.formRecycler.getLayoutManager();
         dataEntryAdapter.swap(updates, () -> {
-            if (myLayoutManager != null)
-                myLayoutManager.scrollToPositionWithOffset(dataEntryAdapter.getOpenSectionPos(), 0);
+            if (myLayoutManager != null) {
+                if(!dataEntryAdapter.isSectionAlreadyOpen()) {
+                    myLayoutManager.scrollToPositionWithOffset(dataEntryAdapter.getOpenSectionPos(), 0);
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## Description
Form now distinguish between a opening and scrolling to the top a previously closed section. Also it does not scrolls to the top when a value of a field is changed.

[ANDROAPP-3104](https://jira.dhis2.org/browse/ANDROAPP-3104)

## Solution description
1. In the adapter we have to determine what section is mark as open, using the isOpen() method and make a public method to get that section position in the list.
2. In the activity we have to setup a callback in the adapter's swap() method to have the layoutManager scroll to the last open section, using the public method describe in the above step.

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code