### PR TITLE
fix: [ANDROAPP-4542] Handle long option names in option sets

### DIFF
--- a/form/src/main/java/org/dhis2/form/ui/binding/OptionSetSpinnerBindings.kt
+++ b/form/src/main/java/org/dhis2/form/ui/binding/OptionSetSpinnerBindings.kt
@@ -1,11 +1,14 @@
 package org.dhis2.form.ui.binding
 
+import android.widget.ArrayAdapter
+import androidx.appcompat.widget.ListPopupWindow
 import android.view.Menu
 import android.view.View
 import android.widget.PopupMenu
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.google.android.material.textfield.TextInputEditText
+import org.dhis2.form.R
 import org.dhis2.form.model.FieldUiModel
 import org.dhis2.form.model.UiEventType
 
@@ -26,21 +29,15 @@ fun TextView.addOptions(field: FieldUiModel) {
 private fun showOptions(view: View, field: FieldUiModel) {
     when (field.optionsToDisplay?.size) {
         in 0..15 -> {
-            PopupMenu(view.context, view).apply {
-                setOnMenuItemClickListener { item ->
+            ListPopupWindow(view.context, null, R.attr.listPopupWindowStyle).apply {
+                anchorView = view
+                val list = field.optionsToDisplay?.map { it.displayName() } ?: emptyList()
+                val adapter = ArrayAdapter(view.context, R.layout.pop_up_menu_item, list)
+                setAdapter(adapter)
+
+                setOnItemClickListener { _, _, position, _ ->
+                    field.optionsToDisplay?.get(position)?.code()?.let { field.onSave(it) }
                     dismiss()
-                    val optionSelected =
-                        field.optionsToDisplay?.first { it.displayName() == item.title }
-                    field.onSave(optionSelected?.code())
-                    true
-                }
-                field.optionsToDisplay?.forEachIndexed { index, option ->
-                    menu.add(
-                        Menu.NONE,
-                        Menu.NONE,
-                        index + 1,
-                        option.displayName()
-                    )
                 }
                 show()
             }

--- a/form/src/main/java/org/dhis2/form/ui/binding/OptionSetSpinnerBindings.kt
+++ b/form/src/main/java/org/dhis2/form/ui/binding/OptionSetSpinnerBindings.kt
@@ -1,11 +1,9 @@
 package org.dhis2.form.ui.binding
 
-import android.widget.ArrayAdapter
-import androidx.appcompat.widget.ListPopupWindow
-import android.view.Menu
 import android.view.View
-import android.widget.PopupMenu
+import android.widget.ArrayAdapter
 import android.widget.TextView
+import androidx.appcompat.widget.ListPopupWindow
 import androidx.databinding.BindingAdapter
 import com.google.android.material.textfield.TextInputEditText
 import org.dhis2.form.R

--- a/form/src/main/res/layout/option_set_select_check_item.xml
+++ b/form/src/main/res/layout/option_set_select_check_item.xml
@@ -14,13 +14,15 @@
 
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/checkBox"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="4dp"
+        android:paddingTop="6dp"
+        android:gravity="top"
         android:enabled="@{item.editable}"
         android:text="@{option.displayName()}"
         app:optionTint="@{item.style}"
         app:layout_constraintTop_toTopOf="parent"
         tools:checked="true"
-        tools:text="Option name" />
+        tools:text="@tools:sample/lorem/random" />
 </layout>

--- a/form/src/main/res/layout/option_set_select_item.xml
+++ b/form/src/main/res/layout/option_set_select_item.xml
@@ -14,13 +14,15 @@
 
     <RadioButton
         android:id="@+id/radio"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="4dp"
+        android:paddingTop="6dp"
         android:enabled="@{item.editable}"
         android:text="@{option.displayName()}"
         app:optionTint="@{item.style}"
         app:layout_constraintTop_toTopOf="parent"
         tools:checked="true"
-        tools:text="Option Name" />
+        android:gravity="top"
+        tools:text="@tools:sample/lorem/random" />
 </layout>

--- a/form/src/main/res/layout/pop_up_menu_item.xml
+++ b/form/src/main/res/layout/pop_up_menu_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:padding="16dp"
+    android:textSize="12sp"
+    tools:text="@tools:sample/lorem/random" />


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/[ANDROAPP-4542)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code