### PR TITLE
fix: [ANDROAPP-3431] Enables clicks on org unit field in the search activity.

### DIFF
--- a/app/src/main/res/layout/custom_text_view_accent.xml
+++ b/app/src/main/res/layout/custom_text_view_accent.xml
@@ -106,7 +106,6 @@
                     android:id="@+id/input_editText"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:enabled="@{isEditable.get()}"
                     android:gravity="start"
                     android:imeOptions="actionNext"
                     android:maxLines="1"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3431](https://jira.dhis2.org/browse/ANDROAPP-3431)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code