### PR TITLE
fix: [ANDROAPP-3309] Shows Dataset save button after Validations error dialog is displayed and closed

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -325,7 +325,6 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
                         binding.saveButton.animate()
                                 .translationY(0)
                                 .start();
-                        binding.saveButton.hide();
                         break;
                     case BottomSheetBehavior.STATE_COLLAPSED:
                         animateArrowUp();


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3309](https://jira.dhis2.org/browse/ANDROAPP-3309)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code