### PR TITLE
fix: [ANDROAPP-3162] refreshes events status when enrollment is completed/reopen

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
@@ -88,6 +88,7 @@ class TeiDashboardTest : BaseTest() {
             clickOnMenuReOpen()
             checkUnlockIconIsDisplay()
             checkCanAddEvent()
+            checkAllEventsAreOpened(1)
         }
     }
 
@@ -100,6 +101,7 @@ class TeiDashboardTest : BaseTest() {
             clickOnMenuDeactivate()
             checkLockIconIsDisplay()
             checkCanNotAddEvent()
+            checkAllEventsAreInactive(1)
         }
     }
 
@@ -112,6 +114,7 @@ class TeiDashboardTest : BaseTest() {
             clickOnMenuComplete()
             checkLockCompleteIconIsDisplay()
             checkCanNotAddEvent()
+            checkAllEventsAreClosed(1)
         }
     }
 

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
@@ -80,7 +80,7 @@ class TeiDashboardTest : BaseTest() {
     }
 
     @Test
-    fun shouldReactivateTEIWhenClickReOpen() {
+    fun shouldReactivateTEIWhenClickReOpenWithProgramCompletedEvents() {
         prepareTeiCompletedProgrammeAndLaunchActivity(rule)
 
         teiDashboardRobot {
@@ -88,7 +88,7 @@ class TeiDashboardTest : BaseTest() {
             clickOnMenuReOpen()
             checkUnlockIconIsDisplay()
             checkCanAddEvent()
-            checkAllEventsAreOpened(1)
+            checkAllEventsCompleted(1)
         }
     }
 
@@ -105,7 +105,7 @@ class TeiDashboardTest : BaseTest() {
         }
     }
 
-    @Test
+   @Test
     fun shouldCompleteTEIWhenClickOpen() {
         prepareTeiOpenedForCompleteProgrammeAndLaunchActivity(rule)
 
@@ -118,7 +118,7 @@ class TeiDashboardTest : BaseTest() {
         }
     }
 
-    @Test
+   @Test
     fun shouldShowQRWhenClickOnShare() {
         prepareTeiCompletedProgrammeAndLaunchActivity(rule)
 

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/TeiDashboardRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/TeiDashboardRobot.kt
@@ -238,4 +238,42 @@ class TeiDashboardRobot : BaseRobot() {
                     hasDescendant(withText(R.string.event_schedule)))))))
     }
 
+    fun checkEventIsClosed(position: Int) {
+        onView(withId(R.id.tei_recycler))
+                .check(matches(allOf(isDisplayed(), isNotEmpty(),
+                        atPosition(position, hasDescendant(withText(R.string.program_completed))))))
+    }
+
+    fun checkEventIsOpen(position: Int) {
+        onView(withId(R.id.tei_recycler))
+                .check(matches(allOf(isDisplayed(), isNotEmpty(),
+                        atPosition(position, hasDescendant(withText(R.string.event_open))))))
+    }
+    fun checkEventIsInactivate(position: Int) {
+        onView(withId(R.id.tei_recycler))
+                .check(matches(allOf(isDisplayed(), isNotEmpty(), atPosition(position, hasDescendant(withText(R.string.program_inactive))))))
+    }
+
+    fun checkAllEventsAreInactive(totalEvents: Int) {
+        var event = 0
+        while (event < totalEvents) {
+            checkEventIsInactivate(event)
+            event++
+        }
+    }
+
+    fun checkAllEventsAreOpened(totalEvents: Int) {
+        var event = 0
+        while (event < totalEvents) {
+            checkEventIsOpen(event)
+            event++
+        }
+    }
+    fun checkAllEventsAreClosed(totalEvents: Int) {
+        var event = 0
+        while (event < totalEvents) {
+            checkEventIsClosed(event)
+            event++
+        }
+    }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/TeiDashboardRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/TeiDashboardRobot.kt
@@ -249,6 +249,13 @@ class TeiDashboardRobot : BaseRobot() {
                 .check(matches(allOf(isDisplayed(), isNotEmpty(),
                         atPosition(position, hasDescendant(withText(R.string.event_open))))))
     }
