### PR TITLE
fix: [ANDROAPP-3837] Does not open keyboard automatically on OrgUnitDialog

### DIFF
--- a/app/src/main/java/org/dhis2/utils/customviews/OrgUnitDialog.java
+++ b/app/src/main/java/org/dhis2/utils/customviews/OrgUnitDialog.java
@@ -35,7 +35,7 @@ public class OrgUnitDialog extends DialogFragment {
     DialogOrgunitBinding binding;
     AndroidTreeView treeView;
     boolean isMultiSelection = false;
-    static OrgUnitDialog instace;
+    static OrgUnitDialog instance;
     private View.OnClickListener possitiveListener;
     private View.OnClickListener negativeListener;
     private TreeNode.TreeNodeClickListener nodeClickListener;
@@ -46,14 +46,14 @@ public class OrgUnitDialog extends DialogFragment {
     private String programUid;
 
     public static OrgUnitDialog getInstace() {
-        if (instace == null) {
-            instace = new OrgUnitDialog();
+        if (instance == null) {
+            instance = new OrgUnitDialog();
         }
-        return instace;
+        return instance;
     }
 
     public OrgUnitDialog() {
-        instace = null;
+        instance = null;
         isMultiSelection = false;
         possitiveListener = null;
         negativeListener = null;
@@ -192,13 +192,13 @@ public class OrgUnitDialog extends DialogFragment {
 
     @Override
     public void dismiss() {
-        instace = null;
+        instance = null;
         super.dismiss();
     }
 
     @Override
     public void onCancel(@NonNull DialogInterface dialog) {
-        instace = null;
+        instance = null;
         super.onCancel(dialog);
     }
 }

--- a/app/src/main/res/layout/dialog_orgunit.xml
+++ b/app/src/main/res/layout/dialog_orgunit.xml
@@ -9,7 +9,9 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3837](https://jira.dhis2.org/browse/ANDROAPP-3837)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code