### PR TITLE
fix: [ANDROAPP-3166] Fixes crash when selectedEnrollment is null in SearchTEViewHolder

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/adapters/SearchTEViewHolder.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/adapters/SearchTEViewHolder.kt
@@ -36,12 +36,14 @@ class SearchTEViewHolder(private val binding: ItemSearchTrackedEntityBinding) :
                 binding.programList,
                 if (selectedEnrollment != null) selectedEnrollment.program() else null
             )
-            selectedEnrollment.setStatusText(
-                itemView.context,
-                binding.enrollmentStatus,
-                isHasOverdue,
-                overdueDate
-            )
+            if (selectedEnrollment != null) {
+                selectedEnrollment.setStatusText(
+                    itemView.context,
+                    binding.enrollmentStatus,
+                    isHasOverdue,
+                    overdueDate
+                )
+            }
             setTeiImage(
                 itemView.context,
                 binding.trackedEntityImage,


### PR DESCRIPTION
## Description
[ANDROAPP-3166](https://jira.dhis2.org/browse/ANDROAPP-3166)

## Solution description
Checks is selectedEnrollment is not null to set its status in the holder

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code