### PR TITLE
fix: [ANDROAPP-4679] Avoid fragment recreation in search form

### DIFF
--- a/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
@@ -211,7 +211,7 @@ class FormView(
                 dataEntryHeaderHelper.checkSectionHeader(recyclerView)
             }
         })
-        if (needToForceUpdate){
+        if (needToForceUpdate) {
             retainInstance = true
         }
         return binding.root

--- a/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
+++ b/app/src/main/java/org/dhis2/data/forms/dataentry/FormView.kt
@@ -211,6 +211,9 @@ class FormView(
                 dataEntryHeaderHelper.checkSectionHeader(recyclerView)
             }
         })
+        if (needToForceUpdate){
+            retainInstance = true
+        }
         return binding.root
     }
 


### PR DESCRIPTION
## Description
[ANDROAPP-4679](https://jira.dhis2.org/browse/ANDROAPP-4679)

## Solution description
According to the[ Android documentation ](https://developer.android.com/reference/android/app/Fragment.html?authuser=1#Fragment%28%29) 

_Every fragment must have an empty constructor, so it can be instantiated when restoring its activity's state. **It is strongly recommended that subclasses do not have other constructors with parameters, since these constructors will not be called when the fragment is re-instantiated**; instead, arguments can be supplied by the caller with [setArguments(Bundle)](https://developer.android.com/reference/android/app/Fragment?authuser=1#setArguments(android.os.Bundle)) and later retrieved by the Fragment with [getArguments()](https://developer.android.com/reference/android/app/Fragment?authuser=1#getArguments())._

The root cause of the crash is the FormView constructor, since it's a hard freeze and I do not think it's the best time to refactor stuff, this was added temporarily until next release

