### PR TITLE
fix: Reviewers script now prevents error when PR  owner is different from the established developers

### DIFF
--- a/scripts/reviewers.py
+++ b/scripts/reviewers.py
@@ -28,8 +28,9 @@ else:
 
     if (pr_owner in quadram_devs):
         quadram_devs.remove(pr_owner)
-    else:
+    elif (pr_owner in dhis_devs):
         dhis_devs.remove(pr_owner)
+
     quadram_reviewer = random.choice(quadram_devs)
     dhis_reviewer = random.choice(dhis_devs)
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code