### PR TITLE
fix: [ANDROAPP-3182] save server and user when login

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
@@ -314,31 +314,39 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
     override fun saveUsersData() {
         (context.applicationContext as App).createUserComponent()
 
-        if (presenter.canHandleBiometrics() == true &&
-            !presenter.areSameCredentials(
-                binding.serverUrlEdit.text.toString(),
-                binding.userNameEdit.text.toString(),
-                binding.userPassEdit.text.toString()
-            )
+        if (!presenter.areSameCredentials(
+            binding.serverUrlEdit.text.toString(),
+            binding.userNameEdit.text.toString(),
+            binding.userPassEdit.text.toString()
+        )
         ) {
-            showInfoDialog(
-                getString(R.string.biometrics_security_title),
-                getString(R.string.biometrics_security_text),
-                object : OnDialogClickListener {
-                    override fun onPossitiveClick(alertDialog: AlertDialog) {
-                        presenter.saveUserCredentials(
-                            binding.serverUrlEdit.text.toString(),
-                            binding.userNameEdit.text.toString(),
-                            binding.userPassEdit.text.toString()
-                        )
-                        goToNextScreen()
-                    }
+            if (presenter.canHandleBiometrics() == true) {
+                showInfoDialog(
+                    getString(R.string.biometrics_security_title),
+                    getString(R.string.biometrics_security_text),
+                    object : OnDialogClickListener {
+                        override fun onPossitiveClick(alertDialog: AlertDialog) {
+                            presenter.saveUserCredentials(
+                                binding.serverUrlEdit.text.toString(),
+                                binding.userNameEdit.text.toString(),
+                                binding.userPassEdit.text.toString()
+                            )
+                            goToNextScreen()
+                        }
 
-                    override fun onNegativeClick(alertDialog: AlertDialog) {
-                        goToNextScreen()
+                        override fun onNegativeClick(alertDialog: AlertDialog) {
+                            goToNextScreen()
+                        }
                     }
-                }
-            )?.show()
+                )?.show()
+            } else {
+                presenter.saveUserCredentials(
+                    binding.serverUrlEdit.text.toString(),
+                    binding.userNameEdit.text.toString(),
+                    ""
+                )
+                goToNextScreen()
+            }
         } else {
             goToNextScreen()
         }


### PR DESCRIPTION
[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3182)

## Solution description
Server URL and username have to be saved and restored when user do log out also when device do not have fingerprint option
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code