### PR TITLE
fix: [ANDROAPP-3122] Fix crash when deleting enrollment

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensions.kt
@@ -7,7 +7,6 @@ fun MutableList<TrackedEntityInstance>.filterDeletedEnrollment(
     d2: D2,
     program: String?
 ): List<TrackedEntityInstance> {
-
     val iterator = this.iterator()
     if (program != null) {
         while (iterator.hasNext()) {

--- a/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensions.kt
@@ -3,26 +3,26 @@ package org.dhis2.Bindings
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 
-fun List<TrackedEntityInstance>.filterDeletedEnrollment(
+fun MutableList<TrackedEntityInstance>.filterDeletedEnrollment(
     d2: D2,
     program: String?
 ): List<TrackedEntityInstance> {
-    return program?.let {
-        this.filter {
-            if (d2.trackedEntityModule().trackedEntityInstances().uid(it.uid()).blockingExists()) {
-                val enrollmentsInProgram = d2.enrollmentModule().enrollments()
-                    .byTrackedEntityInstance().eq(it.uid())
+
+    val iterator = this.iterator()
+    if (program != null) {
+        while (iterator.hasNext()) {
+            val tei = iterator.next()
+            val hasEnrollmentInProgram =
+                !d2.enrollmentModule().enrollments()
+                    .byTrackedEntityInstance().eq(tei.uid())
                     .byProgram().eq(program)
-                    .blockingGet()
-
-                val enrollmentDeleted = enrollmentsInProgram.any { enrollment ->
-                    enrollment.deleted() != true
-                }
-
-                enrollmentsInProgram.size == 0 || enrollmentDeleted
-            } else {
-                true
+                    .byDeleted().isFalse
+                    .blockingIsEmpty()
+            if (!hasEnrollmentInProgram) {
+                iterator.remove()
             }
         }
-    } ?: this
+    }
+
+    return this
 }

--- a/app/src/test/java/org/dhis2/bindings/TrackedEntityInstanceExtensions.kt
+++ b/app/src/test/java/org/dhis2/bindings/TrackedEntityInstanceExtensions.kt
@@ -1,0 +1,81 @@
+package org.dhis2.bindings
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import junit.framework.Assert.assertTrue
+import org.dhis2.Bindings.filterDeletedEnrollment
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.junit.Test
+import org.mockito.Mockito
+
+class TrackedEntityInstanceExtensions {
+
+    private val d2: D2 = Mockito.mock(D2::class.java, Mockito.RETURNS_DEEP_STUBS)
+
+    @Test
+    fun `Should not filter teis if program is null`() {
+        val testList = mutableListOf(
+            TrackedEntityInstance.builder().uid("tei_A").build(),
+            TrackedEntityInstance.builder().uid("tei_C").build(),
+            TrackedEntityInstance.builder().uid("tei_D").build()
+        )
+
+        testList.filterDeletedEnrollment(d2, null)
+
+        assertTrue(testList.size == 3)
+    }
+
+    @Test
+    fun `Should filter tei with deleted enrollment`() {
+        val testList = mutableListOf(
+            TrackedEntityInstance.builder().uid("tei_A").build(),
+            TrackedEntityInstance.builder().uid("tei_C").build(),
+            TrackedEntityInstance.builder().uid("tei_D").build()
+        )
+        testList.forEachIndexed { index, tei ->
+            handleEnrollmentCall(tei.uid(), "programUid", index == 0)
+        }
+
+        testList.filterDeletedEnrollment(d2, "programUid")
+
+        assertTrue(testList.size == 2)
+    }
+
+    private fun handleEnrollmentCall(teiUid: String, programUid: String, returnValue: Boolean) {
+        whenever(
+            d2.enrollmentModule().enrollments()
+                .byTrackedEntityInstance().eq(teiUid)
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments()
+                .byTrackedEntityInstance().eq(teiUid)
+                .byProgram()
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments()
+                .byTrackedEntityInstance().eq(teiUid)
+                .byProgram().eq(programUid)
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments()
+                .byTrackedEntityInstance().eq(teiUid)
+                .byProgram().eq(programUid)
+                .byDeleted()
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments()
+                .byTrackedEntityInstance().eq(teiUid)
+                .byProgram().eq(programUid)
+                .byDeleted().isFalse
+        ) doReturn mock()
+        whenever(
+            d2.enrollmentModule().enrollments()
+                .byTrackedEntityInstance().eq(teiUid)
+                .byProgram().eq(programUid)
+                .byDeleted().isFalse
+                .blockingIsEmpty()
+        ) doReturn returnValue
+    }
+}

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext {
             sdk   : 28,
             tools : "28.0.3",
             minSdk: 19,
-            vCode: 85,
+            vCode: 86,
             vName: "2.1.2"
     ]
 


### PR DESCRIPTION
## Description
[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3122)

## Solution description
Do not return a new list when filtering a datasource.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [x] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [x] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code