### PR TITLE
refactor: [ANDROAPP-4433] migrates flipper from jcenter to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ allprojects {
         jcenter() {
             content {
                 includeModule('de.adorsys.android', 'securestoragelibrary')
-                includeModule('com.facebook.flipper', 'flipper-leakcanary-plugin')
                 includeModule('com.andrognito.pinlockview', 'pinlockview')
                 includeModule('me.toptas.fancyshowcase', 'fancyshowcaseview')
                 includeModule('org.matomo.sdk', 'tracker')

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -64,11 +64,11 @@ ext {
 
             //Debug
             timber                    : "4.7.1",
-            flipper                   : "0.72.0",
-            flippernoop               : "0.72.0",
+            flipper                   : "0.75.1",
+            flippernoop               : "0.75.1",
             soloader                  : "0.9.0",
-            flippernetwork            : "0.72.0",
-            flipperleak               : "0.72.0",
+            flippernetwork            : "0.75.1",
+            flipperleak               : "0.75.1",
             leakcannary               : "1.6.1",
             leakcannarynoop           : "1.6.1",
             rxlint                    : "1.6",


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4433](https://jira.dhis2.org/browse/ANDROAPP-4433)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code