### PR TITLE
fix: [ANDROAPP-3391] Event init takes too long when category has too many options

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/CategoryOptionExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/CategoryOptionExtensions.kt
@@ -1,0 +1,11 @@
+package org.dhis2.Bindings
+
+import java.util.Date
+import org.hisp.dhis.android.core.category.CategoryOption
+
+fun CategoryOption.inDateRange(date: Date?): Boolean {
+    return date?.let {
+        (startDate() == null || date.after(startDate())) &&
+            (endDate() == null || date.before(endDate()))
+    } ?: true
+}

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -43,7 +43,7 @@ import org.dhis2.utils.EventMode;
 import org.dhis2.utils.HelpManager;
 import org.dhis2.utils.analytics.AnalyticsConstants;
 import org.dhis2.utils.category.CategoryDialog;
-import org.dhis2.utils.customviews.CategoryOptionPopUp;
+import org.dhis2.utils.customviews.CatOptionPopUp;
 import org.dhis2.utils.customviews.CustomDialog;
 import org.dhis2.utils.customviews.OrgUnitDialog;
 import org.dhis2.utils.customviews.PeriodDialog;
@@ -65,8 +65,6 @@ import org.hisp.dhis.android.core.program.ProgramStage;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.text.ParseException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -82,6 +80,7 @@ import javax.inject.Inject;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.functions.Consumer;
+import kotlin.Unit;
 import timber.log.Timber;
 
 import static android.text.TextUtils.isEmpty;
@@ -547,46 +546,13 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
                 for (Category category : catCombo.categories()) {
                     CategorySelectorBinding catSelectorBinding = CategorySelectorBinding.inflate(LayoutInflater.from(this));
                     catSelectorBinding.catCombLayout.setHint(category.displayName());
-                    catSelectorBinding.catCombo.setOnClickListener(
-                            view -> {
+                    catSelectorBinding.catCombo.setOnClickListener(view -> {
                                 if (presenter.catOptionSize(category.uid()) > CategoryDialog.DEFAULT_COUNT_LIMIT) {
-                                    new CategoryDialog(
-                                            CategoryDialog.Type.CATEGORY_OPTIONS,
-                                            category.uid(),
-                                            true,
-                                            selectedDate,
-                                            selectedOption -> {
-                                                CategoryOption categoryOption = presenter.getCatOption(selectedOption);
-                                                selectedCatOption.put(category.uid(), categoryOption);
-                                                catSelectorBinding.catCombo.setText(categoryOption.displayName());
-                                                if (selectedCatOption.size() == catCombo.categories().size()) {
-                                                    catOptionComboUid = presenter.getCatOptionCombo(categoryOptionCombos, new ArrayList<>(selectedCatOption.values()));
-                                                    checkActionButtonVisibility();
-                                                }
-                                                return null;
-                                            }
-                                    ).show(getSupportFragmentManager(),
-                                            CategoryDialog.Companion.getTAG());
-
+                                    showCategoryDialog(category, categoryOptionCombos, catSelectorBinding);
                                 } else {
-                                    CategoryOptionPopUp.getInstance()
-                                            .setCategory(category)
-                                            .setDate(selectedDate)
-                                            .setOnClick(item -> {
-                                                if (item != null)
-                                                    selectedCatOption.put(category.uid(), item);
-                                                else
-                                                    selectedCatOption.remove(category.uid());
-                                                catSelectorBinding.catCombo.setText(item != null ? item.displayName() : null);
-                                                if (selectedCatOption.size() == catCombo.categories().size()) {
-                                                    catOptionComboUid = presenter.getCatOptionCombo(categoryOptionCombos, new ArrayList<>(selectedCatOption.values()));
-                                                    checkActionButtonVisibility();
-                                                }
-                                            })
-                                            .show(this, catSelectorBinding.getRoot());
+                                    showCategoryPopUp(category, categoryOptionCombos, catSelectorBinding);
                                 }
                             }
-
                     );
 
                     if (stringCategoryOptionMap != null && stringCategoryOptionMap.get(category.uid()) != null)
@@ -598,6 +564,49 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
                 catOptionComboUid = categoryOptionCombos.get(0).uid();
 
         });
+    }
+
+    private void showCategoryDialog(Category category, List<CategoryOptionCombo> categoryOptionCombos, CategorySelectorBinding catSelectorBinding) {
+        new CategoryDialog(
+                CategoryDialog.Type.CATEGORY_OPTIONS,
+                category.uid(),
+                true,
+                selectedDate,
+                selectedOption -> {
+                    CategoryOption categoryOption = presenter.getCatOption(selectedOption);
+                    selectedCatOption.put(category.uid(), categoryOption);
+                    catSelectorBinding.catCombo.setText(categoryOption.displayName());
+                    if (selectedCatOption.size() == catCombo.categories().size()) {
+                        catOptionComboUid = presenter.getCatOptionCombo(catCombo.uid(), categoryOptionCombos, new ArrayList<>(selectedCatOption.values()));
+                        checkActionButtonVisibility();
+                    }
+                    return null;
+                }
+        ).show(getSupportFragmentManager(),
+                CategoryDialog.Companion.getTAG());
+    }
+
+    private void showCategoryPopUp(Category category, List<CategoryOptionCombo> categoryOptionCombos, CategorySelectorBinding catSelectorBinding) {
+        new CatOptionPopUp(
+                this,
+                catSelectorBinding.getRoot(),
+                category.displayName(),
+                presenter.getCatOptions(category.uid()),
+                true,
+                selectedDate,
+                categoryOption -> {
+                    if (categoryOption != null)
+                        selectedCatOption.put(category.uid(), categoryOption);
+                    else
+                        selectedCatOption.remove(category.uid());
+                    catSelectorBinding.catCombo.setText(categoryOption != null ? categoryOption.displayName() : null);
+                    if (selectedCatOption.size() == catCombo.categories().size()) {
+                        catOptionComboUid = presenter.getCatOptionCombo(catCombo.uid(), categoryOptionCombos, new ArrayList<>(selectedCatOption.values()));
+                        checkActionButtonVisibility();
+                    }
+                    return Unit.INSTANCE;
+                }
+        ).show();
     }
 
     @Override
