### PR TITLE
fix: [ANDROAPP-3173] fix the assigned to me filter switch

### DIFF
--- a/app/src/main/java/org/dhis2/utils/filters/AssignToMeFilterHolder.kt
+++ b/app/src/main/java/org/dhis2/utils/filters/AssignToMeFilterHolder.kt
@@ -15,7 +15,7 @@ internal class AssignToMeFilterHolder(
     init {
         filterType = Filters.ASSIGNED_TO_ME
         this.programType = programType
-        filterArrow.visibility = View.GONE
+        filterArrow.visibility = View.INVISIBLE
         sortingIcon.visibility = View.GONE
     }
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3173](https://jira.dhis2.org/browse/ANDROAPP-3173)

## Solution description
Set the filter arrow visibility from GONE to INVISIBLE in the AssignedToMeHolder, to give space to switch view to accepts clicks events
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code