### PR TITLE
fix: [ANDROAPP-4388] Resets search when coming from a previous succesful search in programs with displayInList()

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -293,6 +293,7 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
         teiMapManager.setOnMapClickListener(this);
 
         binding.showListBtn.setOnClickListener(view -> {
+            presenter.resetSearch();
             binding.messageContainer.setVisibility(GONE);
             binding.scrollView.setVisibility(View.VISIBLE);
             binding.progressLayout.setVisibility(GONE);

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEContractsModule.java
@@ -144,6 +144,8 @@ public class SearchTEContractsModule {
 
         void showFilterGeneral();
 
+        void resetSearch();
+
         void clearFilterClick();
 
         void closeFilterClick();

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenter.java
@@ -539,6 +539,13 @@ public class SearchTEPresenter implements SearchTEContractsModule.Presenter {
     }
 
     @Override
+    public void resetSearch() {
+        showList = true;
+        queryData.clear();
+        listDataProcessor.onNext(new Unit());
+    }
+
+    @Override
     public void onClearClick() {
         isSearching = true;
         queryData.clear();

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchTEPresenterTest.kt
@@ -379,6 +379,24 @@ class SearchTEPresenterTest {
         verify(view, times(1)).setFabIcon(any())
     }
 
+    @Test
+    fun `Should reset search when program has displayInList and a minAttributeRequired`() {
+        val program = Program.builder()
+            .uid("uid")
+            .displayFrontPageList(true)
+            .minAttributesRequiredToSearch(1)
+            .build()
+
+        presenter.setProgramForTesting(program)
+        presenter.program = program
+        presenter.queryData["uid"] = "value"
+        assertTrue(presenter.queryData.isNotEmpty())
+
+        presenter.resetSearch()
+
+        assertTrue(presenter.queryData.isEmpty())
+    }
+
     @After
     fun validate() {
         validateMockitoUsage()


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4388](https://jira.dhis2.org/browse/ANDROAPP-4388)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code