### PR TITLE
fix: [ANDROAPP-3834] disable click on matrix elements when event is not editable

### DIFF
--- a/app/src/main/res/layout/form_image.xml
+++ b/app/src/main/res/layout/form_image.xml
@@ -20,6 +20,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clickable="@{viewModel.editable()}"
         android:onClick="@{()->viewModel.selectOption(option)}"
         tools:background="@color/colorPrimaryLightRed"
         tools:layout_height="200dp">

--- a/app/src/main/res/layout/matrix_option_set.xml
+++ b/app/src/main/res/layout/matrix_option_set.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-
         <variable
             name="item"
             type="org.dhis2.data.forms.dataentry.fields.visualOptionSet.MatrixOptionSetModel" />


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code