### PR TITLE
fix: [ANDROAPP-4377] Aligns cell values to the right in analytics table chart

### DIFF
--- a/dhis_android_analytics/src/main/res/layout/analytics_table_cell.xml
+++ b/dhis_android_analytics/src/main/res/layout/analytics_table_cell.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:ellipsize="end"
-        android:gravity="center"
+        android:gravity="center|end"
         android:singleLine="true"
         android:textColor="@color/textPrimary"
         android:textSize="10sp"

--- a/dhis_android_analytics/src/main/res/layout/analytics_table_fixed_header.xml
+++ b/dhis_android_analytics/src/main/res/layout/analytics_table_fixed_header.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:ellipsize="end"
-        android:gravity="center"
+        android:gravity="start|center"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:singleLine="true"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4377](https://jira.dhis2.org/browse/ANDROAPP-4377)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code