### PR TITLE
fix: [ANDROAPP-4763] Text fields copied to one another when clicking next

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/searchte/robot/SearchTeiRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/searchte/robot/SearchTeiRobot.kt
@@ -87,6 +87,14 @@ class SearchTeiRobot : BaseRobot() {
             .perform(
                 actionOnItemAtPosition<SearchTEViewHolder>(
                     position,
+                    click()
+                )
+            )
+
+        onView(withId(R.id.recyclerView))
+            .perform(
+                actionOnItemAtPosition<SearchTEViewHolder>(
+                    position,
                     typeChildViewWithId(searchWord, R.id.input_editText)
                 )
             )

--- a/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
@@ -30,7 +30,7 @@ class FormRepositoryImpl(
     private val mandatoryItemsWithoutValue: MutableMap<String, String> = mutableMapOf()
     private var openedSectionUid: String? = null
     private var itemList: List<FieldUiModel> = emptyList()
-    private var focusedItem: RowAction? = null
+    private var focusedItemId: String? = null
     private var ruleEffectsResult: RuleUtilsProviderResult? = null
     private var runDataIntegrity: Boolean = false
     private var calculationLoop: Int = 0
@@ -220,13 +220,7 @@ class FormRepositoryImpl(
     }
 
     private fun List<FieldUiModel>.setFocusedItem(): List<FieldUiModel> {
-        return focusedItem?.let {
-            val uid = when (it.type) {
-                ActionType.ON_NEXT -> getNextItem(it.id)
-                ActionType.ON_FINISH -> null
-                else -> it.id
-            }
-
+        return focusedItemId?.let { uid ->
             find { item ->
                 item.uid == uid
             }?.let { item ->
@@ -398,11 +392,15 @@ class FormRepositoryImpl(
     }
 
     override fun setFocusedItem(action: RowAction) {
-        focusedItem = action
+        focusedItemId = when (action.type) {
+            ActionType.ON_NEXT -> getNextItem(action.id)
+            ActionType.ON_FINISH -> null
+            else -> action.id
+        }
     }
 
     override fun currentFocusedItem(): FieldUiModel? {
-        return itemList.find { focusedItem?.id == it.uid }
+        return itemList.find { focusedItemId == it.uid }
     }
 
     override fun updateSectionOpened(action: RowAction) {

--- a/form/src/main/java/org/dhis2/form/ui/DataEntryAdapter.kt
+++ b/form/src/main/java/org/dhis2/form/ui/DataEntryAdapter.kt
@@ -1,5 +1,7 @@
 package org.dhis2.form.ui
 
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -32,6 +34,20 @@ class DataEntryAdapter(private val searchStyle: Boolean) :
     private val sectionHandler = SectionHandler()
     var sectionPositions: MutableMap<String, Int> = LinkedHashMap()
 
+    val textWatcher: TextWatcher = object : TextWatcher {
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            // Not needed
+        }
+
+        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            currentList.find { it.focused }?.onTextChange(p0)
+        }
+
+        override fun afterTextChanged(p0: Editable?) {
+            // Not needed
+        }
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FormViewHolder {
         val layoutInflater =
             if (refactoredViews.contains(viewType) && searchStyle) {
@@ -53,7 +69,7 @@ class DataEntryAdapter(private val searchStyle: Boolean) :
         if (getItem(position) is SectionUiModelImpl) {
             updateSectionData(position, false)
         }
-        holder.bind(getItem(position), this)
+        holder.bind(getItem(position), this, textWatcher)
     }
 
     fun updateSectionData(position: Int, isHeader: Boolean) {

--- a/form/src/main/java/org/dhis2/form/ui/FormViewHolder.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormViewHolder.kt
@@ -1,5 +1,6 @@
 package org.dhis2.form.ui
 
+import android.text.TextWatcher
 import android.widget.ImageView
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
@@ -20,7 +21,7 @@ class FormViewHolder(private val binding: ViewDataBinding) : RecyclerView.ViewHo
         fieldSelected?.clipWithAllRoundedCorners(2.dp)
     }
 
-    fun bind(uiModel: FieldUiModel, callback: FieldItemCallback) {
+    fun bind(uiModel: FieldUiModel, callback: FieldItemCallback, textWatcher: TextWatcher) {
         val itemCallback: FieldUiModel.Callback = object : FieldUiModel.Callback {
             override fun recyclerViewUiEvents(uiEvent: RecyclerViewUiEvents) {
                 callback.recyclerViewEvent(uiEvent)
@@ -37,6 +38,7 @@ class FormViewHolder(private val binding: ViewDataBinding) : RecyclerView.ViewHo
             }
         }
         uiModel.setCallback(itemCallback)
+        binding.setVariable(BR.textWatcher, textWatcher)
         binding.setVariable(BR.item, uiModel)
         binding.executePendingBindings()
     }

--- a/form/src/main/java/org/dhis2/form/ui/binding/FieldBindings.kt
+++ b/form/src/main/java/org/dhis2/form/ui/binding/FieldBindings.kt
@@ -383,14 +383,13 @@ fun RadioGroup.checkListener(item: FieldUiModel) {
     }
 }
 
-@BindingAdapter(value = ["onTyping", "textWatcher"], requireAll = false)
-fun EditText.setOnTyping(item: FieldUiModel, textWatcher: TextWatcher?) {
-    textWatcher?.let {
-        if (item.focused) {
-            addTextChangedListener(textWatcher)
-        } else {
-            removeTextChangedListener(textWatcher)
-        }
+@BindingAdapter(value = ["onTyping", "textWatcher"], requireAll = true)
+fun EditText.setOnTyping(item: FieldUiModel, textWatcher: TextWatcher) {
+    removeTextChangedListener(textWatcher)
+    setText(item.value)
+    setSelection(length())
+    if(item.focused) {
+        addTextChangedListener(textWatcher)
     }
 }
 

--- a/form/src/main/java/org/dhis2/form/ui/binding/FieldBindings.kt
+++ b/form/src/main/java/org/dhis2/form/ui/binding/FieldBindings.kt
@@ -25,7 +25,6 @@ import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.ViewCompat
-import androidx.core.widget.doOnTextChanged
 import androidx.databinding.BindingAdapter
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -384,11 +383,13 @@ fun RadioGroup.checkListener(item: FieldUiModel) {
     }
 }
 
-@BindingAdapter("onTyping")
-fun EditText.setOnTyping(item: FieldUiModel) {
-    doOnTextChanged { text, _, _, _ ->
-        if (hasFocus()) {
-            item.onTextChange(text)
+@BindingAdapter(value = ["onTyping", "textWatcher"], requireAll = false)
+fun EditText.setOnTyping(item: FieldUiModel, textWatcher: TextWatcher?) {
+    textWatcher?.let {
+        if (item.focused) {
+            addTextChangedListener(textWatcher)
+        } else {
+            removeTextChangedListener(textWatcher)
         }
     }
 }

--- a/form/src/main/java/org/dhis2/form/ui/binding/FieldBindings.kt
+++ b/form/src/main/java/org/dhis2/form/ui/binding/FieldBindings.kt
@@ -388,7 +388,7 @@ fun EditText.setOnTyping(item: FieldUiModel, textWatcher: TextWatcher) {
     removeTextChangedListener(textWatcher)
     setText(item.value)
     setSelection(length())
-    if(item.focused) {
+    if (item.focused) {
         addTextChangedListener(textWatcher)
     }
 }

--- a/form/src/main/res/layout/form_edit_text_custom.xml
+++ b/form/src/main/res/layout/form_edit_text_custom.xml
@@ -129,7 +129,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_edit_text_custom.xml
+++ b/form/src/main/res/layout/form_edit_text_custom.xml
@@ -12,6 +12,9 @@
         <variable
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
 
     </data>
 
@@ -125,6 +128,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_email.xml
+++ b/form/src/main/res/layout/form_email.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_email.xml
+++ b/form/src/main/res/layout/form_email.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_integer.xml
+++ b/form/src/main/res/layout/form_integer.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_integer.xml
+++ b/form/src/main/res/layout/form_integer.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_integer_negative.xml
+++ b/form/src/main/res/layout/form_integer_negative.xml
@@ -13,6 +13,9 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +128,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_integer_negative.xml
+++ b/form/src/main/res/layout/form_integer_negative.xml
@@ -129,7 +129,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_integer_positive.xml
+++ b/form/src/main/res/layout/form_integer_positive.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_integer_positive.xml
+++ b/form/src/main/res/layout/form_integer_positive.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_integer_zero_positive.xml
+++ b/form/src/main/res/layout/form_integer_zero_positive.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_integer_zero_positive.xml
+++ b/form/src/main/res/layout/form_integer_zero_positive.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_letter.xml
+++ b/form/src/main/res/layout/form_letter.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_letter.xml
+++ b/form/src/main/res/layout/form_letter.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_long_text_custom.xml
+++ b/form/src/main/res/layout/form_long_text_custom.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -124,6 +128,7 @@
                     android:enabled="@{item.editable}"
                     android:gravity="start"
                     app:onTyping="@{item}"
+                    app:textWatcher="@{textWatcher}"
                     android:paddingTop="8dp"
                     android:paddingBottom="36dp"
                     android:text="@{item.value}"

--- a/form/src/main/res/layout/form_long_text_custom.xml
+++ b/form/src/main/res/layout/form_long_text_custom.xml
@@ -131,7 +131,6 @@
                     app:textWatcher="@{textWatcher}"
                     android:paddingTop="8dp"
                     android:paddingBottom="36dp"
-                    android:text="@{item.value}"
                     android:textAlignment="textStart"
                     android:textIsSelectable="true"
                     android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_number.xml
+++ b/form/src/main/res/layout/form_number.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_number.xml
+++ b/form/src/main/res/layout/form_number.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_percentage.xml
+++ b/form/src/main/res/layout/form_percentage.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_percentage.xml
+++ b/form/src/main/res/layout/form_percentage.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_phone_number.xml
+++ b/form/src/main/res/layout/form_phone_number.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_phone_number.xml
+++ b/form/src/main/res/layout/form_phone_number.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_scan.xml
+++ b/form/src/main/res/layout/form_scan.xml
@@ -119,7 +119,6 @@
                     app:onTyping="@{item}"
                     app:textWatcher="@{textWatcher}"
                     android:singleLine="true"
-                    android:text="@{item.value}"
                     android:textSize="@dimen/form_edit_text_size"
                     app:action_handler="@{item}"
                     app:input_style="@{item}"

--- a/form/src/main/res/layout/form_scan.xml
+++ b/form/src/main/res/layout/form_scan.xml
@@ -12,6 +12,10 @@
         <variable
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
+
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
     </data>
 
 
@@ -113,6 +117,7 @@
                     android:enabled="@{item.editable}"
                     android:imeOptions="actionNext"
                     app:onTyping="@{item}"
+                    app:textWatcher="@{textWatcher}"
                     android:singleLine="true"
                     android:text="@{item.value}"
                     android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_unit_interval.xml
+++ b/form/src/main/res/layout/form_unit_interval.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_unit_interval.xml
+++ b/form/src/main/res/layout/form_unit_interval.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"

--- a/form/src/main/res/layout/form_url.xml
+++ b/form/src/main/res/layout/form_url.xml
@@ -13,6 +13,10 @@
             name="item"
             type="org.dhis2.form.model.FieldUiModel" />
 
+        <variable
+            name="textWatcher"
+            type="android.text.TextWatcher" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,6 +129,7 @@
                         android:gravity="start"
                         android:maxLines="1"
                         app:onTyping="@{item}"
+                        app:textWatcher="@{textWatcher}"
                         android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"

--- a/form/src/main/res/layout/form_url.xml
+++ b/form/src/main/res/layout/form_url.xml
@@ -130,7 +130,6 @@
                         android:maxLines="1"
                         app:onTyping="@{item}"
                         app:textWatcher="@{textWatcher}"
-                        android:text="@{item.value}"
                         android:textAlignment="textStart"
                         android:textSize="@dimen/form_edit_text_size"
                         app:input_style="@{item}"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4763)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code