### PR TITLE
fix: [ANDROAPP-3363] Relationship Tei cards List not showing attributes in same order

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/adapters/RelationshipLiveAdapter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/adapters/RelationshipLiveAdapter.java
@@ -15,6 +15,7 @@ import androidx.paging.PagedListAdapter;
 import androidx.recyclerview.widget.DiffUtil;
 
 import java.io.File;
+import java.util.Objects;
 
 import kotlin.Unit;
 
@@ -28,7 +29,14 @@ public class RelationshipLiveAdapter extends PagedListAdapter<SearchTeiModel, Se
 
         @Override
         public boolean areContentsTheSame(@NonNull SearchTeiModel oldItem, @NonNull SearchTeiModel newItem) {
-            return oldItem.getTei().uid().equals(newItem.getTei().uid());
+            return oldItem.getTei().uid().equals(newItem.getTei().uid()) &&
+                    Objects.equals(oldItem.getTei().state(), newItem.getTei().state()) &&
+                    oldItem.getAttributeValues().equals(newItem.getAttributeValues()) &&
+                    oldItem.getEnrollments().equals(newItem.getEnrollments()) &&
+                    oldItem.getProfilePicturePath().equals(newItem.getProfilePicturePath()) &&
+                    oldItem.isAttributeListOpen() == newItem.isAttributeListOpen() &&
+                    Objects.equals(oldItem.getSortingKey(), newItem.getSortingKey()) &&
+                    Objects.equals(oldItem.getSortingValue(), newItem.getSortingValue());
         }
     };
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3363](https://jira.dhis2.org/browse/ANDROAPP-3363)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code