### PR TITLE
fix: [ANDROAPP-4739] Yes only checkbox should not display the "yes" label

### DIFF
--- a/form/src/main/res/layout/form_check_button.xml
+++ b/form/src/main/res/layout/form_check_button.xml
@@ -124,7 +124,7 @@
                             android:checked="@{item.isAffirmativeChecked}"
                             android:onClick="@{v -> item.onSaveBoolean(true)}"
                             android:textSize="@dimen/form_edit_text_size"
-                            android:text="@string/yes"
+                            android:text='@{item.valueType != ValueType.TRUE_ONLY ? @string/yes : ""}'
                             app:optionTint="@{item.style}"
                             android:enabled="@{item.editable}"
                             android:alpha="@{item.editable ? 1.0f : 0.5f}"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4739)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code