### PR TITLE
fix: [ANDROAPP-3791] Map layers icon resized

### DIFF
--- a/app/src/main/res/drawable/ic_map_layers.xml
+++ b/app/src/main/res/drawable/ic_map_layers.xml
@@ -1,6 +1,5 @@
-<vector android:autoMirrored="true" android:height="44dp"
-    android:viewportHeight="44" android:viewportWidth="44"
-    android:width="44dp" xmlns:android="http://schemas.android.com/apk/res/android">
+<vector android:height="40dp" android:viewportHeight="44"
+    android:viewportWidth="44" android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#ffffff" android:pathData="M22,1L22,1A20,20 0,0 1,42 21L42,21A20,20 0,0 1,22 41L22,41A20,20 0,0 1,2 21L2,21A20,20 0,0 1,22 1z"/>
     <path android:fillColor="#2C98F0" android:pathData="M21.99,27.54L14.62,21.81L13,23.07L22,30.07L31,23.07L29.37,21.8L21.99,27.54ZM22,25L29.36,19.27L31,18L22,11L13,18L14.63,19.27L22,25ZM22,13.53L27.74,18L22,22.47L16.26,18L22,13.53Z"/>
 </vector>

--- a/app/src/main/res/layout-land/activity_search.xml
+++ b/app/src/main/res/layout-land/activity_search.xml
@@ -339,7 +339,7 @@
                     android:id="@+id/mapLayerButton"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="9dp"
                     android:layout_marginEnd="8dp"
                     android:visibility="gone"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -319,7 +319,7 @@
                     android:id="@+id/mapLayerButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="9dp"
                     android:layout_marginEnd="8dp"
                     android:visibility="gone"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_program_event_detail_map.xml
+++ b/app/src/main/res/layout/fragment_program_event_detail_map.xml
@@ -33,7 +33,7 @@
             android:id="@+id/mapLayerButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="9dp"
             android:layout_marginEnd="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3971](https://jira.dhis2.org/browse/ANDROAPP-3971)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code