### PR TITLE
fix: [ANDROAPP-3245] hide error bottom sheet when clicking save on dataset

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -370,7 +370,7 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
     }
 
     @Override
-    public void closeExpandBottom() {
+    public void collapseExpandBottom() {
         if (behavior.getState() == BottomSheetBehavior.STATE_EXPANDED) {
             behavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
         } else if (behavior.getState() == BottomSheetBehavior.STATE_COLLAPSED) {
@@ -379,15 +379,19 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
     }
 
     @Override
-    public void cancelBottomSheet() {
+    public void closeBottomSheet() {
         binding.BSLayout.bottomSheetLayout.setVisibility(View.GONE);
-        binding.saveButton.show();
     }
 
     @Override
     public void completeBottomSheet() {
-        cancelBottomSheet();
+        closeBottomSheet();
         presenter.completeDataSet();
+    }
+
+    @Override
+    public boolean isErrorBottomSheetShowing() {
+        return binding.BSLayout.bottomSheetLayout.getVisibility() == View.VISIBLE;
     }
 
     private void configureShapeDrawable() {
@@ -422,6 +426,8 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
                 .translationY(-ExtensionsKt.getDp(48))
                 .start();
     }
+
+
 
     public void showMoreOptions(View view) {
         new AppMenuHelper.Builder()

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableContract.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableContract.java
@@ -37,9 +37,9 @@ public class DataSetTableContract {
 
         void showCompleteToast();
 
-        void closeExpandBottom();
+        void collapseExpandBottom();
 
-        void cancelBottomSheet();
+        void closeBottomSheet();
 
         void completeBottomSheet();
 
@@ -48,6 +48,8 @@ public class DataSetTableContract {
         void showInternalValidationError();
 
         void saveAndFinish();
+
+        boolean isErrorBottomSheetShowing();
     }
 
     public interface Presenter extends AbstractActivityContracts.Presenter {
@@ -70,9 +72,9 @@ public class DataSetTableContract {
 
         void completeDataSet();
 
-        void closeExpandBottomSheet();
+        void collapseExpandBottomSheet();
 
-        void onCancelBottomSheet();
+        void closeBottomSheet();
 
         void onCompleteBottomSheet();
 

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenter.java
@@ -120,6 +120,9 @@ public class DataSetTablePresenter implements DataSetTableContract.Presenter {
 
     @VisibleForTesting
     public void handleSaveClick() {
+        if (view.isErrorBottomSheetShowing()) {
+            closeBottomSheet();
+        }
         if (tableRepository.hasValidationRules()) {
             if (tableRepository.areValidationRulesMandatory()) {
                 validationProcessor.onNext(true);
@@ -235,13 +238,13 @@ public class DataSetTablePresenter implements DataSetTableContract.Presenter {
     }
 
     @Override
-    public void closeExpandBottomSheet() {
-        view.closeExpandBottom();
+    public void collapseExpandBottomSheet() {
+        view.collapseExpandBottom();
     }
 
     @Override
-    public void onCancelBottomSheet() {
-        view.cancelBottomSheet();
+    public void closeBottomSheet() {
+        view.closeBottomSheet();
     }
 
     @Override

--- a/app/src/main/res/layout/violation_rules_bottom_sheet.xml
+++ b/app/src/main/res/layout/violation_rules_bottom_sheet.xml
@@ -93,7 +93,7 @@
                 android:layout_height="48dp"
                 android:padding="12dp"
                 android:layout_marginEnd="8dp"
-                android:onClick="@{ () -> presenter.closeExpandBottomSheet() }"
+                android:onClick="@{ () -> presenter.collapseExpandBottomSheet() }"
                 app:layout_constraintBottom_toBottomOf="@id/title"
                 app:layout_constraintEnd_toStartOf="@id/endGuideline"
                 app:layout_constraintTop_toTopOf="@id/title"

--- a/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTablePresenterTest.kt
@@ -72,6 +72,7 @@ class DataSetTablePresenterTest {
 
     @Test
     fun `Should show success if no validation rules exist`() {
+        whenever(view.isErrorBottomSheetShowing) doReturn false
         whenever(repository.hasValidationRules()) doReturn false
         whenever(repository.isComplete()) doReturn Single.just(false)
         presenter.handleSaveClick()
@@ -80,6 +81,7 @@ class DataSetTablePresenterTest {
 
     @Test
     fun `Should run validations`() {
+        whenever(view.isErrorBottomSheetShowing) doReturn false
         whenever(repository.hasValidationRules()) doReturn true
         whenever(repository.areValidationRulesMandatory()) doReturn true
         val testObserver = presenter.runValidationProcessor().test()
@@ -87,6 +89,20 @@ class DataSetTablePresenterTest {
         testObserver
             .assertNoErrors()
             .assertValue(true)
+    }
+
+    @Test
+    fun `Should re-run validations when a rule was fixed`() {
+        whenever(view.isErrorBottomSheetShowing) doReturn true
+        whenever(repository.hasValidationRules()) doReturn true
+        whenever(repository.areValidationRulesMandatory()) doReturn true
+        val testObserver = presenter.runValidationProcessor().test()
+        presenter.handleSaveClick()
+        testObserver
+            .assertNoErrors()
+            .assertValue(true)
+
+        verify(view).closeBottomSheet()
     }
 
     @Test
@@ -235,16 +251,16 @@ class DataSetTablePresenterTest {
 
     @Test
     fun `Should close or expand the bottom sheet`() {
-        presenter.closeExpandBottomSheet()
+        presenter.collapseExpandBottomSheet()
 
-        verify(view).closeExpandBottom()
+        verify(view).collapseExpandBottom()
     }
 
     @Test
     fun `Should close bottom sheet on cancel click`() {
-        presenter.onCancelBottomSheet()
+        presenter.closeBottomSheet()
 
-        verify(view).cancelBottomSheet()
+        verify(view).closeBottomSheet()
     }
 
     @Test


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3245](https://jira.dhis2.org/browse/ANDROAPP-3245)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code