### PR TITLE
fix: [ANDROAPP-4331] Granular sync button display in dataset detail screen only.

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.view.ViewCompat;
 import androidx.databinding.DataBindingUtil;
+import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.shape.CornerFamily;
@@ -213,6 +214,17 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
         binding.viewPager.setUserInputEnabled(false);
         binding.viewPager.setAdapter(viewPagerAdapter);
         binding.viewPager.setOffscreenPageLimit(MAX_ITEM_CACHED_VIEWPAGER2);
+        binding.viewPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
+            @Override
+            public void onPageSelected(int position) {
+                if (position == 0) {
+                    binding.syncButton.setVisibility(View.VISIBLE);
+                } else {
+                    binding.syncButton.setVisibility(View.GONE);
+                }
+            }
+        });
+
         new TabLayoutMediator(binding.tabLayout, binding.viewPager, (tab, position) -> {
             if (position == 0) {
                 tab.setText(R.string.dataset_overview);

--- a/app/src/main/res/layout/activity_dataset_table.xml
+++ b/app/src/main/res/layout/activity_dataset_table.xml
@@ -60,7 +60,7 @@
                     <ImageView
                         android:id="@+id/syncButton"
                         style="@style/ActionIcon"
-                        android:onClick="showMoreOptions"
+                        android:visibility="gone"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toStartOf="@id/moreOptions"
                         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4331](https://jira.dhis2.org/browse/ANDROAPP-4331)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code