### PR TITLE
fix: [ANDROAPP-4108] Add breadcrumb to log Event before crash

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventMapper.kt
@@ -9,6 +9,7 @@ import org.dhis2.data.tuples.Pair
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents.EventViewModel
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents.EventViewModelType
 import org.dhis2.utils.DateUtils
+import org.dhis2.utils.reporting.CrashReportController
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
@@ -18,11 +19,21 @@ import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 
-class ProgramEventMapper @Inject constructor(val d2: D2, val periodUtils: DhisPeriodUtils) {
+class ProgramEventMapper @Inject constructor(
+    val d2: D2,
+    val periodUtils: DhisPeriodUtils,
+    val crashReportController: CrashReportController
+) {
 
     fun eventToEventViewModel(event: Event): EventViewModel {
         val programStage =
             d2.programModule().programStages().uid(event.programStage()).blockingGet()
+
+        crashReportController.addBreadCrumb(
+            "ProgramEventMapper.eventToEventViewModel",
+            "Event: $event"
+        )
+
         return EventViewModel(
             EventViewModelType.EVENT,
             programStage,

--- a/app/src/main/java/org/dhis2/utils/reporting/CrashReportController.kt
+++ b/app/src/main/java/org/dhis2/utils/reporting/CrashReportController.kt
@@ -11,4 +11,6 @@ interface CrashReportController {
     fun logException(exception: Exception)
 
     fun logMessage(message: String)
+
+    fun addBreadCrumb(category: String, message: String)
 }

--- a/app/src/main/java/org/dhis2/utils/reporting/CrashReportControllerImpl.kt
+++ b/app/src/main/java/org/dhis2/utils/reporting/CrashReportControllerImpl.kt
@@ -1,5 +1,6 @@
 package org.dhis2.utils.reporting
 
+import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import javax.inject.Inject
 
@@ -27,6 +28,14 @@ class CrashReportControllerImpl @Inject constructor() : CrashReportController {
 
     override fun logMessage(message: String) {
 //        Sentry.captureMessage(message)
+    }
+
+    override fun addBreadCrumb(category: String, message: String) {
+        val breadcrumb = Breadcrumb()
+        breadcrumb.type = "info"
+        breadcrumb.category = category
+        breadcrumb.message = message
+        Sentry.addBreadcrumb(breadcrumb)
     }
 
     companion object {

--- a/app/src/test/java/org/dhis2/usescases/programEventDetail/ProgramEventMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/programEventDetail/ProgramEventMapperTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import java.util.Date
 import mock
 import org.dhis2.data.dhislogic.DhisPeriodUtils
+import org.dhis2.utils.reporting.CrashReportController
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
 import org.hisp.dhis.android.core.common.State
@@ -24,10 +25,11 @@ class ProgramEventMapperTest {
 
     private val d2: D2 = Mockito.mock(D2::class.java, RETURNS_DEEP_STUBS)
     private val periodUtil: DhisPeriodUtils = mock()
+    private val crashReportController: CrashReportController = mock()
 
     @Before
     fun setUp() {
-        mapper = ProgramEventMapper(d2, periodUtil)
+        mapper = ProgramEventMapper(d2, periodUtil, crashReportController)
     }
 
     @Test


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4108

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code