### PR TITLE
fix: [ANDROAPP-3629] Fix clear button for long text fields

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/CustomTextView.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/CustomTextView.java
@@ -237,6 +237,7 @@ public class CustomTextView extends FieldLayout {
                     editText.setImeOptions(EditorInfo.IME_FLAG_NO_ENTER_ACTION);
                     clearButton.setOnClickListener(v -> {
                         editText.getText().clear();
+                        sendAction();
                         updateDeleteVisibility(findViewById(R.id.clear_button));
                     });
                     break;


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3629)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code