### PR TITLE
fix: [ANDROAPP-3275] Indicator name is not always displayed

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/IndicatorViewHolder.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/IndicatorViewHolder.kt
@@ -21,6 +21,9 @@ class IndicatorViewHolder(
             params.guidePercent = 0F
             binding.guideline.layoutParams = params
         } else {
+            val params = binding.guideline.layoutParams as ConstraintLayout.LayoutParams
+            params.guidePercent = 0.6F
+            binding.guideline.layoutParams = params
             binding.setVariable(BR.label, programIndicatorModel.val0()!!.displayName())
             binding.setVariable(BR.description, programIndicatorModel.val0()!!.displayDescription())
         }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3275)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code