### PR TITLE
fix: [ANDROAPP-4671] Re-open a data set from the details screen duplicates fields

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetTableActivity.java
@@ -1,7 +1,6 @@
 package org.dhis2.usescases.datasets.dataSetTable;
 
 import static org.dhis2.commons.extensions.ViewExtensionsKt.closeKeyboard;
-import static org.dhis2.utils.Constants.NO_SECTION;
 import static org.dhis2.utils.analytics.AnalyticsConstants.CLICK;
 import static org.dhis2.utils.analytics.AnalyticsConstants.SHOW_HELP;
 
@@ -43,7 +42,6 @@ import org.dhis2.usescases.datasets.dataSetTable.dataSetSection.DataSetSection;
 import org.dhis2.usescases.datasets.dataSetTable.dataSetSection.DataSetSectionKt;
 import org.dhis2.usescases.general.ActivityGlobalAbstract;
 import org.dhis2.utils.Constants;
-import org.dhis2.utils.granularsync.GranularSyncContracts;
 import org.dhis2.utils.granularsync.SyncStatusDialog;
 import org.dhis2.utils.validationrules.ValidationResultViolationsAdapter;
 import org.dhis2.utils.validationrules.Violation;
@@ -56,8 +54,6 @@ import java.util.Locale;
 import javax.inject.Inject;
 
 import io.reactivex.Observable;
-import io.reactivex.processors.FlowableProcessor;
-import io.reactivex.processors.PublishProcessor;
 import kotlin.Unit;
 
 public class DataSetTableActivity extends ActivityGlobalAbstract implements DataSetTableContract.View {
@@ -83,7 +79,6 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
     private DataSetTableComponent dataSetTableComponent;
 
     private BottomSheetBehavior<View> behavior;
-    private FlowableProcessor<Boolean> reopenProcessor;
     private boolean isKeyboardOpened = false;
 
     private static final int MAX_ITEM_CACHED_VIEWPAGER2 = 2;
@@ -118,7 +113,6 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
         catOptCombo = getIntent().getStringExtra(Constants.CAT_COMB);
         dataSetUid = getIntent().getStringExtra(Constants.DATA_SET_UID);
         accessDataWrite = getIntent().getBooleanExtra(Constants.ACCESS_DATA, true);
-        reopenProcessor = PublishProcessor.create();
 
         dataSetTableComponent = ((App) getApplicationContext()).userComponent()
                 .plus(new DataSetTableModule(this,
@@ -553,7 +547,6 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
     public void displayReopenedMessage(boolean done) {
         if (done) {
             Toast.makeText(this, R.string.action_done, Toast.LENGTH_SHORT).show();
-            reopenProcessor.onNext(true);
         }
 
     }
@@ -578,9 +571,5 @@ public class DataSetTableActivity extends ActivityGlobalAbstract implements Data
                 Toast.LENGTH_SHORT
         ).show();
         finish();
-    }
-
-    public FlowableProcessor<Boolean> observeReopenChanges() {
-        return reopenProcessor;
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailFragment.kt
@@ -6,6 +6,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
 import org.dhis2.R
 import org.dhis2.commons.date.toDateSpan
 import org.dhis2.commons.resources.ColorUtils
@@ -20,9 +23,6 @@ import org.hisp.dhis.android.core.common.ObjectStyle
 import org.hisp.dhis.android.core.dataset.DataSetInstance
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.period.PeriodType
-import java.util.Date
-import java.util.Locale
-import javax.inject.Inject
 
 const val DATASET_UID = "DATASET_UID"
 const val DATASET_ACCESS = "DATASET_ACCESS"

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailFragment.kt
@@ -6,10 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import io.reactivex.Flowable
-import java.util.Date
-import java.util.Locale
-import javax.inject.Inject
 import org.dhis2.R
 import org.dhis2.commons.date.toDateSpan
 import org.dhis2.commons.resources.ColorUtils
@@ -24,6 +20,9 @@ import org.hisp.dhis.android.core.common.ObjectStyle
 import org.hisp.dhis.android.core.dataset.DataSetInstance
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.period.PeriodType
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
 
 const val DATASET_UID = "DATASET_UID"
 const val DATASET_ACCESS = "DATASET_ACCESS"
@@ -160,9 +159,5 @@ class DataSetDetailFragment private constructor() : FragmentGlobalAbstract(), Da
                 iconResource = imageResource
             )
         )
-    }
-
-    override fun observeReopenChanges(): Flowable<Boolean> {
-        return activity.observeReopenChanges()
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailPresenter.kt
@@ -75,16 +75,6 @@ class DataSetDetailPresenter(
                     { error -> Timber.d(error) }
                 )
         )
-
-        disposable.add(
-            view.observeReopenChanges()
-                .subscribeOn(schedulers.io())
-                .observeOn(schedulers.io())
-                .subscribe(
-                    { updateProcessor.onNext(Unit) },
-                    { Timber.e(it) }
-                )
-        )
     }
 
     fun detach() {

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailView.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetDetail/DataSetDetailView.kt
@@ -1,6 +1,5 @@
 package org.dhis2.usescases.datasets.dataSetTable.dataSetDetail
 
-import io.reactivex.Flowable
 import org.hisp.dhis.android.core.common.ObjectStyle
 import org.hisp.dhis.android.core.dataset.DataSetInstance
 import org.hisp.dhis.android.core.period.Period
@@ -14,5 +13,4 @@ interface DataSetDetailView {
     )
     fun hideCatOptCombo()
     fun setStyle(style: ObjectStyle?)
-    fun observeReopenChanges(): Flowable<Boolean>
 }

--- a/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/dataSetTable/dataSetDetail/DataSetDetailPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/datasets/dataSetTable/dataSetTable/dataSetDetail/DataSetDetailPresenterTest.kt
@@ -48,7 +48,6 @@ class DataSetDetailPresenterTest {
         whenever(repository.getPeriod()) doReturn Single.just(defaultPeriod)
         whenever(repository.isComplete()) doReturn Single.just(false)
         whenever(repository.getDataSet()) doReturn Single.just(defaultDataSet)
-        whenever(view.observeReopenChanges()) doReturn Flowable.empty()
 
         presenter.init()
 
@@ -64,7 +63,6 @@ class DataSetDetailPresenterTest {
         whenever(repository.getPeriod()) doReturn Single.just(defaultPeriod)
         whenever(repository.isComplete()) doReturn Single.just(false)
         whenever(repository.getDataSet()) doReturn Single.just(defaultDataSet)
-        whenever(view.observeReopenChanges()) doReturn Flowable.empty()
 
         presenter.init()
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4671)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code