### PR TITLE
fix: [ANDROAPP-4256] display dataset indicators when there is no tables

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
@@ -251,6 +251,7 @@ class DataSetSectionFragment : FragmentGlobalAbstract(), DataValueContract.View 
             false
         )
         binding.tableLayout.addView(indicatorsTable)
+        binding.programProgress.visibility = View.GONE
     }
 
     override fun setSection(section: Section) {

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
@@ -3,7 +3,6 @@ package org.dhis2.usescases.datasets.dataSetTable.dataSetSection
 import androidx.annotation.VisibleForTesting
 import io.reactivex.Flowable
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.functions.Action
 import io.reactivex.functions.Function5
 import io.reactivex.functions.Function6
 import io.reactivex.processors.FlowableProcessor

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
@@ -3,6 +3,7 @@ package org.dhis2.usescases.datasets.dataSetTable.dataSetSection
 import androidx.annotation.VisibleForTesting
 import io.reactivex.Flowable
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.functions.Action
 import io.reactivex.functions.Function5
 import io.reactivex.functions.Function6
 import io.reactivex.processors.FlowableProcessor
@@ -186,12 +187,12 @@ class DataValuePresenter(
                         }
                     ).toObservable().blockingFirst()
                 }
+                .doOnComplete { getDataSetIndicators() }
                 .subscribeOn(schedulerProvider.io())
                 .observeOn(schedulerProvider.ui())
                 .subscribe(
                     { tableData ->
                         view.setTableData(tableData)
-                        getDataSetIndicators()
                     },
                     { Timber.e(it) }
                 )


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code