### PR TITLE
fix: [ANDROAPP-3584] Do not close activity when checking complete dataSet

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/datasets/DataSetIntents.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/datasets/DataSetIntents.kt
@@ -1,0 +1,32 @@
+package org.dhis2.usescases.datasets
+
+import android.content.Intent
+import androidx.test.rule.ActivityTestRule
+import org.dhis2.usescases.datasets.dataSetTable.DataSetTableActivity
+
+fun startDataSetActivity(
+    dataSetUid: String,
+    orgUnitUid: String,
+    orgUnitName: String,
+    periodTypeName: String,
+    periodInitialDate: String,
+    periodId: String,
+    catOptCombo: String,
+    rule: ActivityTestRule<DataSetTableActivity>
+) {
+    Intent().apply {
+        putExtras(
+            DataSetTableActivity.getBundle(
+                dataSetUid,
+                orgUnitUid,
+                orgUnitName,
+                periodTypeName,
+                periodInitialDate,
+                periodId,
+                catOptCombo
+            )
+        )
+    }.also {
+        rule.launchActivity(it)
+    }
+}

--- a/app/src/androidTest/java/org/dhis2/usescases/datasets/DataSetTableRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/datasets/DataSetTableRobot.kt
@@ -1,0 +1,28 @@
+package org.dhis2.usescases.datasets
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.dhis2.R
+import org.dhis2.common.BaseRobot
+import org.dhis2.usescases.datasets.dataSetTable.DataSetTableActivity
+import org.junit.Assert.assertTrue
+
+
+fun dataSetTableRobot(dataSetTableRobot: DataSetTableRobot.() -> Unit) {
+    DataSetTableRobot().apply {
+        dataSetTableRobot()
+    }
+}
+
+class DataSetTableRobot : BaseRobot() {
+    fun clickOnSaveButton() {
+        onView(withId(R.id.saveButton)).perform(click())
+    }
+    fun clickOnRunValidations(){
+        onView(withId(R.id.positive)).perform(click())
+    }
+    fun checkActivityHasNotFinished(activity: DataSetTableActivity) {
+        assertTrue(!activity.isDestroyed)
+    }
+}

--- a/app/src/androidTest/java/org/dhis2/usescases/datasets/DataSetTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/datasets/DataSetTest.kt
@@ -1,0 +1,35 @@
+package org.dhis2.usescases.datasets
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import org.dhis2.usescases.BaseTest
+import org.dhis2.usescases.datasets.dataSetTable.DataSetTableActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DataSetTest : BaseTest() {
+    @get:Rule
+    val ruleDataSet = ActivityTestRule(DataSetTableActivity::class.java, false, false)
+
+    @Test
+    fun shouldNotCloseActivityAfterQualityCheckIfDataSetIsComplete() {
+        setupCredentials()
+        startDataSetActivity(
+            "BfMAe6Itzgt",
+            "DiszpKrYNg8",
+            "Ngelehun CHC",
+            "periodName",
+            "",
+            "202001",
+            "HllvX50cXC0",
+            ruleDataSet
+        )
+
+        dataSetTableRobot {
+            clickOnSaveButton()
+            checkActivityHasNotFinished(ruleDataSet.activity)
+        }
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -492,8 +492,12 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
 
     @Override
     public void saveAndFinish() {
-        Toast.makeText(this, R.string.save, Toast.LENGTH_SHORT).show();
-        finish();
+        if(presenter.isComplete()){
+            Toast.makeText(this, R.string.data_set_quality_check_done, Toast.LENGTH_SHORT).show();
+        }else{
+            Toast.makeText(this, R.string.save, Toast.LENGTH_SHORT).show();
+            finish();
+        }
     }
 
     public FlowableProcessor<Boolean> observeReopenChanges() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -822,4 +822,5 @@
     <string name="value">Value</string>
     <string name="enrolled_in">Enrolled in:</string>
     <string name="section_charts_indicators">Charts and indicators</string>
+    <string name="data_set_quality_check_done">Done!</string>
 </resources>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3584)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code