### PR TITLE
fix: [ANDROAPP-3308] Fix crash when using event date sorting

### DIFF
--- a/app/src/main/java/org/dhis2/data/sorting/SearchSortingValueSetter.kt
+++ b/app/src/main/java/org/dhis2/data/sorting/SearchSortingValueSetter.kt
@@ -48,7 +48,7 @@ class SearchSortingValueSetter(
     ): Pair<String, String>? {
         var eventDate = unknownLabel
         val sortedEvents = d2.eventModule().events()
-            .byEnrollmentUid().eq(teiModel.selectedEnrollment.uid())
+            .byEnrollmentUid().eq(teiModel.selectedEnrollment?.uid() ?: "")
             .byDeleted().isFalse
             .orderByTimeline(
                 if (sortingStatus === SortingStatus.ASC) {

--- a/app/src/test/java/org/dhis2/data/sorting/SearchSortingValueSetterTest.kt
+++ b/app/src/test/java/org/dhis2/data/sorting/SearchSortingValueSetterTest.kt
@@ -45,6 +45,48 @@ class SearchSortingValueSetterTest {
     }
 
     @Test
+    fun `Sorting by event date should return correct key value for online result`() {
+        whenever(
+            d2.eventModule().events()
+                .byEnrollmentUid().eq("")
+        ) doReturn mock()
+        whenever(
+            d2.eventModule().events()
+                .byEnrollmentUid().eq("")
+                .byDeleted()
+        ) doReturn mock()
+        whenever(
+            d2.eventModule().events()
+                .byEnrollmentUid().eq("")
+                .byDeleted().isFalse
+        ) doReturn mock()
+        whenever(
+            d2.eventModule().events()
+                .byEnrollmentUid().eq("")
+                .byDeleted().isFalse
+                .orderByTimeline(RepositoryScope.OrderByDirection.ASC)
+        ) doReturn mock()
+        whenever(
+            d2.eventModule().events()
+                .byEnrollmentUid().eq("")
+                .byDeleted().isFalse
+                .orderByTimeline(RepositoryScope.OrderByDirection.ASC)
+                .blockingGet()
+        ) doReturn emptyList()
+
+        val result = searchSortingValueSetter.setSortingItem(
+            onlineSearchTeiModel(),
+            SortingItem(Filters.PERIOD, SortingStatus.ASC)
+        )
+
+        result.apply {
+            assertTrue(this != null)
+            assertTrue(this?.first == "eventLabel")
+            assertTrue(this?.second == "-")
+        }
+    }
+
+    @Test
     fun `Sorting by event date should return correct key value`() {
         whenever(
             d2.eventModule().events()
@@ -395,6 +437,15 @@ class SearchSortingValueSetterTest {
                     .enrollmentDate(Date.from(Instant.parse("2020-01-01T00:00:00.00Z")))
                     .build()
             )
+            tei = TrackedEntityInstance.builder()
+                .uid("teiUid")
+                .organisationUnit("teiOrgUnit")
+                .build()
+        }
+    }
+
+    private fun onlineSearchTeiModel(): SearchTeiModel {
+        return SearchTeiModel().apply {
             tei = TrackedEntityInstance.builder()
                 .uid("teiUid")
                 .organisationUnit("teiOrgUnit")


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3308)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code