### PR TITLE
fix: Multiple unnecessary network calls in search screen 

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2020-08-10 14:19","gitSha":"ef8706206"}
+{"buildTime":"2020-08-19 18:11","gitSha":"f6d7cb9da"}

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -225,14 +225,14 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
 
 
         ConnectableFlowable<Pair<HashMap<String, String>, FilterManager>> updaterFlowable = currentProgram.distinctUntilChanged().toFlowable(BackpressureStrategy.LATEST)
-                .doOnEach(element -> {Timber.d("outer updaterFlowable before%s", element.getValue());})
+                .doOnEach(element -> {Timber.d("outer updaterFlowable before %s", element.getValue());})
                 .switchMap(program ->
                                 Flowable.combineLatest(queryProcessor.startWith(queryData),
                                         FilterManager.getInstance().asFlowable(),
                                         Pair::create).doOnEach(element -> {Timber.d("inner %s", element.getValue());})
 
                 )
-                .doOnEach(element -> {Timber.d("outer updaterFlowable after%s", element.getValue());})
+                .doOnEach(element -> {Timber.d("outer updaterFlowable after %s", element.getValue());})
                 .onBackpressureLatest()
                 .publish();
 
@@ -310,7 +310,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
                                 ),
                                 Timber::e,
                                 () -> Timber.d("COMPLETED")
-                        )); 
+                        ));
 
         compositeDisposable.add(
                 queryProcessor

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -277,7 +277,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
                         .subscribe(view::setLiveData, Timber::d)
         );
 
-    /*    compositeDisposable.add(
+        compositeDisposable.add(
                 mapDataProcessor
                         .switchMap(unit ->
                                 searchRepository.searchTeiForMap(
@@ -310,7 +310,7 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
                                 ),
                                 Timber::e,
                                 () -> Timber.d("COMPLETED")
-                        )); */
+                        )); 
 
         compositeDisposable.add(
                 queryProcessor

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -223,41 +223,23 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
                         Timber::d)
         );
 
-        /*
-            Flowable.combineLatest(
-                            filterManager.asFlowable().startWith(filterManager),
-                            sectionFlowable,
-                            groupingFlowable,
-                            Trio::create)
-                            .switchMap(stageAndGrouping ->
-                                    Flowable.zip(
-         */
-
-        /*
-                ConnectableFlowable<Pair<HashMap<String, String>, FilterManager>> updaterFlowable = currentProgram.distinctUntilChanged().toFlowable(BackpressureStrategy.LATEST)
-                .doOnEach(element -> {Timber.d("outer before"+ element.getValue().toString());})
-                .switchMap(program ->
-                                Flowable.combineLatest(queryProcessor.startWith(queryData),
-                                        FilterManager.getInstance().asFlowable(),
-                                        Pair::create).doOnEach(element -> {Timber.d("inner "+element.getValue().toString());})
-         */
 
         ConnectableFlowable<Pair<HashMap<String, String>, FilterManager>> updaterFlowable = currentProgram.distinctUntilChanged().toFlowable(BackpressureStrategy.LATEST)
-                .doOnEach(element -> {Timber.d("outer before"+ element.getValue().toString());})
+                .doOnEach(element -> {Timber.d("outer updaterFlowable before%s", element.getValue());})
                 .switchMap(program ->
                                 Flowable.combineLatest(queryProcessor.startWith(queryData),
                                         FilterManager.getInstance().asFlowable(),
-                                        Pair::create).doOnEach(element -> {Timber.d("inner "+element.getValue().toString());})
+                                        Pair::create).doOnEach(element -> {Timber.d("inner %s", element.getValue());})
 
                 )
-                .doOnEach(element -> {Timber.d("outer after"+element.getValue().toString());})
+                .doOnEach(element -> {Timber.d("outer updaterFlowable after%s", element.getValue());})
                 .onBackpressureLatest()
                 .publish();
 
 
         compositeDisposable.add(
                 updaterFlowable
-                        .doOnEach(element -> {Timber.d("Listado "+element.getValue().toString());})
+                        .doOnEach(element -> {Timber.d("Listing update %s", element.getValue());})
                         .map(data -> view.isMapVisible())
                         .subscribeOn(schedulerProvider.io())
                         .observeOn(schedulerProvider.ui())


### PR DESCRIPTION
## Solution Description
@ferdyrod @mmmateos @Balcan 

When you enter search for some programs, for example XX TRACKER for android-current or the ones that @jaboto was testing you could see in the logs that multiple unnecesary network calls were being launched. Here are a few things that I have found out:

- Threading in search is no correct in some places. (UI thread being used when it should not)
- **setProgram** was called twice. There is an distinctUntilChanged (not the best solution) for current program (so the second call was being ignore) but setProgram method was sending events for query processor that were not being ignore.
- _FilterManager.getInstance().asFlowable().startWith(FilterManager.getInstance())_ with combineLatest was actually triggering two events, this combine with setProgram **was adding a minimum of 4 calls**

https://jira.dhis2.org/browse/ANDROAPP-3256

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code