### PR TITLE
fix: [ANDROAPP-3792] Legends text is cut even if there is enough room

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-03-04 11:36","gitSha":"aae7887a5"}
+{"buildTime":"2021-03-24 14:59","gitSha":"a8833b6af"}

--- a/app/src/main/java/org/dhis2/Bindings/Bindings.java
+++ b/app/src/main/java/org/dhis2/Bindings/Bindings.java
@@ -13,10 +13,12 @@ import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.text.method.ScrollingMovementMethod;
 import android.util.TypedValue;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -41,6 +43,7 @@ import org.dhis2.animations.ViewAnimationsKt;
 import org.dhis2.data.forms.dataentry.fields.KeyboardActionType;
 import org.dhis2.data.forms.dataentry.fields.LegendValue;
 import org.dhis2.data.forms.dataentry.fields.radiobutton.RadioButtonViewModel;
+import org.dhis2.databinding.DataElementLegendBinding;
 import org.dhis2.usescases.datasets.dataSetTable.dataSetSection.DataSetTableAdapter;
 import org.dhis2.usescases.programEventDetail.ProgramEventViewModel;
 import org.dhis2.utils.CatComboAdapter;
@@ -861,6 +864,19 @@ public class Bindings {
             ViewAnimationsKt.show(view);
         } else {
             ViewAnimationsKt.hide(view);
+        }
+    }
+
+    @BindingAdapter("legendBadge")
+    public static void setLegendBadge(FrameLayout legendLayout, LegendValue legendValue){
+        legendLayout.setVisibility(
+                legendValue != null ? View.VISIBLE : View.GONE
+        );
+        if(legendValue!=null){
+            DataElementLegendBinding legendBinding = DataElementLegendBinding.inflate(LayoutInflater.from(legendLayout.getContext()));
+            legendBinding.setLegend(legendValue);
+            legendLayout.removeAllViews();
+            legendLayout.addView(legendBinding.getRoot());
         }
     }
 }

--- a/app/src/main/res/layout/custom_text_view.xml
+++ b/app/src/main/res/layout/custom_text_view.xml
@@ -130,19 +130,18 @@
                 tools:visibility="visible" />
         </LinearLayout>
 
-        <include
+        <FrameLayout
             android:id="@+id/legendLabel"
-            layout="@layout/data_element_legend"
             android:layout_width="0dp"
-            android:layout_height="26dp"
+            android:layout_height="wrap_content"
             android:layout_marginEnd="12dp"
-            android:visibility="@{legend!=null?View.VISIBLE:View.GONE}"
+            app:legendBadge="@{legend}"
             app:layout_constraintBottom_toBottomOf="@id/textContainer"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/textContainer"
             app:layout_constraintWidth_default="percent"
             app:layout_constraintWidth_max="wrap"
-            app:layout_constraintWidth_percent="0.5"
-            app:legend="@{legend}" />
+            app:layout_constraintWidth_percent="0.5"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/form_spinner.xml
+++ b/app/src/main/res/layout/form_spinner.xml
@@ -122,21 +122,18 @@
                 app:srcCompat="@drawable/ic_close" />
         </LinearLayout>
 
-        <include
+        <FrameLayout
             android:id="@+id/legendLabel"
-            layout="@layout/data_element_legend"
             android:layout_width="0dp"
-            android:layout_height="26dp"
+            android:layout_height="wrap_content"
             android:layout_marginEnd="12dp"
-            android:visibility="@{legend!=null?View.VISIBLE:View.GONE}"
+            app:legendBadge="@{legend}"
             app:layout_constraintBottom_toBottomOf="@id/textContainer"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/textContainer"
             app:layout_constraintTop_toTopOf="@id/textContainer"
             app:layout_constraintWidth_default="percent"
             app:layout_constraintWidth_max="wrap"
-            app:layout_constraintWidth_percent="0.5"
-            app:legend="@{legend}" />
+            app:layout_constraintWidth_percent="0.5"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-3792)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code