### PR TITLE
fix: [ANDROAPP-4581] Avoid navigate during activity recreation

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailActivity.java
@@ -71,6 +71,7 @@ public class ProgramEventDetailActivity extends ActivityGlobalAbstract implement
 
     private boolean backDropActive;
     private String programUid;
+    private boolean recreationActivity = false;
 
     public static final String EXTRA_PROGRAM_UID = "PROGRAM_UID";
     private ProgramEventDetailViewModel programEventsViewModel;
@@ -146,8 +147,11 @@ public class ProgramEventDetailActivity extends ActivityGlobalAbstract implement
         });
 
         programEventsViewModel.getEventClicked().observe(this, eventData -> {
-            if (eventData != null) {
+            if (eventData != null && !programEventsViewModel.getRecreationActivity()) {
+                programEventsViewModel.onRecreationActivity(false);
                 navigateToEvent(eventData.component1(), eventData.component2());
+            } else if (programEventsViewModel.getRecreationActivity()){
+                programEventsViewModel.onRecreationActivity(false);
             }
         });
 
@@ -187,6 +191,14 @@ public class ProgramEventDetailActivity extends ActivityGlobalAbstract implement
                 })
                 .build();
         syncDialog.show(getSupportFragmentManager(), "EVENT_SYNC");
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (isChangingConfigurations()) {
+            programEventsViewModel.onRecreationActivity(true);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailActivity.java
@@ -71,7 +71,6 @@ public class ProgramEventDetailActivity extends ActivityGlobalAbstract implement
 
     private boolean backDropActive;
     private String programUid;
-    private boolean recreationActivity = false;
 
     public static final String EXTRA_PROGRAM_UID = "PROGRAM_UID";
     private ProgramEventDetailViewModel programEventsViewModel;

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailViewModel.kt
@@ -11,6 +11,7 @@ class ProgramEventDetailViewModel : ViewModel() {
     val eventSyncClicked = MutableLiveData<String?>(null)
     val eventClicked = MutableLiveData<Pair<String, String>?>(null)
     var updateEvent: String? = null
+    var recreationActivity: Boolean = false
     enum class EventProgramScreen {
         LIST, MAP, ANALYTICS
     }
@@ -34,5 +35,9 @@ class ProgramEventDetailViewModel : ViewModel() {
 
     fun showAnalytics() {
         _currentScreen.value = EventProgramScreen.ANALYTICS
+    }
+
+    fun onRecreationActivity(isRecreating: Boolean) {
+        recreationActivity = isRecreating
     }
 }


### PR DESCRIPTION
## Description
Solution by google
https://developer.android.com/codelabs/kotlin-android-training-live-data#6

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code