### PR TITLE
fix: [ANDROAPP-3250] Missing catCombo in event initial screen

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -553,6 +553,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
                                             selectedOption -> {
                                                 CategoryOption categoryOption = presenter.getCatOption(selectedOption);
                                                 selectedCatOption.put(category.uid(), categoryOption);
+                                                catSelectorBinding.catCombo.setText(categoryOption.displayName());
                                                 if (selectedCatOption.size() == catCombo.categories().size()) {
                                                     catOptionComboUid = presenter.getCatOptionCombo(categoryOptionCombos, new ArrayList<>(selectedCatOption.values()));
                                                     checkActionButtonVisibility();


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3250)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code