### PR TITLE
fix: [ANDROAPP-4427] prevents from updating an event status when it is a ReadOnly event.

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialActivity.java
@@ -445,7 +445,11 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
                 binding.catComboLayout.getChildAt(i).findViewById(R.id.cat_combo).setEnabled(false);
             binding.orgUnit.setEnabled(false);
             binding.temp.setEnabled(false);
-            binding.actionButton.setText(getString(R.string.check_event));
+            if (presenter.isEventEditable()) {
+                binding.actionButton.setText(getString(R.string.action_close));
+            } else {
+                binding.actionButton.setText(getString(R.string.check_event));
+            }
             binding.executePendingBindings();
 
         }
@@ -778,7 +782,7 @@ public class EventInitialActivity extends ActivityGlobalAbstract implements Even
             binding.orgUnit.setEnabled(false);
             for (int i = 0; i < binding.catComboLayout.getChildCount(); i++)
                 binding.catComboLayout.getChildAt(i).findViewById(R.id.cat_combo).setEnabled(false);
-            binding.actionButton.setText(getString(R.string.check_event));
+            binding.actionButton.setText(getString(R.string.action_close));
             binding.executePendingBindings();
         }
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenter.java
@@ -315,16 +315,19 @@ public class EventInitialPresenter {
 
     public void editEvent(String trackedEntityInstance, String programStageModel, String eventUid, String date,
                           String orgUnitUid, String catComboUid, String catOptionCombo, Geometry geometry) {
-
-        compositeDisposable.add(
-                eventInitialRepository.editEvent(trackedEntityInstance, eventUid, date, orgUnitUid, catComboUid, catOptionCombo, geometry)
-                        .subscribeOn(schedulerProvider.io())
-                        .observeOn(schedulerProvider.ui())
-                        .subscribe(
-                                eventModel -> view.onEventUpdated(eventModel.uid()),
-                                error -> view.displayMessage(error.getLocalizedMessage())
-                        )
-        );
+        if (eventInitialRepository.getEditableStatus().blockingFirst() instanceof EventEditableStatus.NonEditable) {
+            view.onEventUpdated(eventUid);
+        } else {
+            compositeDisposable.add(
+                    eventInitialRepository.editEvent(trackedEntityInstance, eventUid, date, orgUnitUid, catComboUid, catOptionCombo, geometry)
+                            .subscribeOn(schedulerProvider.io())
+                            .observeOn(schedulerProvider.ui())
+                            .subscribe(
+                                    eventModel -> view.onEventUpdated(eventModel.uid()),
+                                    error -> view.displayMessage(error.getLocalizedMessage())
+                            )
+            );
+        }
     }
 
     public void onDateClick(@Nullable DatePickerDialog.OnDateSetListener listener) {

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenter.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenter.java
@@ -315,9 +315,7 @@ public class EventInitialPresenter {
 
     public void editEvent(String trackedEntityInstance, String programStageModel, String eventUid, String date,
                           String orgUnitUid, String catComboUid, String catOptionCombo, Geometry geometry) {
-        if (eventInitialRepository.getEditableStatus().blockingFirst() instanceof EventEditableStatus.NonEditable) {
-            view.onEventUpdated(eventUid);
-        } else {
+        if (isEventEditable()) {
             compositeDisposable.add(
                     eventInitialRepository.editEvent(trackedEntityInstance, eventUid, date, orgUnitUid, catComboUid, catOptionCombo, geometry)
                             .subscribeOn(schedulerProvider.io())
@@ -327,6 +325,8 @@ public class EventInitialPresenter {
                                     error -> view.displayMessage(error.getLocalizedMessage())
                             )
             );
+        } else {
+            view.onEventUpdated(eventUid);
         }
     }
 
@@ -486,5 +486,9 @@ public class EventInitialPresenter {
 
     public void onEventCreated() {
         matomoAnalyticsController.trackEvent(EVENT_LIST, CREATE_EVENT, CLICK);
+    }
+
+    public boolean isEventEditable() {
+        return eventInitialRepository.getEditableStatus().blockingFirst() instanceof EventEditableStatus.Editable;
     }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4427](https://jira.dhis2.org/browse/ANDROAPP-4427)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code