### PR TITLE
fix: [ANDROAPP-1157] Hides "complete anyways" button when dataset has set that it must be valid to complete

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableContract.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableContract.java
@@ -67,6 +67,8 @@ public class DataSetTableContract {
         void onCancelBottomSheet();
 
         void onCompleteBottomSheet();
+
+        boolean isValidationMandatoryToComplete();
     }
 
 }

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenter.java
@@ -109,7 +109,7 @@ public class DataSetTablePresenter implements DataSetTableContract.Presenter {
                         .subscribe(
                                 allOk -> {
                                     if (allOk) {
-                                        if (tableRepository.runMandatoryValidationRules()) {
+                                        if (isValidationMandatoryToComplete()) {
                                             executeValidationRules();
                                         } else {
                                             checkIfValidationRulesExecutionIsOptional();
@@ -212,4 +212,9 @@ public class DataSetTablePresenter implements DataSetTableContract.Presenter {
 
     @Override
     public void onCompleteBottomSheet() { view.completeBottomSheet(); }
+
+    @Override
+    public boolean isValidationMandatoryToComplete() {
+        return tableRepository.runMandatoryValidationRules();
+    }
 }

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableRepositoryImpl.kt
@@ -99,7 +99,7 @@ class DataSetTableRepositoryImpl(
                 if (sections.isEmpty()) {
                     arrayListOf("NO_SECTION")
                 } else {
-                    sections.map { it.displayName() }
+                    sections.map { it.displayName()!! }
                 }
             }.toFlowable()
     }

--- a/app/src/main/res/layout/violation_rules_bottom_sheet.xml
+++ b/app/src/main/res/layout/violation_rules_bottom_sheet.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="android.view.View"/>
+
         <variable
             name="errorCount"
             type="java.lang.Integer" />
@@ -142,6 +144,7 @@
                 android:textColor="?colorPrimary"
                 android:textSize="14sp"
                 android:text="@string/complete_anyway"
+                android:visibility="@{ presenter.isValidationMandatoryToComplete() ? View.GONE : View.VISIBLE }"
                 android:onClick="@{ () -> presenter.onCompleteBottomSheet() }"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/endGuideline" />


### PR DESCRIPTION
## Description
Hides "complete anyways" button from error bottomsheet if the dataset has set that it must be valid to complete.

[ANDROAPP-1157](https://jira.dhis2.org/browse/ANDROAPP-1157)

## Solution description
Check if the dataset has the setting "Complete allowed only if validation passes" in its configuration and show the complete button only when this setting is false.

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code