### PR TITLE
fix: [ANDROAPP-3167] truncates coordinates values when entered manually by user.

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/StringExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/StringExtensions.kt
@@ -64,3 +64,5 @@ fun String.toDate(): Date {
 
     return date
 }
+
+fun String.parseToDouble() = this.toDoubleOrNull()?.toString() ?: "0.0"

--- a/app/src/main/java/org/dhis2/uicomponents/map/geometry/LngLatValidator.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/geometry/LngLatValidator.kt
@@ -1,5 +1,7 @@
 package org.dhis2.uicomponents.map.geometry
 
-fun areLngLatCorrect(lon: Double, lat: Double): Boolean {
-    return (lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180)
-}
+fun areLngLatCorrect(lon: Double, lat: Double) = isLatitudeValid(lat) && isLongitudeValid(lon)
+
+fun isLongitudeValid(longitude: Double) = longitude >= -180 && longitude <= 180
+
+fun isLatitudeValid(latitude: Double) = latitude >= -90 && latitude <= 90

--- a/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
+++ b/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
@@ -148,6 +148,28 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
         position.setOnClickListener(this);
         map.setOnClickListener(this);
         clearButton.setOnClickListener(this);
+
+        longitude.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if(!hasFocus)
+                    if (!longitude.getText().toString().isEmpty()) {
+                        Double lon = DoubleExtensionsKt.truncate(getLongitude());
+                        longitude.setText(lon.toString());
+                    }
+            }
+        });
+
+        latitude.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if(!hasFocus)
+                    if (!latitude.getText().toString().isEmpty()) {
+                        Double lat = DoubleExtensionsKt.truncate(getLatitude());
+                        latitude.setText(lat.toString());
+                    }
+            }
+        });
     }
 
     private boolean validateCoordinates() {

--- a/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
+++ b/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
@@ -28,6 +28,7 @@ import org.dhis2.Bindings.StringExtensionsKt;
 import org.dhis2.R;
 import org.dhis2.databinding.FormCoordinatesAccentBinding;
 import org.dhis2.databinding.FormCoordinatesBinding;
+import org.dhis2.uicomponents.map.geometry.LngLatValidatorKt;
 import org.dhis2.usescases.general.ActivityGlobalAbstract;
 import org.dhis2.utils.customviews.FieldLayout;
 import org.hisp.dhis.android.core.arch.helpers.GeometryHelper;
@@ -113,7 +114,13 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
             if (validateCoordinates()) {
                 Double latitudeValue = isEmpty(latitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLatitude());
                 Double longitudeValue = isEmpty(longitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLongitude());
-                currentLocationListener.onCurrentLocationClick(GeometryHelper.createPointGeometry(longitudeValue, latitudeValue));
+                if (latitudeValue != null || longitudeValue != null) {
+                    if (LngLatValidatorKt.isLatitudeValid(latitudeValue)) {
+                        currentLocationListener.onCurrentLocationClick(GeometryHelper.createPointGeometry(longitudeValue, latitudeValue));
+                    } else {
+                        setError(getContext().getString(R.string.coordinates_error));
+                    }
+                }
             } else {
                 longitude.requestFocus();
                 longitude.performClick();
@@ -125,7 +132,13 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
             if (validateCoordinates()) {
                 Double latitudeValue = isEmpty(latitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLatitude());
                 Double longitudeValue = isEmpty(longitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLongitude());
-                currentLocationListener.onCurrentLocationClick(GeometryHelper.createPointGeometry(longitudeValue, latitudeValue));
+                if (latitudeValue != null || longitudeValue != null) {
+                    if (LngLatValidatorKt.areLngLatCorrect(longitudeValue, latitudeValue)) {
+                        currentLocationListener.onCurrentLocationClick(GeometryHelper.createPointGeometry(longitudeValue, latitudeValue));
+                    } else {
+                        setError(getContext().getString(R.string.coordinates_error));
+                    }
+                }
             } else {
                 latitude.requestFocus();
                 latitude.performClick();
@@ -261,6 +274,9 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
             case R.id.clearButton:
                 clearValueData();
                 updateLocation(null);
+                if (errorView.getVisibility()== VISIBLE) {
+                    setError(null);
+                }
                 break;
         }
     }
@@ -375,11 +391,8 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
     }
 
     public void clearValueData() {
-
         this.latitude.setText(null);
         this.longitude.setText(null);
-        this.clearButton.setVisibility(GONE);
-
     }
 
     public Double getLatitude() {

--- a/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
+++ b/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
@@ -24,6 +24,7 @@ import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.dhis2.Bindings.DoubleExtensionsKt;
+import org.dhis2.Bindings.StringExtensionsKt;
 import org.dhis2.R;
 import org.dhis2.databinding.FormCoordinatesAccentBinding;
 import org.dhis2.databinding.FormCoordinatesBinding;
@@ -110,8 +111,8 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
 
         latitude.setOnEditorActionListener((v, actionId, event) -> {
             if (validateCoordinates()) {
-                Double latitudeValue = isEmpty(latitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(Double.valueOf(latitude.getText().toString()));
-                Double longitudeValue = isEmpty(longitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(Double.valueOf(longitude.getText().toString()));
+                Double latitudeValue = isEmpty(latitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLatitude());
+                Double longitudeValue = isEmpty(longitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLongitude());
                 currentLocationListener.onCurrentLocationClick(GeometryHelper.createPointGeometry(longitudeValue, latitudeValue));
             } else {
                 longitude.requestFocus();
@@ -122,8 +123,8 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
 
         longitude.setOnEditorActionListener((v, actionId, event) -> {
             if (validateCoordinates()) {
-                Double latitudeValue = isEmpty(latitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(Double.valueOf(latitude.getText().toString()));
-                Double longitudeValue = isEmpty(longitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(Double.valueOf(longitude.getText().toString()));
+                Double latitudeValue = isEmpty(latitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLatitude());
+                Double longitudeValue = isEmpty(longitude.getText().toString()) ? null : DoubleExtensionsKt.truncate(getLongitude());
                 currentLocationListener.onCurrentLocationClick(GeometryHelper.createPointGeometry(longitudeValue, latitudeValue));
             } else {
                 latitude.requestFocus();
@@ -381,21 +382,14 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
 
     }
 
-    public boolean validateInputtedData() {
-        if (!validateCoordinates())
-            return false;
-
-        double latitude = Double.valueOf(this.latitude.getText().toString());
-        double longitude = Double.valueOf(this.longitude.getText().toString());
-        return ((latitude > -90 && latitude < 90) && (longitude > -180 && longitude < 180));
-    }
-
     public Double getLatitude() {
-        return Double.valueOf(latitude.getText().toString());
+        String latString = StringExtensionsKt.parseToDouble(latitude.getText().toString());
+        return Double.valueOf(latString);
     }
 
     public Double getLongitude() {
-        return Double.valueOf(longitude.getText().toString());
+        String lonString = StringExtensionsKt.parseToDouble(longitude.getText().toString());
+        return Double.valueOf(lonString);
     }
 
     public String currentCoordinates() {

--- a/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
+++ b/app/src/main/java/org/dhis2/usescases/coodinates/CoordinatesView.java
@@ -163,26 +163,37 @@ public class CoordinatesView extends FieldLayout implements View.OnClickListener
         map.setOnClickListener(this);
         clearButton.setOnClickListener(this);
 
-        longitude.setOnFocusChangeListener(new OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if(!hasFocus)
-                    if (!longitude.getText().toString().isEmpty()) {
-                        Double lon = DoubleExtensionsKt.truncate(getLongitude());
-                        longitude.setText(lon.toString());
+        longitude.setOnFocusChangeListener((v, hasFocus) -> {
+            if(!hasFocus) {
+                if (!longitude.getText().toString().isEmpty()) {
+                    Double lon = DoubleExtensionsKt.truncate(getLongitude());
+                    longitude.setText(lon.toString());
+                    if (!latitude.getText().toString().isEmpty()) {
+                        Double lat = getLatitude();
+                        if (!LngLatValidatorKt.areLngLatCorrect(lon, lat)) {
+                            setError(getContext().getString(R.string.coordinates_error));
+                        } else {
+                            setError(null);
+                        }
                     }
+                }
             }
         });
 
-        latitude.setOnFocusChangeListener(new OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if(!hasFocus)
-                    if (!latitude.getText().toString().isEmpty()) {
-                        Double lat = DoubleExtensionsKt.truncate(getLatitude());
-                        latitude.setText(lat.toString());
+        latitude.setOnFocusChangeListener((v, hasFocus) -> {
+            if(!hasFocus)
+                if (!latitude.getText().toString().isEmpty()) {
+                    Double lat = DoubleExtensionsKt.truncate(getLatitude());
+                    latitude.setText(lat.toString());
+                    if (!longitude.getText().toString().isEmpty()) {
+                        Double lon = getLongitude();
+                        if (!LngLatValidatorKt.areLngLatCorrect(lon, lat)) {
+                            setError(getContext().getString(R.string.coordinates_error));
+                        } else {
+                            setError(null);
+                        }
                     }
-            }
+                }
         });
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -740,4 +740,5 @@
     <string name="filters_title_event_date">Event date</string>
     <string name="dataset_data">Data</string>
     <string name="tei_type_has_no_attributes">%s has no public attributes. Please select a program</string>
+    <string name="coordinates_error">Coordinates values are not valid</string>
 </resources>

--- a/app/src/test/java/org/dhis2/bindings/StringExtensionsTest.kt
+++ b/app/src/test/java/org/dhis2/bindings/StringExtensionsTest.kt
@@ -1,6 +1,7 @@
 package org.dhis2.bindings
 
 import org.dhis2.Bindings.initials
+import org.dhis2.Bindings.parseToDouble
 import org.junit.Test
 
 class StringExtensionsTest {
@@ -33,5 +34,35 @@ class StringExtensionsTest {
     fun `Should return empty for null string`() {
         val user = null
         assert(user.initials == "")
+    }
+
+    @Test
+    fun `Should parse a string correctly for a wrong string value`() {
+        val string = "."
+        assert(string.parseToDouble() == "0.0")
+    }
+
+    @Test
+    fun `Should parse a string correctly for a wrong double value`() {
+        val string = "-."
+        assert(string.parseToDouble() == "0.0")
+    }
+
+    @Test
+    fun `Should parse a string correctly for a missing double value`() {
+        val string = "-1."
+        assert(string.parseToDouble() == "-1.0")
+    }
+
+    @Test
+    fun `Should parse a string correctly for a incorrectly double value`() {
+        val string = "12ccd33"
+        assert(string.parseToDouble() == "0.0")
+    }
+
+    @Test
+    fun `Should return the same value for a correctly inputted double value`() {
+        val string = "3.47658"
+        assert(string.parseToDouble() == "3.47658")
     }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3167](https://jira.dhis2.org/browse/ANDROAPP-3167)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code