### PR TITLE
fix: [ANDROAPP-3371] Theme color prevented seeing the add event button

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/StageViewHolder.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/StageViewHolder.kt
@@ -26,7 +26,7 @@ internal class StageViewHolder(
             stage.style().color(),
             ColorUtils.getPrimaryColor(
                 itemView.context,
-                ColorUtils.ColorType.PRIMARY_LIGHT
+                ColorUtils.ColorType.PRIMARY
             )
         )
 

--- a/app/src/main/res/layout/item_stage_section.xml
+++ b/app/src/main/res/layout/item_stage_section.xml
@@ -75,7 +75,7 @@
                 style="@style/ActionIcon"
                 android:layout_width="40dp"
                 android:layout_height="40dp"
-                android:tint="?colorPrimaryLight"
+                android:tint="?colorPrimary"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -121,8 +121,8 @@
 
     <style name="colorPrimary_e57" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary_e57</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark_Pink</item>
-        <item name="colorPrimaryLight">@color/colorPrimaryLight_Pink</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark_e57</item>
+        <item name="colorPrimaryLight">@color/colorPrimaryLight_e57</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:datePickerDialogTheme">@style/DatePickerThemeRed</item>
         <item name="android:timePickerDialogTheme">@style/TimePickerThemeRed</item>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3371)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code