### PR TITLE
docs: add SMS to implementation guide and references [skip ci]

### DIFF
--- a/docs/src/commonmark/en/content/capture-app/new-android-specific-features.md
+++ b/docs/src/commonmark/en/content/capture-app/new-android-specific-features.md
@@ -214,6 +214,10 @@ The record is marked as “SMS synced”.
 
 ![](resources/images/image90.png){ width=25%}
 
+> **Note**
+>
+>  Note that in order to user the SMS sync capabilities the SMS services needs to be enabled in the server side as described in the (official documentation)[https://docs.dhis2.org/master/en/dhis2_user_manual_en/mobile.html#sms-service]. You can also find more information on how to use different gateways in the (Android Implementation Guidelines)[https://docs.dhis2.org/master/en/dhis2_android_implementation_guideline/about-this-guide.html].
+
 ## Org unit
 
 <!-- DHIS2-SECTION-ID:generic_ou -->

--- a/docs/src/commonmark/en/dhis2_android_implementation_guideline_INDEX.md
+++ b/docs/src/commonmark/en/dhis2_android_implementation_guideline_INDEX.md
@@ -15,6 +15,7 @@ applicable_txt: 'Applicable to version 2.2'
 !INCLUDE "content/implementation-guide/dhis2-server-requirements.md"
 !INCLUDE "content/implementation-guide/data-security-and-privacy.md"
 !INCLUDE "content/implementation-guide/mobile-device-specs.md"
+!INCLUDE "content/implementation-guide/SMS-for-reporting.md"
 !INCLUDE "content/implementation-guide/dhis2-configuration-for-android.md"
 !INCLUDE "content/implementation-guide/installing-the-app.md"
 !INCLUDE "content/implementation-guide/testing.md"


### PR DESCRIPTION
Add SMS gateway information in the implementation guide and the reference on the configuration guide (SMS sync feature)