### PR TITLE
fix: [ANDROAPP-2849] Removes Long TextField dark gray color.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -69,6 +69,7 @@
         <item name="colorAccent">@color/text_black_333</item>
         <item name="colorControlNormal">@color/text_black_333</item>
         <item name="colorControlActivated">@color/text_black_333</item>
+        <item name="boxBackgroundColor">@color/bg_white_f9f</item>
     </style>
 
     <style name="ValueType_Text">


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-2849](https://jira.dhis2.org/browse/ANDROAPP-2849)

## Solution description
Adds a style setting to the TextInputLayout style to add the same color as the background color

## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code