### PR TITLE
fix: [ANDROAPP-3822] open keyboard on search for android <= 7

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/CustomTextView.java
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/fields/edittext/CustomTextView.java
@@ -59,6 +59,7 @@ import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 import static android.view.inputmethod.EditorInfo.IME_ACTION_NEXT;
 import static java.lang.String.valueOf;
 import static org.dhis2.Bindings.ViewExtensionsKt.closeKeyboard;
+import static org.dhis2.Bindings.ViewExtensionsKt.openKeyboard;
 
 
 public class CustomTextView extends FieldLayout {
@@ -136,6 +137,9 @@ public class CustomTextView extends FieldLayout {
             return false;
         });
         editText.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus && viewModel.isSearchMode()) {
+                openKeyboard(v);
+            }
             if (valueHasChanged()) {
                 if (validate()) {
                     inputLayout.setError(null);


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code