### PR TITLE
fix: [ANDROAPP-3519] set editText max height for longtext dialog

### DIFF
--- a/app/src/main/res/layout/dialog_edittext.xml
+++ b/app/src/main/res/layout/dialog_edittext.xml
@@ -10,6 +10,7 @@
         android:layout_height="wrap_content"
         android:textCursorDrawable="@null"
         android:textSize="16sp"
+        android:maxHeight="280dp"
         app:backgroundTint="@color/greyish"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3519)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code