### PR TITLE
fix: [ANDROAPP-3228] sets same style to OK button in the dialog

### DIFF
--- a/app/src/main/res/layout/dialog_body.xml
+++ b/app/src/main/res/layout/dialog_body.xml
@@ -18,6 +18,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
+        style="@style/Widget.MaterialComponents.Button"
         android:id="@+id/dialogAccept"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3228](https://jira.dhis2.org/browse/ANDROAPP-3228)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code