### PR TITLE
fix: [ANDROAPP-4561] Event detail sync button hidden on events that have EventMode.NEW

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.java
@@ -122,7 +122,7 @@ public class EventCaptureActivity extends ActivityGlobalAbstract implements Even
             @Override
             public void onPageSelected(int position) {
                 super.onPageSelected(position);
-                if (position == 0) {
+                if (position == 0 && eventMode != EventMode.NEW) {
                     binding.syncButton.setVisibility(View.VISIBLE);
                 } else {
                     binding.syncButton.setVisibility(View.GONE);


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4561](https://jira.dhis2.org/browse/ANDROAPP-4561)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code