### PR TITLE
fix: [ANDROAPP-3395] Map not showing icons on initialization when search backdrop is active

### DIFF
--- a/app/src/main/java/org/dhis2/uicomponents/map/managers/TeiMapManager.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/managers/TeiMapManager.kt
@@ -36,6 +36,7 @@ class TeiMapManager(mapView: MapView) : MapManager(mapView) {
     private var teiImages: HashMap<String, Bitmap> = hashMapOf()
     var teiFeatureType: FeatureType? = FeatureType.POINT
     var enrollmentFeatureType: FeatureType? = FeatureType.POINT
+    private var boundingBox: BoundingBox? = null
 
     companion object {
         const val TEIS_SOURCE_ID = "TEIS_SOURCE_ID"
@@ -50,10 +51,10 @@ class TeiMapManager(mapView: MapView) : MapManager(mapView) {
         this.teiFeatureCollections = teiFeatureCollections
         this.eventsFeatureCollection = eventsFeatureCollection.featureCollectionMap
         this.teiFeatureCollections?.putAll(eventsFeatureCollection.featureCollectionMap)
+        this.boundingBox = boundingBox
         teiFeatureCollections[TEIS_SOURCE_ID]?.let {
             setTeiImages(it)
         }
-        initCameraPosition(boundingBox)
     }
 
     override fun loadDataForStyle() {
@@ -205,6 +206,7 @@ class TeiMapManager(mapView: MapView) : MapManager(mapView) {
                 LayerType.TEI_EVENT_LAYER,
                 eventsFeatureCollection?.keys?.toList() ?: emptyList()
             )
+        boundingBox?.let { initCameraPosition(it) }
     }
 
     override fun findFeature(

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -461,6 +461,9 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
                     showMap(false);
                     break;
                 case R.id.menu_map:
+                    if(backDropActive){
+                        closeFilters();
+                    }
                     showMap(true);
                     break;
                 default:


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3395

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code