### PR TITLE
fix: [ANDROAPP-4260] Selects the first image field as profile image of a tei

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/Extensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/Extensions.kt
@@ -77,6 +77,7 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
     } else {
         null
     }
+
     if (attributeValue != null) {
         val fileResource =
             d2.fileResourceModule().fileResources().uid(attributeValue.value()).blockingGet()

--- a/app/src/main/java/org/dhis2/Bindings/Extensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/Extensions.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.MutableLiveData
 import org.dhis2.App
 import org.dhis2.data.user.UserComponent
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 
@@ -33,15 +34,27 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
         .byTrackedEntityTypeUid().eq(trackedEntityType())
         .byDisplayInList().isTrue
         .byTrackedEntityAttributeUid().`in`(imageAttributes)
+        .bySortOrder().isNotNull
         .blockingGet().map { it.trackedEntityAttribute()?.uid() }
 
     if (attributes.isEmpty() && programUid != null) {
-        attributes = d2.programModule().programTrackedEntityAttributes()
-            .byDisplayInList().isTrue
-            .byProgram().eq(programUid)
-            .byTrackedEntityAttribute().`in`(imageAttributes)
-            .blockingGet().filter { it.trackedEntityAttribute() != null }
-            .map { it.trackedEntityAttribute()!!.uid() }
+        val sections = d2.programModule().programSections().withAttributes().byProgramUid()
+            .eq(programUid).blockingGet()
+        attributes = if (sections.isEmpty()) {
+            d2.programModule().programTrackedEntityAttributes()
+                .byDisplayInList().isTrue
+                .byProgram().eq(programUid)
+                .byTrackedEntityAttribute().`in`(imageAttributes)
+                .blockingGet().filter { it.trackedEntityAttribute() != null }
+                .map { it.trackedEntityAttribute()!!.uid() }
+        } else {
+            d2.programModule().programSections().withAttributes().byProgramUid().eq(programUid)
+                .blockingGet()
+                .mapNotNull { section ->
+                    section.attributes()?.filter { imageAttributes.contains(it.uid()) }
+                        ?.map { it.uid() }
+                }.flatten()
+        }
     } else if (attributes.isEmpty() && programUid == null) {
         val enrollmentProgramUids = d2.enrollmentModule().enrollments()
             .byTrackedEntityInstance().eq(uid())
@@ -50,15 +63,20 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
             .byDisplayInList().isTrue
             .byProgram().`in`(enrollmentProgramUids)
             .byTrackedEntityAttribute().`in`(imageAttributes)
+            .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
             .blockingGet().filter { it.trackedEntityAttribute() != null }
             .map { it.trackedEntityAttribute()!!.uid() }
     }
 
-    val attributeValue = d2.trackedEntityModule().trackedEntityAttributeValues()
-        .byTrackedEntityInstance().eq(uid())
-        .byTrackedEntityAttribute().`in`(attributes)
-        .byValue().isNotNull
-        .one().blockingGet()
+    val attributeValue = if (attributes.isNotEmpty()) {
+        d2.trackedEntityModule().trackedEntityAttributeValues()
+            .byTrackedEntityInstance().eq(uid())
+            .byTrackedEntityAttribute().`in`(attributes[0])
+            .byValue().isNotNull
+            .one().blockingGet()
+    } else {
+        null
+    }
     if (attributeValue != null) {
         val fileResource =
             d2.fileResourceModule().fileResources().uid(attributeValue.value()).blockingGet()


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4260](https://jira.dhis2.org/browse/ANDROAPP-4260)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code