### PR TITLE
fix: [ANDROAPP-4416] Added top padding to the indicators table in datasets

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
@@ -245,6 +245,7 @@ class DataSetSectionFragment : FragmentGlobalAbstract(), DataValueContract.View 
         val adapter = DataSetIndicatorAdapter(requireContext())
         indicatorsTable?.adapter = adapter
         indicatorsTable?.headerCount = 1
+        indicatorsTable?.setPadding(0, 48.dp, 0, 0)
         val width = indicators.keys.toList().calculateWidth(requireContext()).second + 16.dp
         val max = resources.displayMetrics.widthPixels * 2 / 3
         indicatorsTable?.setRowHeaderWidth(if (width < max) width else max)


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4416](https://jira.dhis2.org/browse/ANDROAPP-4416)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code