### PR TITLE
fix: [ANDROAPP-3366] Check datavalue authority in data sets

### DIFF
--- a/app/src/main/java/org/dhis2/data/dhislogic/Authorities.kt
+++ b/app/src/main/java/org/dhis2/data/dhislogic/Authorities.kt
@@ -1,0 +1,3 @@
+package org.dhis2.data.dhislogic
+
+const val AUTH_DATAVALUE_ADD = "F_DATAVALUE_ADD"

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import io.reactivex.Flowable
 import java.util.ArrayList
 import java.util.HashMap
+import org.dhis2.data.dhislogic.AUTH_DATAVALUE_ADD
 import org.dhis2.data.tuples.Pair
 import org.dhis2.usescases.datasets.dataSetTable.DataSetTableModel
 import org.hisp.dhis.android.core.D2
@@ -458,7 +459,10 @@ class DataValueRepositoryImpl(private val d2: D2, private val dataSetUid: String
                                             ).blockingGet()
                                     canWriteOrgUnit = organisationUnits.isNotEmpty()
                                 }
-                                canWriteCatOption && canWriteOrgUnit
+                                val hasDataValueAuthority = !d2.userModule().authorities()
+                                    .byName().eq(AUTH_DATAVALUE_ADD)
+                                    .blockingIsEmpty()
+                                hasDataValueAuthority && canWriteCatOption && canWriteOrgUnit
                             }
                     else -> Flowable.just(false)
                 }

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetDetail/DataSetDetailRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetDetail/DataSetDetailRepositoryImpl.java
@@ -24,6 +24,8 @@ import java.util.Locale;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 
+import static org.dhis2.data.dhislogic.AuthoritiesKt.AUTH_DATAVALUE_ADD;
+
 public class DataSetDetailRepositoryImpl implements DataSetDetailRepository {
 
     private final D2 d2;
@@ -111,7 +113,7 @@ public class DataSetDetailRepositoryImpl implements DataSetDetailRepository {
     public Flowable<Boolean> canWriteAny() {
         return d2.dataSetModule().dataSets().uid(dataSetUid).get().toFlowable()
                 .flatMap(dataSet -> {
-                    if (dataSet.access().data().write())
+                    if (dataSet.access().data().write() && hasDataValueAuthority())
                         return d2.categoryModule().categoryOptionCombos().withCategoryOptions()
                                 .byCategoryComboUid().eq(dataSet.categoryCombo().uid()).get().toFlowable()
                                 .map(categoryOptionCombos -> {
@@ -141,6 +143,10 @@ public class DataSetDetailRepositoryImpl implements DataSetDetailRepository {
                         return Flowable.just(false);
                 });
 
+    }
+
+    private boolean hasDataValueAuthority(){
+        return !d2.userModule().authorities().byName().eq(AUTH_DATAVALUE_ADD).blockingIsEmpty();
     }
 
     @Override

--- a/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepositoryTest.kt
@@ -873,6 +873,14 @@ class DataValueRepositoryTest {
         ) doReturn listOf(OrganisationUnit.builder().uid(UUID.randomUUID().toString()).build())
         whenever(
             d2.userModule().authorities()
+                .byName()
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
                 .byName().eq(AUTH_DATAVALUE_ADD)
                 .blockingIsEmpty()
         ) doReturn true

--- a/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Single
 import java.util.UUID
+import org.dhis2.data.dhislogic.AUTH_DATAVALUE_ADD
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.category.CategoryCombo
@@ -680,6 +681,19 @@ class DataValueRepositoryTest {
                 .byCategoryComboUid().eq(dataSet.categoryCombo()?.uid())
                 .get()
         ) doReturn Single.just(listOf(categoryOptionCombo))
+        whenever(
+            d2.userModule().authorities()
+                .byName()
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn false
 
         val testObserver = repository.canWriteAny().test()
 
@@ -725,6 +739,19 @@ class DataValueRepositoryTest {
                 .byCategoryComboUid().eq(dataSet.categoryCombo()?.uid())
                 .get()
         ) doReturn Single.just(listOf(categoryOptionCombo))
+        whenever(
+            d2.userModule().authorities()
+                .byName()
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn false
 
         val testObserver = repository.canWriteAny().test()
 
@@ -778,6 +805,77 @@ class DataValueRepositoryTest {
                     OrganisationUnit.Scope.SCOPE_DATA_CAPTURE
                 ).blockingGet()
         ) doReturn listOf(OrganisationUnit.builder().uid(UUID.randomUUID().toString()).build())
+        whenever(
+            d2.userModule().authorities()
+                .byName()
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn false
+
+        val testObserver = repository.canWriteAny().test()
+
+        testObserver.assertNoErrors()
+        testObserver.assertValue(false)
+
+        testObserver.dispose()
+    }
+
+    @Test
+    fun `Should return user don't have data value authority`() {
+        val dataSet = dummyDataSet()
+        val categoryOption = CategoryOption.builder()
+            .uid(UUID.randomUUID().toString())
+            .access(Access.create(false, false, DataAccess.create(false, false)))
+            .build()
+        val categoryOptionCombo = CategoryOptionCombo.builder()
+            .uid(UUID.randomUUID().toString())
+            .categoryOptions(listOf(categoryOption))
+            .build()
+
+        whenever(
+            d2.dataSetModule().dataSets().uid(dataSetUid).get()
+        ) doReturn Single.just(dataSet)
+
+        whenever(
+            d2.categoryModule()
+                .categoryOptionCombos().withCategoryOptions()
+        ) doReturn mock()
+        whenever(
+            d2.categoryModule()
+                .categoryOptionCombos().withCategoryOptions()
+                .byCategoryComboUid()
+        ) doReturn mock()
+        whenever(
+            d2.categoryModule()
+                .categoryOptionCombos().withCategoryOptions()
+                .byCategoryComboUid().eq(dataSet.categoryCombo()?.uid())
+        ) doReturn mock()
+        whenever(
+            d2.categoryModule()
+                .categoryOptionCombos().withCategoryOptions()
+                .byCategoryComboUid().eq(dataSet.categoryCombo()?.uid())
+                .get()
+        ) doReturn Single.just(listOf(categoryOptionCombo))
+
+        whenever(
+            d2.organisationUnitModule().organisationUnits()
+                .byDataSetUids(listOf(dataSetUid))
+                .byOrganisationUnitScope(
+                    OrganisationUnit.Scope.SCOPE_DATA_CAPTURE
+                ).blockingGet()
+        ) doReturn listOf(OrganisationUnit.builder().uid(UUID.randomUUID().toString()).build())
+        whenever(
+            d2.userModule().authorities()
+                .byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn true
 
         val testObserver = repository.canWriteAny().test()
 

--- a/app/src/test/java/org/dhis2/usescases/datasets/datasetDetail/DataSetDetailRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/datasets/datasetDetail/DataSetDetailRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Single
+import org.dhis2.data.dhislogic.AUTH_DATAVALUE_ADD
 import org.dhis2.data.tuples.Pair
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.category.CategoryCombo
@@ -104,6 +105,59 @@ class DataSetDetailRepositoryTest {
                 .byCategoryComboUid().eq("categoryCombo")
                 .get()
         ) doReturn Single.just(categoryOptionCombos)
+        whenever(
+            d2.userModule()
+                .authorities().byName()
+        ) doReturn mock()
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn false
+
+        val testObserver = repository.canWriteAny().test()
+
+        testObserver.assertValueCount(1)
+        testObserver.assertNoErrors()
+        testObserver.assertValueAt(0) {
+            Assert.assertEquals(it, false)
+            true
+        }
+    }
+
+    @Test
+    fun `Should return false if the user does not have the authority`() {
+        val dataSet = dummyDataSet()
+        val categoryOptionCombos = dummyCategoryOptionsCombos(true)
+
+        whenever(d2.dataSetModule().dataSets().uid(dataSetUid).get()) doReturn Single.just(dataSet)
+        whenever(
+            d2.categoryModule().categoryOptionCombos().withCategoryOptions().byCategoryComboUid()
+        ) doReturn mock()
+        whenever(
+            d2.categoryModule()
+                .categoryOptionCombos().withCategoryOptions()
+                .byCategoryComboUid().eq("categoryCombo")
+        ) doReturn mock()
+        whenever(
+            d2.categoryModule()
+                .categoryOptionCombos().withCategoryOptions()
+                .byCategoryComboUid().eq("categoryCombo")
+                .get()
+        ) doReturn Single.just(categoryOptionCombos)
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn true
 
         val testObserver = repository.canWriteAny().test()
 
@@ -140,6 +194,15 @@ class DataSetDetailRepositoryTest {
                 .organisationUnits().byDataSetUids(listOf(dataSetUid))
                 .byOrganisationUnitScope(any()).blockingCount()
         ) doReturn 0
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn false
 
         val testObserver = repository.canWriteAny().test()
 
@@ -176,6 +239,19 @@ class DataSetDetailRepositoryTest {
                 .organisationUnits().byDataSetUids(listOf(dataSetUid))
                 .byOrganisationUnitScope(any()).blockingCount()
         ) doReturn 1
+        whenever(
+            d2.userModule()
+                .authorities().byName()
+        ) doReturn mock()
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+        ) doReturn mock()
+        whenever(
+            d2.userModule()
+                .authorities().byName().eq(AUTH_DATAVALUE_ADD)
+                .blockingIsEmpty()
+        ) doReturn false
 
         val testObserver = repository.canWriteAny().test()
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3366)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code