### PR TITLE
fix: [ANDROAPP-4439] Prevents NPE crash when opening a relationship that is not local data

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/relationships/RelationshipPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/relationships/RelationshipPresenter.kt
@@ -200,7 +200,7 @@ class RelationshipPresenter internal constructor(
         } else {
             view.showRelationshipNotFoundError(
                 d2.trackedEntityModule()
-                    .trackedEntityTypes().uid(teiType).blockingGet()!!.displayName() ?: ""
+                    .trackedEntityTypes().uid(teiType).blockingGet()?.displayName() ?: ""
             )
         }
     }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4439](https://jira.dhis2.org/browse/ANDROAPP-4439)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code