### PR TITLE
fix: [ANDROAPP-4433] Isolates JCenter-only dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     repositories {
         google()
         mavenLocal()
-        jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
     dependencies {
@@ -31,7 +30,17 @@ apply from: 'buildsystem/dependencies.gradle'
 allprojects {
     repositories {
         google()
-        jcenter()
+        jcenter() {
+            content {
+                includeModule('de.adorsys.android', 'securestoragelibrary')
+                includeModule('com.facebook.flipper', 'flipper-leakcanary-plugin')
+                includeModule('com.andrognito.pinlockview', 'pinlockview')
+                includeModule('me.toptas.fancyshowcase', 'fancyshowcaseview')
+                includeModule('org.matomo.sdk', 'tracker')
+                includeModule('com.journeyapps', 'zxing-android-embedded')
+                includeGroup('co.infinum')
+            }
+        }
         mavenCentral()
         maven {
             url 'https://maven.google.com'


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4433](https://jira.dhis2.org/browse/ANDROAPP-4433)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code