### PR TITLE
fix: [ANDROAPP-4241] don't overlap icon for DE on map

### DIFF
--- a/app/src/main/java/org/dhis2/uicomponents/map/camera/CameraExtension.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/camera/CameraExtension.kt
@@ -14,7 +14,7 @@ import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import org.dhis2.uicomponents.map.geometry.bound.GetBoundingBox
 
-const val DEFAULT_BOUND_PADDING = 500
+const val DEFAULT_BOUND_PADDING = 50
 const val DEFAULT_EASE_CAMERA_ANIM_DURATION = 1200
 
 fun MapboxMap.initCameraToViewAllElements(context: Context?, bounds: LatLngBounds) {

--- a/app/src/main/java/org/dhis2/uicomponents/map/layer/LayerConstants.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/layer/LayerConstants.kt
@@ -54,6 +54,7 @@ fun SymbolLayer.withDEIconAndTextProperties(): SymbolLayer = withProperties(
     PropertyFactory.iconAllowOverlap(true),
     PropertyFactory.textField(Expression.get(MapCoordinateFieldToFeatureCollection.FIELD_NAME)),
     PropertyFactory.textAllowOverlap(false),
+    PropertyFactory.textIgnorePlacement(true),
     PropertyFactory.textAnchor(Property.TEXT_ANCHOR_TOP),
     PropertyFactory.textRadialOffset(2f),
     PropertyFactory.textHaloWidth(1f),

--- a/app/src/main/java/org/dhis2/uicomponents/map/layer/types/FieldMapLayer.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/layer/types/FieldMapLayer.kt
@@ -1,11 +1,13 @@
 package org.dhis2.uicomponents.map.layer.types
 
 import com.mapbox.geojson.Feature
+import com.mapbox.geojson.FeatureCollection
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.style.expressions.Expression
 import com.mapbox.mapboxsdk.style.layers.Layer
 import com.mapbox.mapboxsdk.style.layers.Property
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory
+import com.mapbox.mapboxsdk.style.layers.PropertyValue
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import org.dhis2.uicomponents.map.geometry.TEI_UID
@@ -30,7 +32,7 @@ class FieldMapLayer(
         style.addLayer(pointLayer)
         style.addSource(GeoJsonSource(SELECTED_POINT_SOURCE_ID))
         style.addLayer(teiPointLayer)
-        style.addLayer(selectedPointLayer)
+        style.addLayerBelow(selectedPointLayer, POINT_LAYER_ID)
     }
 
     private val pointLayer: Layer

--- a/app/src/main/java/org/dhis2/uicomponents/map/layer/types/FieldMapLayer.kt
+++ b/app/src/main/java/org/dhis2/uicomponents/map/layer/types/FieldMapLayer.kt
@@ -1,13 +1,11 @@
 package org.dhis2.uicomponents.map.layer.types
 
 import com.mapbox.geojson.Feature
-import com.mapbox.geojson.FeatureCollection
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.style.expressions.Expression
 import com.mapbox.mapboxsdk.style.layers.Layer
 import com.mapbox.mapboxsdk.style.layers.Property
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory
-import com.mapbox.mapboxsdk.style.layers.PropertyValue
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import org.dhis2.uicomponents.map.geometry.TEI_UID


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code