### PR TITLE
fix: [ANDROAPP-3498] IndexOutOfBounds in dataEntryAdapter when checking section header

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryAdapter.java
@@ -410,6 +410,10 @@ public final class DataEntryAdapter extends ListAdapter<FieldViewModel, ViewHold
     }
 
     public boolean isSection(int position) {
-        return getItemViewType(position) == SECTION;
+        if (position <= getItemCount()) {
+            return getItemViewType(position) == SECTION;
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
validates that a the first visible position from the form is not greater than the items size, and returns false if it is instead of a IndexOutOfBoundsError

## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3498](https://jira.dhis2.org/browse/ANDROAPP-3498)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code