### PR TITLE
fix: [ANDROAPP-1161] set max width to indicator label

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
@@ -236,9 +236,9 @@ class DataSetSectionFragment : FragmentGlobalAbstract(), DataValueContract.View 
         val adapter = DataSetIndicatorAdapter(requireContext())
         indicatorsTable?.adapter = adapter
         indicatorsTable?.headerCount = 1
-        indicatorsTable?.setRowHeaderWidth(
-            indicators.keys.toList().calculateWidth(requireContext()).second.dp + 16.dp
-        )
+        val width = indicators.keys.toList().calculateWidth(requireContext()).second + 16.dp
+        val max = resources.displayMetrics.widthPixels*2/3
+        indicatorsTable?.setRowHeaderWidth(if (width < max) width else max)
         adapter.setAllItems(
             listOf(listOf(getString(R.string.value))),
             indicators.keys.toList(),

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
@@ -237,7 +237,7 @@ class DataSetSectionFragment : FragmentGlobalAbstract(), DataValueContract.View 
         indicatorsTable?.adapter = adapter
         indicatorsTable?.headerCount = 1
         val width = indicators.keys.toList().calculateWidth(requireContext()).second + 16.dp
-        val max = resources.displayMetrics.widthPixels*2/3
+        val max = resources.displayMetrics.widthPixels * 2 / 3
         indicatorsTable?.setRowHeaderWidth(if (width < max) width else max)
         adapter.setAllItems(
             listOf(listOf(getString(R.string.value))),

--- a/tableview/src/main/res/layout/item_table_header.xml
+++ b/tableview/src/main/res/layout/item_table_header.xml
@@ -16,6 +16,6 @@
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:textColor="@color/table_view_default_text_color"
-        android:textSize="14sp"
+        android:textSize="12sp"
         tools:text="Test"/>
 </LinearLayout>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-1161)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code