### PR TITLE
fix: [ANDROAPP-3094] Removes the grammar red lines from option sets options

### DIFF
--- a/app/src/main/java/org/dhis2/utils/customviews/OptionSetView.java
+++ b/app/src/main/java/org/dhis2/utils/customviews/OptionSetView.java
@@ -1,6 +1,7 @@
 package org.dhis2.utils.customviews;
 
 import android.content.Context;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
@@ -70,6 +71,7 @@ public class OptionSetView extends FieldLayout implements OptionSetOnClickListen
 
 
         editText.setFocusable(false);
+        editText.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
 
         delete.setOnClickListener(view -> deleteSelectedOption());
 


### PR DESCRIPTION
## Description
Removes the grammar red lines from option sets options when there are strange words.

[ANDROAPP-3094](https://jira.dhis2.org/browse/ANDROAPP-3094)

## Solution description
Added the TEXT_FLAG_NO_SUGGESTION inputText to the option set's editText.

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code