### PR TITLE
feat: [ANDROAPP-3016] Resize arrow prevents reducing more than a minimum size and are aligned to the left

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@
 /app/dhis_keystore.jks
 /app/src/main/res/raw/testing_credentials.json
 /venv
-/.bitrise.secrets.yml
+/*.secrets.yml
 /gradle.deps

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetSectionFragment.kt
@@ -16,6 +16,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.evrencoskun.tableview.TableView
+import com.evrencoskun.tableview.adapter.recyclerview.CellRecyclerView
 import com.evrencoskun.tableview.adapter.recyclerview.holder.AbstractViewHolder
 import com.evrencoskun.tableview.adapter.recyclerview.holder.AbstractViewHolder.SelectionState.UNSELECTED
 import io.reactivex.Flowable
@@ -294,57 +295,44 @@ class DataSetSectionFragment : FragmentGlobalAbstract(), DataValueContract.View 
                     (binding.headerContainer.childCount - 2) *
                     binding.headerContainer.getChildAt(0).layoutParams.height
             }
-            cornerView.findViewById<View>(R.id.buttonRowScaleAdd).setOnClickListener {
-                for (i in 0 until binding.tableLayout.childCount) {
-                    if (binding.tableLayout.getChildAt(i) is TableView) {
-                        val table = binding.tableLayout.getChildAt(i) as TableView
-                        if (table.adapter is DataSetTableAdapter) {
-                            val adapter = table.adapter as DataSetTableAdapter
-                            adapter.scaleRowWidth(true)
-                            val params = cornerView.layoutParams
-                            params.width = adapter.rowHeaderWidth
-                            cornerView.layoutParams = params
-                            if (i == 0) {
-                                presenterFragment.saveCurrentSectionMeasures(
-                                    adapter.rowHeaderWidth,
-                                    adapter.columnHeaderHeight
-                                )
-                                val scrollPos = table.scrollHandler.columnPosition
-                                table.scrollToColumnPosition(scrollPos)
-                                for (rv in rvs) {
-                                    rv.layoutManager!!.scrollToPosition(scrollPos)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            cornerView.findViewById<View>(R.id.buttonRowScaleMinus).setOnClickListener { view ->
-                for (i in 0 until binding.tableLayout.childCount) {
-                    if (binding.tableLayout.getChildAt(i) is TableView) {
-                        val table = binding.tableLayout.getChildAt(i) as TableView
-                        if (table.adapter is DataSetTableAdapter) {
-                            val adapter = table.adapter as DataSetTableAdapter
-                            adapter.scaleRowWidth(false)
-                            val params = cornerView.layoutParams
-                            params.width = adapter.rowHeaderWidth
-                            cornerView.layoutParams = params
-                            if (i == 0) {
-                                presenterFragment.saveCurrentSectionMeasures(
-                                    adapter.rowHeaderWidth,
-                                    adapter.columnHeaderHeight
-                                )
-                                val scrollPos = table.scrollHandler.columnPosition
-                                table.scrollToColumnPosition(scrollPos)
-                                for (rv in rvs) {
-                                    rv.layoutManager!!.scrollToPosition(scrollPos)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+
+            val buttonAddWidth = cornerView.findViewById<View>(R.id.buttonRowScaleAdd)
+            val buttonMinusWidth = cornerView.findViewById<View>(R.id.buttonRowScaleMinus)
+
+            buttonAddWidth.setOnClickListener { resizeHeaderRowWidth(true, cornerView, rvs) }
+            buttonMinusWidth.setOnClickListener { resizeHeaderRowWidth(false, cornerView, rvs) }
+
             binding.headerContainer.addView(cornerView)
+        }
+    }
+
+    private fun resizeHeaderRowWidth(
+        add: Boolean,
+        cornerView: View,
+        rvs: MutableList<CellRecyclerView>
+    ) {
+        for (i in 0 until binding.tableLayout.childCount) {
+            if (binding.tableLayout.getChildAt(i) is TableView) {
+                val table = binding.tableLayout.getChildAt(i) as TableView
+                if (table.adapter is DataSetTableAdapter) {
+                    val adapter = table.adapter as DataSetTableAdapter
+                    adapter.scaleRowWidth(add)
+                    val params = cornerView.layoutParams
+                    params.width = adapter.rowHeaderWidth
+                    cornerView.layoutParams = params
+                    if (i == 0) {
+                        presenterFragment.saveCurrentSectionMeasures(
+                            adapter.rowHeaderWidth,
+                            adapter.columnHeaderHeight
+                        )
+                        val scrollPos = table.scrollHandler.columnPosition
+                        table.scrollToColumnPosition(scrollPos)
+                        for (rv in rvs) {
+                            rv.layoutManager!!.scrollToPosition(scrollPos)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetTableAdapter.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataSetTableAdapter.java
@@ -137,7 +137,10 @@ public class DataSetTableAdapter extends AbstractTableAdapter<CategoryOption, Da
         if (add) {
             rowWidth += 50;
         } else {
-            rowWidth -= 50;
+            int minRowHeaderWidth = (int) context.getResources().getDimension(R.dimen.row_header_min_width);
+            if (rowWidth - 50 > minRowHeaderWidth) {
+                rowWidth -= 50;
+            }
         }
 
         Triple<String, Integer, Integer> measures =

--- a/app/src/main/res/layout/table_view_corner_layout.xml
+++ b/app/src/main/res/layout/table_view_corner_layout.xml
@@ -13,7 +13,7 @@
         android:layout_height="wrap_content"
         app:tint="@color/colorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/buttonRowScaleAdd"
+        app:layout_constraintStart_toStartOf="parent"
         app:srcCompat="@drawable/ic_reduce_width" />
 
     <ImageView
@@ -23,15 +23,7 @@
         android:layout_height="wrap_content"
         app:tint="@color/colorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/buttonRowScaleMinus"
         app:srcCompat="@drawable/ic_increase_width" />
-
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dp"
-        android:background="@color/colorPrimaryLight"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,4 +26,5 @@ http://developer.android.com/guide/topics/appwidgets/index.html#CreatingLayout
     <dimen name="item_carousel_height">72dp</dimen>
     <dimen name="item_carousel_corner_radius">6dp</dimen>
     <dimen name="padding_16">16dp</dimen>
+    <dimen name="row_header_min_width">90dp</dimen>
 </resources>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-3016](https://jira.dhis2.org/browse/ANDROAPP-3016)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code