### PR TITLE
fix: [ANDROAPP-3824] autogenerated fields remain non-editable when focusing on other fields. 

### DIFF
--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,2 +1,1 @@
-{"buildTime":"2021-03-26 10:04","gitSha":"ac355b27b"}
-
+{"buildTime":"2021-04-06 14:45","gitSha":"b9a475e94"}

--- a/app/src/main/assets/paperwork.json
+++ b/app/src/main/assets/paperwork.json
@@ -1,1 +1,1 @@
-{"buildTime":"2021-04-05 12:53","gitSha":"7945ef5ff"}
+{"buildTime":"2021-04-06 17:05","gitSha":"c8aeed468"}

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt
@@ -257,7 +257,7 @@ class EnrollmentPresenterImpl(
                                 }?.let { item ->
                                     itemList = list.updated(
                                         list.indexOf(item),
-                                        item.withValue(rowAction.value).withEditMode(true)
+                                        item.withValue(rowAction.value)
                                     )
                                 }
                             }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ ANDROAPP-3824](https://jira.dhis2.org/browse/ANDROAPP-3824)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code