### PR TITLE
fix: [ANDROAPP-3140] don't lose focus when change focus manually

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/FormViewHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/FormViewHolder.java
@@ -28,6 +28,7 @@ public abstract class FormViewHolder extends RecyclerView.ViewHolder {
     protected MutableLiveData<String> currentUid;
     protected String fieldUid;
     protected ObjectStyle objectStyle;
+    protected static String selectedFieldUid;
 
     public FormViewHolder(ViewDataBinding binding) {
         super(binding.getRoot());
@@ -50,7 +51,7 @@ public abstract class FormViewHolder extends RecyclerView.ViewHolder {
     public void initFieldFocus() {
         if (currentUid != null) {
             currentUid.observeForever(fieldUid -> {
-                if (Objects.equals(fieldUid, this.fieldUid)) {
+                if((selectedFieldUid == null && Objects.equals(fieldUid, this.fieldUid)) || ((selectedFieldUid != null) && selectedFieldUid.equals(this.fieldUid))){
                     Drawable bgDrawable = AppCompatResources.getDrawable(itemView.getContext(), R.drawable.item_selected_bg);
                     itemView.setBackground(bgDrawable);
                 } else {
@@ -80,7 +81,9 @@ public abstract class FormViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void setSelectedBackground(boolean isSarchMode) {
-        if (!isSarchMode)
+        if (!isSarchMode) {
+            selectedFieldUid = fieldUid;
             currentUid.setValue(fieldUid);
+        }
     }
 }

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/FormViewHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/FormViewHolder.java
@@ -51,7 +51,7 @@ public abstract class FormViewHolder extends RecyclerView.ViewHolder {
     public void initFieldFocus() {
         if (currentUid != null) {
             currentUid.observeForever(fieldUid -> {
-                if((selectedFieldUid == null && Objects.equals(fieldUid, this.fieldUid)) || ((selectedFieldUid != null) && selectedFieldUid.equals(this.fieldUid))){
+                if(fieldWasSelectedManually() || currentSelectedItem(fieldUid)){
                     Drawable bgDrawable = AppCompatResources.getDrawable(itemView.getContext(), R.drawable.item_selected_bg);
                     itemView.setBackground(bgDrawable);
                 } else {
@@ -60,6 +60,14 @@ public abstract class FormViewHolder extends RecyclerView.ViewHolder {
             });
 
         }
+    }
+
+    private boolean fieldWasSelectedManually() {
+        return selectedFieldUid != null && selectedFieldUid.equals(this.fieldUid);
+    }
+
+    private boolean currentSelectedItem(String fieldUid) {
+        return selectedFieldUid == null && Objects.equals(fieldUid, this.fieldUid);
     }
 
     public void closeKeyboard(View v) {

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/EditTextCustomHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/EditTextCustomHolder.java
@@ -64,6 +64,7 @@ public class EditTextCustomHolder extends FormViewHolder {
             validateRegex();
         });
         binding.customEdittext.setOnEditorActionListener((v, actionId, event) -> {
+            selectedFieldUid = null;
             binding.customEdittext.getEditText().clearFocus();
             sendAction();
             closeKeyboard(binding.customEdittext.getEditText());

--- a/app/src/main/java/org/dhis2/utils/customviews/CustomTextView.java
+++ b/app/src/main/java/org/dhis2/utils/customviews/CustomTextView.java
@@ -102,7 +102,6 @@ public class CustomTextView extends FieldLayout {
             if (hasFocus) {
                 activate();
             } else if (focusListener != null && validate()) {
-                dummy.requestFocus();
                 focusListener.onFocusChange(v, hasFocus);
             }
         });


### PR DESCRIPTION
[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3140)

## Solution description
We should keep field focus to be able to open the corresponding keyboard.
Also, we have to keep focus on selected item when selecting a field that is above current

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [x] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code