### PR TITLE
fix: [ANDROAPP-3287] handles correct selection when scrolling in the sync error log 

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/settings/ErrorAdapter.java
+++ b/app/src/main/java/org/dhis2/usescases/settings/ErrorAdapter.java
@@ -12,8 +12,6 @@ import org.dhis2.R;
 import org.dhis2.data.tuples.Pair;
 import org.dhis2.databinding.ItemErrorDialogBinding;
 import org.dhis2.usescases.settings.models.ErrorViewModel;
-import org.hisp.dhis.android.core.imports.TrackerImportConflict;
-import org.hisp.dhis.android.core.maintenance.D2Error;
 
 import java.util.List;
 

--- a/app/src/main/java/org/dhis2/usescases/settings/ErrorViewHolder.java
+++ b/app/src/main/java/org/dhis2/usescases/settings/ErrorViewHolder.java
@@ -36,6 +36,10 @@ public class ErrorViewHolder extends RecyclerView.ViewHolder {
         binding.errorDate.setText(DateUtils.dateTimeFormat().format(errorMessageModel.getCreationDate()));
         binding.errorMessage.setText(errorMessageModel.getErrorDescription());
         binding.errorComponent.setText(errorMessageModel.getErrorComponent());
-        binding.selected.setOnCheckedChangeListener((buttonView, isChecked) -> processor.onNext(Pair.create(isChecked, errorMessageModel)));
+        binding.selected.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            errorMessageModel.setSelected(isChecked);
+            processor.onNext(Pair.create(isChecked, errorMessageModel));
+        });
+        binding.selected.setChecked(errorMessageModel.isSelected());
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/settings/models/ErrorViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/settings/models/ErrorViewModel.kt
@@ -6,5 +6,6 @@ data class ErrorViewModel(
     val creationDate: Date?,
     val errorCode: String?,
     val errorDescription: String?,
-    val errorComponent: String?
+    val errorComponent: String?,
+    var isSelected: Boolean = false
 )


### PR DESCRIPTION
## Description

[ANDROAPP-3287](https://jira.dhis2.org/browse/ANDROAPP-3287)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code