### PR TITLE
fix: [ANDROAPP-3043] update OU filter list

### DIFF
--- a/app/src/main/java/org/dhis2/utils/filters/OrgUnitFilterHolder.java
+++ b/app/src/main/java/org/dhis2/utils/filters/OrgUnitFilterHolder.java
@@ -77,7 +77,9 @@ class OrgUnitFilterHolder extends FilterHolder {
             }
         });
 
-        localBinding.filterOrgUnit.ouTreeButton.setOnClickListener(view ->
-                FilterManager.getInstance().getOuTreeProcessor().onNext(true));
+        localBinding.filterOrgUnit.ouTreeButton.setOnClickListener(view -> {
+                localBinding.root.clearFocus();
+                FilterManager.getInstance().getOuTreeProcessor().onNext(true);
+        });
     }
 }


### PR DESCRIPTION

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3043)

## Solution description
We should clear focus when going to OU tree selector because of that OU adapter was not updating when returning from tree selector

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code