@@ -695,7 +704,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
     @Override
     public void onDateSet(DatePicker datePicker, int year, int month, int day) {
         Calendar c = Calendar.getInstance();
-        c.set(year,month,day,0,0);
+        c.set(year, month, day, 0, 0);
         selectedDate = c.getTime();
         selectedDateString = DateUtils.getInstance().getPeriodUIString(periodType, selectedDate, Locale.getDefault());
         binding.date.setText(selectedDateString);

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialContract.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialContract.java
@@ -121,7 +121,7 @@ public class EventInitialContract {
 
         void getStageObjectStyle(String uid);
 
-        String getCatOptionCombo(List<CategoryOptionCombo> categoryOptionCombos, List<CategoryOption> values);
+        String getCatOptionCombo(String uid, List<CategoryOptionCombo> categoryOptionCombos, List<CategoryOption> values);
 
         Date getStageLastDate(String programStageUid, String enrollmentUid);
 
@@ -132,6 +132,8 @@ public class EventInitialContract {
         CategoryOption getCatOption(String selectedOption);
 
         int catOptionSize(String uid);
+
+        List<CategoryOption> getCatOptions(String categoryUid);
     }
 
 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenter.java
@@ -52,9 +52,7 @@ import static org.dhis2.utils.analytics.AnalyticsConstants.BACK_EVENT;
 import static org.dhis2.utils.analytics.AnalyticsConstants.CLICK;
 import static org.dhis2.utils.analytics.AnalyticsConstants.CREATE_EVENT;
 
-public class EventInitialPresenter
-        implements
-        EventInitialContract.Presenter {
+public class EventInitialPresenter implements EventInitialContract.Presenter {
 
     public static final int ACCESS_LOCATION_PERMISSION_REQUEST = 101;
     private final PreferenceProvider preferences;
@@ -74,8 +72,6 @@ public class EventInitialPresenter
 
     private Program program;
 
-    private CategoryCombo catCombo;
-
     private String programStageId;
 
     private List<OrganisationUnit> orgUnits;
@@ -86,8 +82,8 @@ public class EventInitialPresenter
                                  @NonNull EventSummaryRepository eventSummaryRepository,
                                  @NonNull EventInitialRepository eventInitialRepository,
                                  @NonNull SchedulerProvider schedulerProvider,
-                                @NonNull PreferenceProvider preferenceProvider,
-                                @NonNull AnalyticsHelper analyticsHelper) {
+                                 @NonNull PreferenceProvider preferenceProvider,
+                                 @NonNull AnalyticsHelper analyticsHelper) {
 
         this.view = view;
         this.eventInitialRepository = eventInitialRepository;
@@ -121,12 +117,11 @@ public class EventInitialPresenter
                                     .subscribeOn(schedulerProvider.io()).observeOn(schedulerProvider.ui())
                                     .subscribe(sextet -> {
                                         this.program = sextet.val1();
-                                        this.catCombo = sextet.val2();
                                         this.orgUnits = sextet.val5();
                                         view.setProgram(sextet.val1());
                                         view.setProgramStage(sextet.val3());
                                         view.setEvent(sextet.val0());
-                                        getCatOptionCombos(catCombo, !sextet.val4().isEmpty() ? sextet.val4() : null);
+                                        getCatOptionCombos(sextet.val2(), !sextet.val4().isEmpty() ? sextet.val4() : null);
                                     }, Timber::d));
 
         } else {
@@ -141,10 +136,9 @@ public class EventInitialPresenter
                                     .subscribeOn(schedulerProvider.io()).observeOn(schedulerProvider.ui())
                                     .subscribe(trioFlowable -> {
                                         this.program = trioFlowable.val0();
-                                        this.catCombo = trioFlowable.val1();
                                         this.orgUnits = trioFlowable.val2();
                                         view.setProgram(trioFlowable.val0());
-                                        getCatOptionCombos(catCombo, null);
+                                        getCatOptionCombos(trioFlowable.val1(), null);
                                     }, Timber::d));
             getProgramStages(programId, programStageId);
         }
@@ -393,8 +387,8 @@ public class EventInitialPresenter
     }
 
     @Override
