### PR TITLE
fix: [ANDROAPP-4460] Transformation error from pie 

### DIFF
--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/providers/ChartCoordinatesProviderImpl.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/providers/ChartCoordinatesProviderImpl.kt
@@ -221,10 +221,14 @@ class ChartCoordinatesProviderImpl(
                     metadata[it]?.displayName.toString()
                 }
 
-                val position = periodId.let {
-                    when (metadata[periodId]) {
-                        is MetadataItem.RelativePeriodItem -> categories.indexOf(periodId)
-                        else -> categories.indexOf(periodId)
+                val position = if (periodId == ""){
+                    0f
+                } else {
+                    periodId.let {
+                        when (metadata[periodId]) {
+                            is MetadataItem.RelativePeriodItem -> categories.indexOf(periodId)
+                            else -> categories.indexOf(periodId)
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Description
The problems comes from the transformation from pie chart to table. The SDK/Web is returning empty rows, therefore through the mapping periodId becomes empty string and therefore there is no position and end up being "-1". Other option should be to fix this in the SDK. Thoughts?