### PR TITLE
fix: [ANDROAPP-3222] Keyboard is closed when moving to next cell

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
@@ -288,7 +288,7 @@ final class EditTextCellCustomHolder extends FormViewHolder {
         if (selectionState == SelectionState.SELECTED && editTextModel.editable()) {
             editText.requestFocus();
             editText.setSelection(editText.getText().length());
-            openKeyboard(editText);
+            editText.post(() -> openKeyboard(editText));
         }
     }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3222)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code