### PR TITLE
fix: [ANDROAPP-3113] close keyboard before open calendar picker

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/datetime/DateTimeHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/datetime/DateTimeHolder.java
@@ -38,20 +38,26 @@ public class DateTimeHolder extends FormViewHolder implements OnDateSelected {
 
         if (binding instanceof FormTimeTextBinding) {
             ((FormTimeTextBinding) binding).timeView.setDateListener(this);
-            ((FormTimeTextBinding) binding).timeView.setActivationListener(() ->
-                    setSelectedBackground(isSearchMode));
+            ((FormTimeTextBinding) binding).timeView.setActivationListener(() -> {
+                    setSelectedBackground(isSearchMode);
+                    closeKeyboard(binding.getRoot());
+            });
         }
 
         if (binding instanceof FormDateTextBinding) {
             ((FormDateTextBinding) binding).dateView.setDateListener(this);
-            ((FormDateTextBinding) binding).dateView.setActivationListener(() ->
-                    setSelectedBackground(isSearchMode));
+            ((FormDateTextBinding) binding).dateView.setActivationListener(() -> {
+                setSelectedBackground(isSearchMode);
+                closeKeyboard(binding.getRoot());
+            });
         }
 
         if (binding instanceof FormDateTimeTextBinding) {
             ((FormDateTimeTextBinding) binding).dateTimeView.setDateListener(this);
-            ((FormDateTimeTextBinding) binding).dateTimeView.setActivationListener(() ->
-                    setSelectedBackground(isSearchMode));
+            ((FormDateTimeTextBinding) binding).dateTimeView.setActivationListener(() -> {
+                setSelectedBackground(isSearchMode);
+                closeKeyboard(binding.getRoot());
+            });
         }
     }
 


### PR DESCRIPTION

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3113)

## Solution description
Close keyboard when a field with datetime is open

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code