### PR TITLE
fix: [ANDROAPP-3098] add horizontal scroll when to many options

### DIFF
--- a/app/src/main/res/layout/form_spinner_selection.xml
+++ b/app/src/main/res/layout/form_spinner_selection.xml
@@ -100,25 +100,35 @@
             app:srcCompat="@drawable/ic_close"
             app:tint="?colorPrimary" />
 
-        <LinearLayout
-            android:id="@+id/checkLayout"
+        <HorizontalScrollView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:weightSum="6"
             app:layout_constraintEnd_toStartOf="@id/delete"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/warningError" />
+            app:layout_constraintTop_toBottomOf="@id/warningError">
+            <LinearLayout
+                android:id="@+id/checkLayout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:weightSum="6"
+                 />
+        </HorizontalScrollView>
 
-        <RadioGroup
-            android:id="@+id/radioLayout"
+        <HorizontalScrollView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:weightSum="6"
-            app:layout_constraintEnd_toStartOf="@id/delete"
+            app:layout_constraintEnd_toStartOf="@+id/delete"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label" />
+            app:layout_constraintTop_toBottomOf="@id/label">
+
+            <RadioGroup
+                android:id="@+id/radioLayout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:weightSum="6" />
+        </HorizontalScrollView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3098)

## Solution description
Add a horizontal scroll view to scroll items when it is configured as horizontal checkboxes or horizontal radio button and there are many items

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code