### PR TITLE
fix: [ANDROAPP-3330] Prevents crash when section has no data elements

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
@@ -207,8 +207,10 @@ public final class DataEntryAdapter extends RecyclerView.Adapter<ViewHolder> {
         } else {
             ((SectionHolder) holder).setBottomShadow(
                     position > 0 && getItemViewType(position - 1) != SECTION);
-            ((SectionHolder) holder).setLastSectionHeight(
-                    position == getItemCount() - 1 && getItemViewType(position - 1) != SECTION);
+            if (position > 0) {
+                ((SectionHolder) holder).setLastSectionHeight(
+                        position == getItemCount() - 1 && getItemViewType(position - 1) != SECTION);
+            }
             ((SectionHolder) holder).setSectionNumber(getSectionNumber(position));
         }
     }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3330](https://jira.dhis2.org/browse/ANDROAPP-3330)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code