### PR TITLE
fix: [ANDROAPP-3633] Break the glass dialog not showing keyboard for android api < 26

### DIFF
--- a/app/src/main/res/layout/break_the_glass_bottom_dialog.xml
+++ b/app/src/main/res/layout/break_the_glass_bottom_dialog.xml
@@ -90,15 +90,15 @@
                 android:id="@+id/input_editText"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
+                android:layout_marginTop="4dp"
                 android:layout_marginEnd="40dp"
                 android:background="@color/white"
+                android:clickable="true"
                 android:gravity="start"
-                android:layout_marginTop="4dp"
                 android:hint="@string/break_glass_hint"
                 android:imeOptions="actionNext"
                 android:textAlignment="textStart"
                 android:textColor="@color/textPrimary"
-                android:textIsSelectable="true"
                 android:textSize="12sp"
                 app:layout_constraintBottom_toBottomOf="@id/fieldBackground"
                 app:layout_constraintEnd_toEndOf="@id/fieldBackground"
@@ -110,8 +110,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_marginHorizontal="16dp"
-                app:layout_constraintTop_toBottomOf="@id/input_editText"
-                android:background="@color/text_black_8A3"/>
+                android:background="@color/text_black_8A3"
+                app:layout_constraintTop_toBottomOf="@id/input_editText" />
 
             <View
                 android:layout_width="match_parent"
@@ -147,9 +147,9 @@
             android:layout_marginBottom="8dp"
             android:text='@string/cancel'
             android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/positive"
-            app:layout_constraintTop_toBottomOf="@id/reasonContainer"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintTop_toBottomOf="@id/reasonContainer" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/positive"
@@ -163,9 +163,9 @@
             android:text='@string/action_accept'
             android:textColor="@color/break_glass_color_selector"
             android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/reasonContainer"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintTop_toBottomOf="@id/reasonContainer" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3633)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code