### PR TITLE
fix: [ANDROAPP-4254] OptionSet rendering type not showing in enrollment forms

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/EnrollmentRepository.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/EnrollmentRepository.kt
@@ -143,7 +143,13 @@ class EnrollmentRepository(
                     .byTrackedEntityAttribute().eq(attribute.uid())
                     .one().blockingGet()?.let { programTrackedEntityAttribute ->
                     val field = transform(programTrackedEntityAttribute, section.uid())
-                    if (
+                    if (field is OptionSetViewModel) {
+                        val options =
+                            d2.optionModule().options().byOptionSetUid().eq(field.optionSet())
+                                .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
+                                .blockingGet()
+                        fields.add(field.withOptions(options))
+                    } else if (
                         (index == section.attributes()!!.lastIndex) &&
                         field is EditTextViewModel &&
                         field.valueType() != ValueType.LONG_TEXT


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4254)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code