-    public String getCatOptionCombo(List<CategoryOptionCombo> categoryOptionCombos, List<CategoryOption> values) {
-        return eventInitialRepository.getCategoryOptionCombo(catCombo.uid(), UidsHelper.getUidsList(values));
+    public String getCatOptionCombo(String catComboUid, List<CategoryOptionCombo> categoryOptionCombos, List<CategoryOption> values) {
+        return eventInitialRepository.getCategoryOptionCombo(catComboUid, UidsHelper.getUidsList(values));
     }
 
     @Override
@@ -447,5 +441,10 @@ public class EventInitialPresenter
     @Override
     public int catOptionSize(String uid) {
         return eventInitialRepository.getCatOptionSize(uid);
+    }
+
+    @Override
+    public List<CategoryOption> getCatOptions(String categoryUid) {
+        return eventInitialRepository.getCategoryOptions(categoryUid);
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepository.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepository.java
@@ -80,4 +80,6 @@ public interface EventInitialRepository {
     CategoryOption getCatOption(String selectedOption);
 
     int getCatOptionSize(String uid);
+
+    List<CategoryOption> getCategoryOptions(String categoryUid);
 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepositoryImpl.java
@@ -116,9 +116,11 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
                             if (!categoryCombo.isDefault() && event.attributeOptionCombo() != null) {
                                 List<CategoryOption> selectedCatOptions = d2.categoryModule().categoryOptionCombos().withCategoryOptions().uid(event.attributeOptionCombo()).blockingGet().categoryOptions();
                                 for (Category category : categoryCombo.categories()) {
-                                    for (CategoryOption categoryOption : selectedCatOptions)
-                                        if (category.categoryOptions().contains(categoryOption))
+                                    for (CategoryOption categoryOption : selectedCatOptions) {
+                                        List<CategoryOption> categoryOptions = d2.categoryModule().categoryOptions().byCategoryUid(category.uid()).blockingGet();
+                                        if (categoryOptions.contains(categoryOption))
                                             map.put(category.uid(), categoryOption);
+                                    }
                                 }
                             }
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialRepositoryImpl.java
@@ -24,7 +24,6 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.program.Program;
 import org.hisp.dhis.android.core.program.ProgramStage;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -96,21 +95,11 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
     @Override
     public Observable<CategoryCombo> catCombo(String programUid) {
         return d2.programModule().programs().uid(programUid).get()
-                .flatMap(program ->
-                        d2.categoryModule().categoryCombos().withCategories().withCategoryOptionCombos().uid(program.categoryComboUid()).get())
-                .map(categoryCombo -> {
-                    List<Category> fullCategories = new ArrayList<>();
-                    List<CategoryOptionCombo> fullOptionCombos = new ArrayList<>();
-                    for (Category category : categoryCombo.categories()) {
-                        fullCategories.add(d2.categoryModule().categories().withCategoryOptions().uid(category.uid()).blockingGet());
-                    }
-                    List<CategoryOptionCombo> catOptionCombos = d2.categoryModule().categoryOptionCombos()
-                            .byCategoryComboUid().eq(categoryCombo.uid())
-                            .blockingGet();
-                    for (CategoryOptionCombo categoryOptionCombo : catOptionCombos)
-                        fullOptionCombos.add(d2.categoryModule().categoryOptionCombos().withCategoryOptions().uid(categoryOptionCombo.uid()).blockingGet());
-                    return categoryCombo.toBuilder().categories(fullCategories).categoryOptionCombos(fullOptionCombos).build();
-                }).toObservable();
+                .flatMap(program -> d2.categoryModule().categoryCombos()
+                        .withCategories()
+                        .withCategoryOptionCombos()
+                        .uid(program.categoryComboUid()
+                        ).get()).toObservable();
     }
 
     @Override
@@ -404,5 +393,12 @@ public class EventInitialRepositoryImpl implements EventInitialRepository {
                 .byCategoryUid(uid)
                 .byAccessDataWrite().isTrue()
                 .blockingCount();
+    }
+
+    @Override
+    public List<CategoryOption> getCategoryOptions(String categoryUid) {
+        return d2.categoryModule().categoryOptions()
+                .byCategoryUid(categoryUid)
+                .blockingGet();
     }
 }

--- a/app/src/main/java/org/dhis2/utils/customviews/CatOptionPopUp.kt
+++ b/app/src/main/java/org/dhis2/utils/customviews/CatOptionPopUp.kt
@@ -1,0 +1,40 @@
+package org.dhis2.utils.customviews
+
+import android.content.Context
+import android.view.Menu
+import android.view.View
+import android.widget.PopupMenu
+import java.util.Date
+import org.dhis2.Bindings.inDateRange
+import org.hisp.dhis.android.core.category.CategoryOption
+
+class CatOptionPopUp(
+    val context: Context,
+    anchor: View,
+    private val categoryName: String,
+    val options: List<CategoryOption>,
+    val showOnlyWithAccess: Boolean,
+    val date: Date?,
+    private val onOptionSelected: (CategoryOption?) -> Unit
+) :
+    PopupMenu(context, anchor) {
+
+    override fun show() {
+        setOnMenuItemClickListener {
+            when (it.order) {
+                0 -> onOptionSelected.invoke(null)
+                else -> onOptionSelected.invoke(options[it.order - 1])
+            }
+            true
+        }
+        menu.add(Menu.NONE, Menu.NONE, 0, categoryName)
+        options.filter { option ->
+            showOnlyWithAccess && option.access().data().write()
+        }.forEachIndexed { index, option ->
+            if (option.inDateRange(date)) {
+                menu.add(Menu.NONE, Menu.NONE, index + 1, option.displayName())
+            }
+        }
+        super.show()
+    }
+}

--- a/app/src/test/java/org/dhis2/data/dhislogic/CategoryOptionExtensionsKtTest.kt
+++ b/app/src/test/java/org/dhis2/data/dhislogic/CategoryOptionExtensionsKtTest.kt
@@ -1,0 +1,68 @@
+package org.dhis2.data.dhislogic
+
+import java.time.Instant
+import java.util.Date
+import org.dhis2.Bindings.inDateRange
+import org.hisp.dhis.android.core.category.CategoryOption
+import org.hisp.dhis.android.core.common.Access
+import org.hisp.dhis.android.core.common.DataAccess
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CategoryOptionExtensionsKtTest {
+
+    @Test
+    fun `Should return true if date is null`() {
+        assertTrue(
+            catOption(null, null).inDateRange(null) &&
+                catOption(Date(), Date()).inDateRange(null) &&
+                catOption(Date(), null).inDateRange(null) &&
+                catOption(null, Date()).inDateRange(null)
+        )
+    }
+
+    @Test
+    fun `Should return true if date not null and option does not have start and end dates`() {
+        assertTrue(
+            catOption(null, null).inDateRange(Date())
+        )
+    }
+
+    @Test
+    fun `Should return true if date after option start date`() {
+        val date = Date.from(Instant.parse("2020-01-02T00:00:00.00Z"))
+        val startDate = Date.from(Instant.parse("2020-01-01T00:00:00.00Z"))
+        assertTrue(
+            catOption(startDate, null).inDateRange(date)
+        )
+    }
+
+    @Test
+    fun `Should return true if date before option end date`() {
+        val date = Date.from(Instant.parse("2020-01-02T00:00:00.00Z"))
+        val endDate = Date.from(Instant.parse("2020-01-03T00:00:00.00Z"))
+        assertTrue(
+            catOption(null, endDate).inDateRange(date)
+        )
+    }
+
+    @Test
+    fun `Should return true if date between option start and end date`() {
+        val date = Date.from(Instant.parse("2020-01-02T00:00:00.00Z"))
+        val startDate = Date.from(Instant.parse("2020-01-01T00:00:00.00Z"))
+        val endDate = Date.from(Instant.parse("2020-01-03T00:00:00.00Z"))
+        assertTrue(
+            catOption(startDate, endDate).inDateRange(date)
+        )
+    }
+
+    private fun catOption(startDate: Date?, endDate: Date?): CategoryOption {
+        return CategoryOption.builder()
+            .uid("CatOptUid")
+            .displayName("CatOptName")
+            .startDate(startDate)
+            .endDate(endDate)
+            .access(Access.create(true, true, DataAccess.create(true, true)))
+            .build()
+    }
+}


### PR DESCRIPTION

## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3391)
## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code