### PR TITLE
fix: Add requireContext() for FileResourceDirectoryHelper

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
@@ -706,7 +706,9 @@ class FormView(
                                 requireContext(),
                                 BuildConfig.APPLICATION_ID + ".provider",
                                 File(
-                                    FileResourceDirectoryHelper.getFileResourceDirectory(requireContext()),
+                                    FileResourceDirectoryHelper.getFileResourceDirectory(
+                                        requireContext()
+                                    ),
                                     "tempFile.png"
                                 )
                             )

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
@@ -706,7 +706,7 @@ class FormView(
                                 requireContext(),
                                 BuildConfig.APPLICATION_ID + ".provider",
                                 File(
-                                    FileResourceDirectoryHelper.getFileResourceDirectory(context),
+                                    FileResourceDirectoryHelper.getFileResourceDirectory(requireContext()),
                                     "tempFile.png"
                                 )
                             )


### PR DESCRIPTION
## Description
Related to [this PR in the SDK](https://github.com/dhis2/dhis2-android-sdk/pull/1737). The FileResourceDirectoryHelper has been migrated to kotlin and expects a NonNull context. This was not considered a breaking change because the context must be NonNull before as well, but it was not imposed by an annotation in Java.

[ANDROSDK-1494](https://jira.dhis2.org/browse/ANDROSDK-1494)

## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [X] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code