### PR TITLE
fix: [ANDROAPP-3164] avoid showing orgUnit dialog two times

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetInitial/DataSetInitialActivity.java
@@ -48,6 +48,7 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
     private OrganisationUnit selectedOrgUnit;
     private Date selectedPeriod;
     private String dataSetUid;
+    private OrgUnitDialog orgUnitDialog;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -57,6 +58,7 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_dataset_initial);
         binding.setPresenter(presenter);
+        orgUnitDialog = OrgUnitDialog.getInstace();
     }
 
     @Override
@@ -114,27 +116,28 @@ public class DataSetInitialActivity extends ActivityGlobalAbstract implements Da
      */
     @Override
     public void showOrgUnitDialog(List<OrganisationUnit> data) {
-        OrgUnitDialog orgUnitDialog = OrgUnitDialog.getInstace();
-        orgUnitDialog
-                .setMultiSelection(false)
-                .setOrgUnits(data)
-                .setProgram(dataSetUid)
-                .setTitle(getString(R.string.org_unit))
-                .setPossitiveListener(v -> {
-                    if (orgUnitDialog.getSelectedOrgUnit() != null && !orgUnitDialog.getSelectedOrgUnit().isEmpty()) {
-                        selectedOrgUnit = orgUnitDialog.getSelectedOrgUnitModel();
-                        if (selectedOrgUnit == null)
-                            orgUnitDialog.dismiss();
-                        binding.dataSetOrgUnitEditText.setText(selectedOrgUnit.displayName());
-                        binding.dataSetPeriodEditText.setText(null);
-                        selectedPeriod = null;
-                        clearCatOptionCombo();
-                    }
-                    checkActionVisivbility();
-                    orgUnitDialog.dismiss();
-                })
-                .setNegativeListener(v -> orgUnitDialog.dismiss())
-                .show(getSupportFragmentManager(), OrgUnitDialog.class.getSimpleName());
+        if (!orgUnitDialog.isVisible()) {
+            orgUnitDialog
+                    .setMultiSelection(false)
+                    .setOrgUnits(data)
+                    .setProgram(dataSetUid)
+                    .setTitle(getString(R.string.org_unit))
+                    .setPossitiveListener(v -> {
+                        if (orgUnitDialog.getSelectedOrgUnit() != null && !orgUnitDialog.getSelectedOrgUnit().isEmpty()) {
+                            selectedOrgUnit = orgUnitDialog.getSelectedOrgUnitModel();
+                            if (selectedOrgUnit == null)
+                                orgUnitDialog.dismiss();
+                            binding.dataSetOrgUnitEditText.setText(selectedOrgUnit.displayName());
+                            binding.dataSetPeriodEditText.setText(null);
+                            selectedPeriod = null;
+                            clearCatOptionCombo();
+                        }
+                        checkActionVisivbility();
+                        orgUnitDialog.dismiss();
+                    })
+                    .setNegativeListener(v -> orgUnitDialog.dismiss())
+                    .show(getSupportFragmentManager(), OrgUnitDialog.class.getSimpleName());
+        }
     }
 
     @Override


### PR DESCRIPTION

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3164)

## Solution description
Check dialog is not visible when displaying it to avoid show it two times and get a crash


## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code