### PR TITLE
fix: [ANDROAPP-4775] Event status icon missing start margin

### DIFF
--- a/app/src/main/res/layout/item_event.xml
+++ b/app/src/main/res/layout/item_event.xml
@@ -79,7 +79,7 @@
                         app:eventProgram="@{program}"
                         app:eventProgramStage="@{stage}"
                         app:eventStatusIcon="@{event}"
-                        app:layout_constraintEnd_toEndOf="parent"
+                        android:layout_marginStart="16dp"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
                         app:srcCompat="@drawable/ic_event_status_open"


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4775)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code