### PR TITLE
fix: [ANDROAPP-3443] Adds ripple effect to date, datetime, and time field's icons.

### DIFF
--- a/app/src/main/res/layout/date_time_view.xml
+++ b/app/src/main/res/layout/date_time_view.xml
@@ -90,11 +90,11 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <ImageView
-                android:layout_gravity="center"
                 android:id="@+id/descIcon"
+                style="@style/ActionIcon"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:paddingHorizontal="11dp"
+                android:layout_gravity="center"
                 tools:visibility="visible"
                 tools:src="@drawable/ic_form_date"/>
 

--- a/app/src/main/res/layout/date_time_view_accent.xml
+++ b/app/src/main/res/layout/date_time_view_accent.xml
@@ -93,13 +93,13 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <ImageView
-                android:layout_gravity="center"
                 android:id="@+id/descIcon"
+                style="@style/ActionIcon"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:paddingHorizontal="11dp"
-                tools:visibility="visible"
+                android:layout_gravity="center"
                 app:tint="?colorAccent"
+                tools:visibility="visible"
                 tools:src="@drawable/ic_form_date"/>
 
             <ImageView


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3443](https://jira.dhis2.org/browse/ANDROAPP-3443)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [x] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code