### PR TITLE
fix: [ANDROAPP-3534] Unable to type in text fields in data set

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/tablefields/edittext/EditTextCellCustomHolder.java
@@ -111,6 +111,7 @@ final class EditTextCellCustomHolder extends FormViewHolder {
     private void setInputType(ValueType valueType) {
 
         editText.setFilters(new InputFilter[]{});
+        editText.setFocusable(true);
 
 
         if (editTextModel.editable())
@@ -123,6 +124,8 @@ final class EditTextCellCustomHolder extends FormViewHolder {
                             InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
                     break;
                 case TEXT:
+                    editText.setInputType(InputType.TYPE_CLASS_TEXT);
+                    break;
                 case LONG_TEXT:
                     editText.setKeyListener(null);
                     editText.setFocusable(false);


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3534

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code