### PR TITLE
fix: [ANDROAPP-3158] disable horizontal swipe on dataset tabs

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -124,6 +124,7 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
 
     private void setViewPager() {
         viewPagerAdapter = new DataSetSectionAdapter(this, accessDataWrite, getIntent().getStringExtra(Constants.DATA_SET_UID));
+        binding.viewPager.setUserInputEnabled(false);
         binding.viewPager.setAdapter(viewPagerAdapter);
         new TabLayoutMediator(binding.tabLayout, binding.viewPager, (tab, position) -> {
             if (position == 0) {


### PR DESCRIPTION
## Description
Disable horizontal swipe in dataset tabs. Change tab will be able only by clicking it

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3158)

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code