+
+    fun checkEventIsCompleted(position: Int) {
+        onView(withId(R.id.tei_recycler))
+            .check(matches(allOf(isDisplayed(), isNotEmpty(),
+                atPosition(position, hasDescendant(withText(R.string.event_completed))))))
+    }
+
     fun checkEventIsInactivate(position: Int) {
         onView(withId(R.id.tei_recycler))
                 .check(matches(allOf(isDisplayed(), isNotEmpty(), atPosition(position, hasDescendant(withText(R.string.program_inactive))))))
@@ -269,6 +276,15 @@ class TeiDashboardRobot : BaseRobot() {
             event++
         }
     }
+
+    fun checkAllEventsCompleted(totalEvents: Int) {
+        var event = 0
+        while (event < totalEvents) {
+            checkEventIsCompleted(event)
+            event++
+        }
+    }
+
     fun checkAllEventsAreClosed(totalEvents: Int) {
         var event = 0
         while (event < totalEvents) {

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2020-07-08 00:22","gitSha":"5febed8cb"}
+{"buildTime":"2020-07-09 13:44","gitSha":"eb5a8c7ff"}

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
@@ -197,6 +197,7 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
     @Override
     public void setEnrollment(Enrollment enrollment) {
         binding.setEnrollment(enrollment);
+        binding.executePendingBindings();
         dashboardViewModel.updateDashboard(dashboardModel);
         if (adapter != null) {
             adapter.clear();

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
@@ -197,9 +197,10 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
     @Override
     public void setEnrollment(Enrollment enrollment) {
         binding.setEnrollment(enrollment);
+        dashboardViewModel.updateDashboard(dashboardModel);
         if (adapter != null) {
             adapter.clear();
-            adapter.updateEnrollement(enrollment);
+            adapter.updateEnrollment(enrollment);
         }
     }
 
@@ -407,7 +408,7 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
     public Consumer<EnrollmentStatus> enrollmentCompleted() {
         return enrollmentStatus -> {
             if (enrollmentStatus == EnrollmentStatus.COMPLETED)
-                activity.getPresenter().init();
+                activity.updateStatus();
         };
     }
 

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
@@ -197,6 +197,10 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
     @Override
     public void setEnrollment(Enrollment enrollment) {
         binding.setEnrollment(enrollment);
+        if (adapter != null) {
+            adapter.clear();
+            adapter.updateEnrollement(enrollment);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventAdapter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventAdapter.kt
@@ -22,7 +22,7 @@ import org.hisp.dhis.android.core.program.Program
 class EventAdapter(
     val presenter: TEIDataContracts.Presenter,
     val program: Program,
-    val enrollment: Enrollment
+    var enrollment: Enrollment
 ) : ListAdapter<EventViewModel, RecyclerView.ViewHolder>(
     object : DiffUtil.ItemCallback<EventViewModel>() {
         override fun areItemsTheSame(oldItem: EventViewModel, newItem: EventViewModel): Boolean {
@@ -98,5 +98,14 @@ class EventAdapter(
 
     override fun getItemId(position: Int): Long {
         return getItem(position).hashCode().toLong()
+    }
+
+    fun updateEnrollement(enrollment: Enrollment) {
+        this.enrollment = enrollment
+    }
+
+    fun clear() {
+        this.submitList(emptyList())
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventAdapter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventAdapter.kt
@@ -100,12 +100,11 @@ class EventAdapter(
         return getItem(position).hashCode().toLong()
     }
 
-    fun updateEnrollement(enrollment: Enrollment) {
+    fun updateEnrollment(enrollment: Enrollment) {
         this.enrollment = enrollment
     }
 
     fun clear() {
         this.submitList(emptyList())
-        notifyDataSetChanged()
     }
 }


### PR DESCRIPTION
## Description
[ANDROAPP-3162](https://jira.dhis2.org/browse/ANDROAPP-3162)

## Solution description
Updates enrollment in the eventAdapter
## Covered unit test cases
Functional test
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code