### PR TITLE
fix: Navigate back to home from a different section in navigation drawer

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt
@@ -55,6 +55,11 @@ class MainRobot : BaseRobot() {
         Intents.intended(allOf(IntentMatchers.hasComponent(LoginActivity::class.java.name)))
     }
 
+    fun checkHomeIsDisplayed() {
+        onView(withId(R.id.program_recycler))
+            .check(matches(isDisplayed()))
+    }
+
     fun filterByPeriodToday() {
         onView(withId(R.id.filter)).perform(click())
         onView(withId(R.id.filterLayout))

--- a/app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import org.dhis2.usescases.BaseTest
-import org.dhis2.usescases.login.loginRobot
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,14 +42,22 @@ class MainTest : BaseTest() {
             clickOnLogout()
             checkLogInIsLaunched()
         }
+    }
 
-        loginRobot {
-            checkUsernameFieldIsClear()
-            checkPasswordFieldIsClear()
+    @Test
+    fun shouldNavigateToHomeWhenBackPressed() {
+        setupCredentials()
+        startActivity()
+
+        homeRobot {
+            clickOnNavigationDrawerMenu()
+            clickOnSettings()
+            pressBack()
+            checkHomeIsDisplayed()
         }
     }
 
-    fun startActivity() {
+    private fun startActivity() {
         rule.launchActivity(null)
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
@@ -215,12 +215,15 @@ class MainActivity :
 
     override fun onBackPressed() {
         when {
-            fragId != R.id.menu_home -> changeFragment(R.id.menu_home)
-            isPinLayoutVisible -> {
-                isPinLayoutVisible = false
-            }
+            fragId != R.id.menu_home -> presenter.onNavigateBackToHome()
+            isPinLayoutVisible -> isPinLayoutVisible = false
             else -> super.onBackPressed()
         }
+    }
+
+    override fun goToHome() {
+        changeFragment(R.id.menu_home)
+        initCurrentScreen()
     }
 
     override fun changeFragment(id: Int) {

--- a/app/src/main/java/org/dhis2/usescases/main/MainPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainPresenter.kt
@@ -139,4 +139,8 @@ class MainPresenter(
         }
         return false
     }
+
+    fun onNavigateBackToHome() {
+        view.goToHome()
+    }
 }

--- a/app/src/main/java/org/dhis2/usescases/main/MainView.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainView.kt
@@ -45,4 +45,6 @@ interface MainView : AbstractActivityContracts.View {
     fun updateFilters(totalFilters: Int)
 
     fun showPeriodRequest(periodRequest: FilterManager.PeriodRequest)
+
+    fun goToHome()
 }

--- a/app/src/test/java/org/dhis2/usescases/main/MainPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/main/MainPresenterTest.kt
@@ -118,6 +118,12 @@ class MainPresenterTest {
         verify(view).openDrawer(any())
     }
 
+    @Test
+    fun `should return to home section when user taps back in a different section`() {
+        presenter.onNavigateBackToHome()
+        verify(view).goToHome()
+    }
+
     private fun presenterMocks() {
         // UserModule
         whenever(d2.userModule()) doReturn mock()


### PR DESCRIPTION
## Description
In the Main screen, if we are in a section different than Home, when the user tap back, the current section changes but the transition is not made. Then is user taps again, the app consider it is in Home and exits the application.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3261

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code