### PR TITLE
fix: [ANDROAPP-4481] Fix crash in event and multi-section enrollment fields

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/EnrollmentRepository.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/EnrollmentRepository.kt
@@ -144,7 +144,9 @@ class EnrollmentRepository(
                         .byProgram().eq(programUid)
                         .byTrackedEntityAttribute().eq(attribute.uid())
                         .one().blockingGet()?.let { programTrackedEntityAttribute ->
-                        transform(programTrackedEntityAttribute, section.uid())
+                        fields.add(
+                            transform(programTrackedEntityAttribute, section.uid())
+                        )
                     }
                 }
             }

--- a/app/src/test/java/org/dhis2/utils/RulesUtilsProviderImplTest.kt
+++ b/app/src/test/java/org/dhis2/utils/RulesUtilsProviderImplTest.kt
@@ -1,12 +1,12 @@
 package org.dhis2.utils
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Flowable
 import java.util.ArrayList
 import org.dhis2.data.forms.dataentry.fields.FieldViewModelFactory
 import org.dhis2.data.forms.dataentry.fields.FieldViewModelFactoryImpl
@@ -182,9 +182,11 @@ class RulesUtilsProviderImplTest {
             )
         )
 
-        whenever(valueStore.save(testingUid, null, null)) doReturn StoreResult(
-            testingUid,
-            ValueStoreResult.VALUE_CHANGED
+        whenever(valueStore.saveWithTypeCheck(testingUid, null)) doReturn Flowable.just(
+            StoreResult(
+                testingUid,
+                ValueStoreResult.VALUE_CHANGED
+            )
         )
 
         val result = ruleUtils.applyRuleEffects(
@@ -195,7 +197,7 @@ class RulesUtilsProviderImplTest {
         )
 
         Assert.assertFalse(testFieldViewModels.contains(testingUid))
-        verify(valueStore, times(1)).save(testingUid, null, null)
+        verify(valueStore, times(1)).saveWithTypeCheck(testingUid, null)
         assertTrue(result.fieldsToUpdate.contains(testingUid))
     }
 
@@ -292,7 +294,7 @@ class RulesUtilsProviderImplTest {
             valueStore
         )
 
-        verify(valueStore, times(1)).save(testingUid, "data", null)
+        verify(valueStore, times(1)).saveWithTypeCheck(testingUid, "data")
         assertTrue(testFieldViewModels[testingUid]!!.value.equals("data"))
         assertTrue(!testFieldViewModels[testingUid]!!.editable)
     }
@@ -317,11 +319,12 @@ class RulesUtilsProviderImplTest {
             )
         )
 
-        whenever(valueStore.save(any(), any(), anyOrNull())) doReturn
+        whenever(valueStore.saveWithTypeCheck(any(), any())) doReturn Flowable.just(
             StoreResult(
                 testingUid,
                 ValueStoreResult.VALUE_CHANGED
             )
+        )
 
         val result = ruleUtils.applyRuleEffects(
             true,
@@ -330,8 +333,8 @@ class RulesUtilsProviderImplTest {
             valueStore
         )
 
-        verify(valueStore, times(1)).save(testingUid, "data", null)
-        verify(valueStore, times(0)).save(testingUid2, "test", null)
+        verify(valueStore, times(1)).saveWithTypeCheck(testingUid, "data")
+        verify(valueStore, times(0)).saveWithTypeCheck(testingUid2, "test")
         assertTrue(testFieldViewModels[testingUid]!!.value.equals("data"))
         assertTrue(testFieldViewModels[testingUid2]!!.value.equals("test"))
         assertTrue(!testFieldViewModels[testingUid]!!.editable)

--- a/form/src/main/java/org/dhis2/form/data/FormValueStore.kt
+++ b/form/src/main/java/org/dhis2/form/data/FormValueStore.kt
@@ -1,10 +1,12 @@
 package org.dhis2.form.data
 
+import io.reactivex.Flowable
 import org.dhis2.form.model.StoreResult
 
 interface FormValueStore {
 
     fun save(uid: String, value: String?, extraData: String?): StoreResult
+    fun saveWithTypeCheck(uid: String, value: String?): Flowable<StoreResult>
     fun deleteOptionValues(optionCodeValuesToDelete: List<String>)
     fun deleteOptionValueIfSelected(field: String, optionUid: String): StoreResult
     fun deleteOptionValueIfSelectedInGroup(

--- a/form/src/main/java/org/dhis2/form/data/RulesUtilsProviderImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/RulesUtilsProviderImpl.kt
@@ -164,9 +164,7 @@ class RulesUtilsProviderImpl(val d2: D2) : RulesUtilsProvider {
     }
 
     private fun saveForEvent(uid: String, value: String?): ValueStoreResult {
-        /*return valueStore?.saveWithTypeCheck(uid, value)?.blockingFirst()?.valueStoreResult
-            ?: ValueStoreResult.VALUE_HAS_NOT_CHANGED*/
-        return valueStore?.save(uid, value, null)?.valueStoreResult
+        return valueStore?.saveWithTypeCheck(uid, value)?.blockingFirst()?.valueStoreResult
             ?: ValueStoreResult.VALUE_HAS_NOT_CHANGED
     }
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4481)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code