### PR TITLE
fix: Filter out RELATIONSHIP teis in search query

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensions.kt
@@ -2,6 +2,7 @@ package org.dhis2.Bindings
 
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper
+import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.period.DatePeriod
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
@@ -15,6 +16,7 @@ fun MutableList<TrackedEntityInstance>.filterDeletedEnrollment(
         while (iterator.hasNext()) {
             val tei = iterator.next()
             val isLocal = d2.trackedEntityModule().trackedEntityInstances()
+                .byState().neq(State.RELATIONSHIP)
                 .uid(tei.uid())
                 .blockingExists()
             val hasEnrollmentInProgram =

--- a/app/src/test/java/org/dhis2/bindings/TrackedEntityInstanceExtensions.kt
+++ b/app/src/test/java/org/dhis2/bindings/TrackedEntityInstanceExtensions.kt
@@ -9,6 +9,7 @@ import org.dhis2.Bindings.filterDeletedEnrollment
 import org.dhis2.Bindings.filterEvents
 import org.dhis2.Bindings.toDate
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.period.DatePeriod
@@ -43,6 +44,16 @@ class TrackedEntityInstanceExtensions {
         )
         whenever(
             d2.trackedEntityModule().trackedEntityInstances()
+                .byState().neq(State.RELATIONSHIP)
+        ) doReturn mock()
+        whenever(
+            d2.trackedEntityModule().trackedEntityInstances()
+                .byState().neq(State.RELATIONSHIP)
+                .uid(anyString())
+        ) doReturn mock()
+        whenever(
+            d2.trackedEntityModule().trackedEntityInstances()
+                .byState().neq(State.RELATIONSHIP)
                 .uid(anyString())
                 .blockingExists()
         ) doReturn true


### PR DESCRIPTION
## Description
Local teis marked as RELATIONSHIP might hide online teis in search query.

[ ANDROAPP-3827 ](https://jira.dhis2.org/browse/ANDROAPP-3827)

## Solution description
Do not consider RELATIONSHIP teis as valid teis.
## Covered unit test cases
--
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [X] 9.X - 10.X
- [ ] Other
## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code