### PR TITLE
feat: [ANDROAPP-1655] Only show troubleshooting option in release apk

### DIFF
--- a/app/src/debug/res/menu/main_menu.xml
+++ b/app/src/debug/res/menu/main_menu.xml
@@ -46,6 +46,9 @@
     <group
         android:id="@+id/extra_section"
         android:checkableBehavior="single">
+        <item android:id="@+id/menu_troubleshooting"
+            android:icon="@drawable/ic_troubleshooting"
+            android:title="@string/main_menu_troubleshooting"/>
         <item
             android:id="@+id/menu_jira"
             android:icon="@drawable/ic_jira"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-1655)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code