### PR TITLE
fix: [ANDROAPP-3274] Prevents user's ability to add an enrollment when doing an empty search

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -519,7 +519,10 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
 
     private boolean compliesWithMinAttributesToSearch() {
         if (selectedProgram != null) {
-            if (selectedProgram.displayFrontPageList() && !queryData.isEmpty() && queryData.size() < selectedProgram.minAttributesRequiredToSearch()) {
+            if (selectedProgram.displayFrontPageList() && queryData.isEmpty()) {
+                return false;
+            }
+            else if (selectedProgram.displayFrontPageList() && !queryData.isEmpty() && queryData.size() < selectedProgram.minAttributesRequiredToSearch()) {
                 return false;
             } else if (!selectedProgram.displayFrontPageList() && queryData.size() < selectedProgram.minAttributesRequiredToSearch()) {
                 return false;

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenterTest.kt
@@ -58,7 +58,7 @@ class SearchTEPresenterTest {
     }
 
     @Test
-    fun `Should set fabIcon to search if displayFrontPageList and minAttributes is ok`() {
+    fun `Should set fabIcon to search if displayFrontPageList and queryData is empty`() {
         presenter.setProgramForTesting(
             Program.builder()
                 .uid("uid")
@@ -71,6 +71,23 @@ class SearchTEPresenterTest {
 
         verify(view).clearData()
         verify(view).updateFiltersSearch(0)
+        verify(view).setFabIcon(true)
+    }
+
+    @Test
+    fun `Should set fabIcon to search if displayFrontPageList and minAttributes is ok`() {
+        presenter.setProgramForTesting(
+            Program.builder()
+                .uid("uid")
+                .displayFrontPageList(true)
+                .minAttributesRequiredToSearch(1)
+                .build()
+        )
+        presenter.queryData["uid"] = "value"
+        presenter.onFabClick(true)
+
+        verify(view).clearData()
+        verify(view).updateFiltersSearch(1)
         verify(view).setFabIcon(false)
     }
 
@@ -83,11 +100,11 @@ class SearchTEPresenterTest {
                 .minAttributesRequiredToSearch(0)
                 .build()
         )
-
+        presenter.queryData["uid"] = "value"
         presenter.onFabClick(true)
 
         verify(view).clearData()
-        verify(view).updateFiltersSearch(0)
+        verify(view).updateFiltersSearch(1)
         verify(view).setFabIcon(false)
     }
 


### PR DESCRIPTION
## Description

[ANDROAPP-3274](https://jira.dhis2.org/browse/ANDROAPP-3274)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code