### PR TITLE
fix: [ANDROAPP-3143] Set viewpager2 in event data entry

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
@@ -22,6 +22,7 @@ import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator;
 
 import org.dhis2.Bindings.ExtensionsKt;
 import org.dhis2.R;
@@ -90,14 +91,20 @@ public class EventCaptureActivity extends ActivityGlobalAbstract implements Even
         binding.setPresenter(presenter);
         eventMode = (EventMode) getIntent().getSerializableExtra(Constants.EVENT_MODE);
 
-        binding.eventTabLayout.setupWithViewPager(binding.eventViewPager);
         binding.eventTabLayout.setTabMode(TabLayout.MODE_FIXED);
         binding.eventViewPager.setAdapter(new EventCapturePagerAdapter(
-                getSupportFragmentManager(),
-                getContext(),
+                this,
                 getIntent().getStringExtra(PROGRAM_UID),
                 getIntent().getStringExtra(Constants.EVENT_UID)
         ));
+        new TabLayoutMediator(binding.eventTabLayout, binding.eventViewPager,
+                (tab, position) -> {
+                    if (position == 1) {
+                        tab.setText(R.string.event_notes);
+                    } else {
+                        tab.setText(R.string.event_overview);
+                    }
+                }).attach();
         presenter.initNoteCounter();
         presenter.init();
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePagerAdapter.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePagerAdapter.java
@@ -1,53 +1,37 @@
 package org.dhis2.usescases.eventsWithoutRegistration.eventCapture;
 
-import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
 
-import org.dhis2.R;
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureFragment.EventCaptureFormFragment;
 import org.dhis2.usescases.notes.NotesFragment;
 
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentStatePagerAdapter;
+public class EventCapturePagerAdapter extends FragmentStateAdapter {
 
-/**
- * QUADRAM. Created by ppajuelo on 19/11/2018.
- */
-public class EventCapturePagerAdapter extends FragmentStatePagerAdapter {
-
-    private final Context context;
     private final String programUid;
     private final String eventUid;
 
-    public EventCapturePagerAdapter(FragmentManager fm, Context context,String programUid, String eventUid) {
-        super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
-        this.context = context;
+    public EventCapturePagerAdapter(FragmentActivity fragmentActivity,
+                                    String programUid,
+                                    String eventUid) {
+        super(fragmentActivity);
         this.programUid = programUid;
         this.eventUid = eventUid;
     }
 
+    @NonNull
     @Override
-    public Fragment getItem(int position) {
-        switch (position) {
-            default:
-                return EventCaptureFormFragment.newInstance(eventUid);
-            case 1:
-                return NotesFragment.newEventInstance(programUid, eventUid);
+    public Fragment createFragment(int position) {
+        if (position == 1) {
+            return NotesFragment.newEventInstance(programUid, eventUid);
         }
+        return EventCaptureFormFragment.newInstance(eventUid);
     }
 
     @Override
-    public int getCount() {
-        return 2; //TODO: ADD OVERVIEW, INDICATORS
-    }
-
-    @Override
-    public CharSequence getPageTitle(int position) {
-        switch (position) {
-            default:
-                return context.getString(R.string.event_overview);
-            case 1:
-                return context.getString(R.string.event_notes);
-        }
+    public int getItemCount() {
+        return 2;
     }
 }

--- a/app/src/main/res/layout/activity_event_capture.xml
+++ b/app/src/main/res/layout/activity_event_capture.xml
@@ -105,7 +105,7 @@
             app:tabTextAppearance="@style/DhisTabText"
             tools:visibility="visible"/>
 
-        <androidx.viewpager.widget.ViewPager
+        <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/eventViewPager"
             android:layout_width="match_parent"
             android:layout_height="0dp"


### PR DESCRIPTION
## Description
An user has reported that the note fragment is selected automatically during data entry.
Cound not be replicated and in the code there is no way to change pages except by scrolling or clicking in the correct tab so it is highly possible it is an issue in the device screen.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3143)

## Solution description
No fix is needed. But just in case, we have migrated the viewpager to viewpager2.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code