### PR TITLE
fix: [ANDROAPP-4255] indicators table header width not fixed

### DIFF
--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/table/GraphTableAdapter.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/table/GraphTableAdapter.kt
@@ -37,7 +37,7 @@ class GraphTableAdapter(context: Context) : AbstractTableAdapter<String, String,
         parent: ViewGroup,
         viewType: Int
     ): AbstractViewHolder = GraphTableHolder(
-        LayoutInflater.from(parent.context).inflate(R.layout.item_table_header, parent, false)
+        LayoutInflater.from(parent.context).inflate(R.layout.item_table_fixed_header, parent, false)
     )
     override fun onBindRowHeaderViewHolder(
         holder: AbstractViewHolder?,

--- a/tableview/src/main/res/layout/item_table_fixed_header.xml
+++ b/tableview/src/main/res/layout/item_table_fixed_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    android:layout_width="@dimen/default_row_header_width"
     android:layout_height="@dimen/small_column_header_height"
     android:orientation="horizontal">
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code