### PR TITLE
fix: [ANDROAPP-3425] Save sms settings when focus is cleared

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/ViewExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/ViewExtensions.kt
@@ -3,7 +3,9 @@ package org.dhis2.Bindings
 import android.app.Activity
 import android.util.TypedValue
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
 import com.tbuonomo.viewpagerdotsindicator.R
 
 fun View.closeKeyboard() {
@@ -15,4 +17,24 @@ fun View.getThemePrimaryColor(): Int {
     val value = TypedValue()
     context.theme.resolveAttribute(R.attr.colorPrimary, value, true)
     return value.data
+}
+
+fun View.onFocusRemoved(onFocusRemovedCallback: () -> Unit) {
+    setOnFocusChangeListener { view, hasFocus ->
+        if (!hasFocus) {
+            view.closeKeyboard()
+            onFocusRemovedCallback.invoke()
+        }
+    }
+}
+
+fun TextView.clearFocusOnDone() {
+    setOnEditorActionListener { view, actionId, _ ->
+        if (actionId == EditorInfo.IME_ACTION_DONE) {
+            view.clearFocus()
+            true
+        } else {
+            false
+        }
+    }
 }

--- a/app/src/main/java/org/dhis2/usescases/settings/SyncManagerFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/settings/SyncManagerFragment.java
@@ -9,7 +9,6 @@ import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.ImageSpan;
@@ -19,6 +18,7 @@ import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -48,7 +48,6 @@ import org.dhis2.utils.ColorUtils;
 import org.dhis2.utils.Constants;
 import org.dhis2.utils.HelpManager;
 import org.dhis2.utils.NetworkUtils;
-import org.hisp.dhis.android.core.maintenance.D2Error;
 import org.hisp.dhis.android.core.settings.LimitScope;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,6 +55,10 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import kotlin.Unit;
+
+import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
+import static android.text.Spanned.SPAN_INCLUSIVE_EXCLUSIVE;
 import static org.dhis2.Bindings.SettingExtensionsKt.EVERY_12_HOUR;
 import static org.dhis2.Bindings.SettingExtensionsKt.EVERY_24_HOUR;
 import static org.dhis2.Bindings.SettingExtensionsKt.EVERY_30_MIN;
@@ -92,8 +95,6 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
     private boolean metadataInit;
     private boolean scopeLimitInit;
     private boolean dataWorkRunning;
-    private boolean metadataWorkRunning;
-//    scopeLimitInit = false;
 
     public SyncManagerFragment() {
         // Required empty public constructor
@@ -128,9 +129,7 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
                 binding.syncMetaLayout.message.setTextColor(ContextCompat.getColor(context, R.color.text_black_333));
                 String metaText = metaSyncSettings().concat("\n").concat(context.getString(R.string.syncing_configuration));
                 binding.syncMetaLayout.message.setText(metaText);
-                metadataWorkRunning = true;
             } else {
-                metadataWorkRunning = false;
                 presenter.checkData();
             }
             checkSyncMetaButtonStatus();
@@ -405,8 +404,8 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
             SpannableString str = new SpannableString(src);
             int wIndex = src.indexOf('@');
             int eIndex = src.indexOf('$');
-            str.setSpan(new ImageSpan(context, R.drawable.ic_sync_warning), wIndex, wIndex + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-            str.setSpan(new ImageSpan(context, R.drawable.ic_sync_problem_red), eIndex, eIndex + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            str.setSpan(new ImageSpan(context, R.drawable.ic_sync_warning), wIndex, wIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE);
+            str.setSpan(new ImageSpan(context, R.drawable.ic_sync_problem_red), eIndex, eIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE);
             binding.syncDataLayout.message.setText(str);
             binding.syncDataLayout.message.setTextColor(ContextCompat.getColor(context, R.color.red_060));
 
@@ -414,7 +413,7 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
             String src = dataSyncSetting().concat("\n").concat(getString(R.string.data_sync_warning));
             SpannableString str = new SpannableString(src);
             int wIndex = src.indexOf('@');
-            str.setSpan(new ImageSpan(context, R.drawable.ic_sync_warning), wIndex, wIndex + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            str.setSpan(new ImageSpan(context, R.drawable.ic_sync_warning), wIndex, wIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE);
             binding.syncDataLayout.message.setText(str);
             binding.syncDataLayout.message.setTextColor(ContextCompat.getColor(context, R.color.colorPrimaryOrange));
         }
@@ -602,7 +601,7 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
             str.setSpan(new ForegroundColorSpan(ColorUtils.getPrimaryColor(context, ColorUtils.ColorType.PRIMARY)),
                     indexOfNumber,
                     indexOfNumber + 1,
-                    Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
+                    SPAN_INCLUSIVE_EXCLUSIVE);
             binding.specificSettingsText.setText(str);
             binding.specificSettingsButton.setOnClickListener(view ->
                     startActivity(SettingsProgramActivity.Companion.getIntentActivity(context)));
@@ -610,9 +609,6 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
             binding.specificSettingsText.setVisibility(View.GONE);
             binding.specificSettingsButton.setVisibility(View.GONE);
         }
-
-        /*binding.downloadLimitScope.setAdapter(new ArrayAdapter<>(context, R.layout.spinner_settings_item,
-                context.getResources().getStringArray(R.array.download_limit_scope)));*/
 
         if (parameterSettings.getLimitScopeIsEditable()) {
             binding.downloadLimitScopeHint.setVisibility(View.VISIBLE);
@@ -639,7 +635,7 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
     }
 
     private void setUpSyncParameterListeners() {
-        if(binding.downloadLimitScope.getOnItemSelectedListener()==null) {
+        if (binding.downloadLimitScope.getOnItemSelectedListener() == null) {
             binding.downloadLimitScope.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
                 public void onItemSelected(AdapterView<?> adapterView, View view, int position, long l) {
@@ -734,35 +730,23 @@ public class SyncManagerFragment extends FragmentGlobalAbstract implements SyncM
     }
 
     private void setUpSmsListeners() {
-        binding.settingsSms.settingsSmsReceiver.setOnEditorActionListener((view, actionId, keyEvent) -> {
-            if (actionId == EditorInfo.IME_ACTION_DONE && !binding.settingsSms.settingsSmsReceiver.getText().toString().isEmpty()) {
-                ViewExtensionsKt.closeKeyboard(view);
-                presenter.saveGatewayNumber(binding.settingsSms.settingsSmsReceiver.getText().toString());
-                return true;
-            } else {
-                return false;
-            }
+        ViewExtensionsKt.clearFocusOnDone(binding.settingsSms.settingsSmsReceiver);
+        ViewExtensionsKt.clearFocusOnDone(binding.settingsSms.settingsSmsResultSender);
+        ViewExtensionsKt.clearFocusOnDone(binding.settingsSms.settingsSmsResultTimeout);
+
+        ViewExtensionsKt.onFocusRemoved(binding.settingsSms.settingsSmsReceiver, () -> {
+            presenter.saveGatewayNumber(binding.settingsSms.settingsSmsReceiver.getText().toString());
+            return Unit.INSTANCE;
         });
 
-        binding.settingsSms.settingsSmsResultSender.setOnEditorActionListener((view, actionId, keyEvent) -> {
-            if (actionId == EditorInfo.IME_ACTION_DONE && !binding.settingsSms.settingsSmsResultSender.getText().toString().isEmpty()) {
-                ViewExtensionsKt.closeKeyboard(view);
-                presenter.saveSmsResultSender(binding.settingsSms.settingsSmsResultSender.getText().toString());
-                return true;
-            } else {
-                return false;
-            }
+        ViewExtensionsKt.onFocusRemoved(binding.settingsSms.settingsSmsResultSender, () -> {
+            presenter.saveSmsResultSender(binding.settingsSms.settingsSmsResultSender.getText().toString());
+            return Unit.INSTANCE;
         });
 
-        binding.settingsSms.settingsSmsResultTimeout.setOnEditorActionListener((view, actionId, keyEvent) -> {
-            if (actionId == EditorInfo.IME_ACTION_DONE && !binding.settingsSms.settingsSmsResultTimeout.getText().toString().isEmpty()) {
-                ViewExtensionsKt.closeKeyboard(view);
-                presenter.saveSmsResponseTimeout(
-                        Integer.valueOf(binding.settingsSms.settingsSmsResultTimeout.getText().toString()));
-                return true;
-            } else {
-                return false;
-            }
+        ViewExtensionsKt.onFocusRemoved(binding.settingsSms.settingsSmsReceiver, () -> {
+            presenter.saveSmsResponseTimeout(Integer.valueOf(binding.settingsSms.settingsSmsResultTimeout.getText().toString()));
+            return Unit.INSTANCE;
         });
 
         binding.settingsSms.settingsSmsResponseWaitSwitch.setOnCheckedChangeListener((compoundButton, isChecked) -> {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -62,6 +62,7 @@
                     <ImageView
                         android:id="@+id/menu"
                         style="@style/ActionIcon"
+                        android:focusable="true"
                         android:onClick="@{()->presenter.onMenuClick()}"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3425)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code