### PR TITLE
fix: [ANDROAPP-3326] Prevent crash on datasets with optionset

### DIFF
--- a/app/src/main/java/org/dhis2/utils/customviews/OptionSetView.java
+++ b/app/src/main/java/org/dhis2/utils/customviews/OptionSetView.java
@@ -177,9 +177,13 @@ public class OptionSetView extends FieldLayout implements OptionSetOnClickListen
         if (value != null && value.contains("_os_"))
             value = value.split("_os_")[0];
 
-        inputLayout.setHintAnimationEnabled(false);
+        if (inputLayout != null) {
+            inputLayout.setHintAnimationEnabled(false);
+        }
         editText.setText(value);
-        inputLayout.setHintAnimationEnabled(true);
+        if (inputLayout != null) {
+            inputLayout.setHintAnimationEnabled(true);
+        }
 
         if (delete != null && editText.getText() != null && !editText.getText().toString().isEmpty()) {
             delete.setVisibility(View.VISIBLE);


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3326](https://jira.dhis2.org/browse/ANDROAPP-3326)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code