### PR TITLE
fix: [ANDROAPP-3471] Sticky section header now sticks

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryHeaderHelper.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/DataEntryHeaderHelper.kt
@@ -89,6 +89,10 @@ class DataEntryHeaderHelper(
             dataEntryAdapter.getSectionPosition(section.uid())?.let {
                 loadHeader(dataEntryAdapter.getSectionForPosition(it))
             }
+        } ?: run {
+            if (dataEntryAdapter.getSectionSize() > 1) {
+                loadHeader(dataEntryAdapter.getSectionForPosition(0))
+            }
         }
     }
 }

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/SectionHandler.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/SectionHandler.kt
@@ -11,7 +11,7 @@ class SectionHandler {
         } else {
             var finalPosition = NO_POSITION
             positionLoop@ for (sectionPosition in sectionPositions) {
-                if (sectionPosition < visiblePosition) {
+                if (sectionPosition <= visiblePosition) {
                     finalPosition = sectionPosition
                 } else {
                     break@positionLoop


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3471](https://jira.dhis2.org/browse/ANDROAPP-3471)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code