### PR TITLE
fix: [ANDROAPP-3213] Changes the tab title when the dataset has no section from "Tables" to "Data"

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -145,7 +145,7 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
         binding.viewPager.setAdapter(viewPagerAdapter);
         new TabLayoutMediator(binding.tabLayout, binding.viewPager, (tab, position) -> {
             if (position == 0) {
-                tab.setText(R.string.dataset_data);
+                tab.setText(R.string.dataset_overview);
             } else {
                 tab.setText(viewPagerAdapter.getSectionTitle(position));
             }
@@ -157,7 +157,7 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
         this.sections = sections;
         if (sections.contains(NO_SECTION) && sections.size() > 1) {
             sections.remove(NO_SECTION);
-            sections.add(getString(R.string.tab_tables));
+            sections.add(getString(R.string.dataset_data));
         }
         viewPagerAdapter.swapData(sections);
         binding.viewPager.setCurrentItem(1);
@@ -166,7 +166,7 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
     public void updateTabLayout(String section, int numTables) {
         if (sections.get(0).equals(NO_SECTION)) {
             sections.remove(NO_SECTION);
-            sections.add(getString(R.string.tab_tables));
+            sections.add(getString(R.string.dataset_data));
             viewPagerAdapter.swapData(sections);
             binding.viewPager.setCurrentItem(1);
         }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3213](https://jira.dhis2.org/browse/ANDROAPP-3213)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code