### PR TITLE
fix: [ANDROAPP-3342] Do not round value in field of ValueType UNIT_INTERVAL

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/ValueExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/ValueExtensions.kt
@@ -132,14 +132,12 @@ fun String?.withValueTypeCheck(valueType: ValueType?): String? {
     return this?.let {
         if (isEmpty()) return this
         when (valueType) {
-            ValueType.UNIT_INTERVAL,
             ValueType.PERCENTAGE,
             ValueType.INTEGER,
             ValueType.INTEGER_POSITIVE,
             ValueType.INTEGER_NEGATIVE,
-            ValueType.INTEGER_ZERO_OR_POSITIVE -> {
-                it.toFloat().toInt().toString()
-            }
+            ValueType.INTEGER_ZERO_OR_POSITIVE -> it.toFloat().toInt().toString()
+            ValueType.UNIT_INTERVAL -> it.toFloat().toString()
             else -> this
         }
     } ?: this

--- a/app/src/test/java/org/dhis2/bindings/ValueExtensionsTest.kt
+++ b/app/src/test/java/org/dhis2/bindings/ValueExtensionsTest.kt
@@ -32,4 +32,29 @@ class ValueExtensionsTest {
             )
         }
     }
+
+    @Test
+    fun `Should parse to correct unit interval format`() {
+        val valueList: List<String?> = arrayListOf(
+            "",
+            "0",
+            ".2233",
+            "1",
+            null
+        )
+
+        val expectedResults = arrayListOf(
+            "",
+            "0.0",
+            "0.2233",
+            "1.0",
+            null
+        )
+
+        valueList.forEachIndexed { index, value ->
+            assertTrue(
+                value.withValueTypeCheck(ValueType.UNIT_INTERVAL) == expectedResults[index]
+            )
+        }
+    }
 }


### PR DESCRIPTION

## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3342](https://jira.dhis2.org/browse/ANDROAPP-3342)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code