### PR TITLE
fix: [ANDROAPP-653] Correctly clears username field when trying to add a new account and the field was previously filled.

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
@@ -472,13 +472,7 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
 
     private fun setAccount(serverUrl: String?, userName: String?, wasAccountClicked: Boolean) {
         serverUrl?.let { binding.serverUrlEdit.setText(it) }
-
-        if (userName != null) {
-            binding.userNameEdit.setText(userName)
-        } else {
-            binding.userNameEdit.setText("")
-        }
-
+        binding.userNameEdit.setText(userName ?: "")
         binding.userPassEdit.text = null
         if (wasAccountClicked) {
             binding.serverUrlEdit.isEnabled = false

--- a/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
@@ -472,7 +472,13 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
 
     private fun setAccount(serverUrl: String?, userName: String?, wasAccountClicked: Boolean) {
         serverUrl?.let { binding.serverUrlEdit.setText(it) }
-        userName?.let { binding.userNameEdit.setText(it) }
+
+        if (userName != null) {
+            binding.userNameEdit.setText(userName)
+        } else {
+            binding.userNameEdit.setText("")
+        }
+
         binding.userPassEdit.text = null
         if (wasAccountClicked) {
             binding.serverUrlEdit.isEnabled = false


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-653](https://jira.dhis2.org/browse/ANDROAPP-653)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code