### PR TITLE
fix: [ANDROAPP-4790] save 0 and 1 for unit interval

### DIFF
--- a/app/src/test/java/org/dhis2/bindings/ValueExtensionsTest.kt
+++ b/app/src/test/java/org/dhis2/bindings/ValueExtensionsTest.kt
@@ -47,9 +47,9 @@ class ValueExtensionsTest {
 
         val expectedResults = arrayListOf(
             "",
-            "0.0",
+            "0",
             "0.2233",
-            "1.0",
+            "1",
             null
         )
 

--- a/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
@@ -1,4 +1,4 @@
-package org.dhis2.Bindings
+package org.dhis2.commons.bindings
 
 import org.dhis2.commons.date.DateUtils
 import org.hisp.dhis.android.core.D2
@@ -158,7 +158,7 @@ fun String?.withValueTypeCheck(valueType: ValueType?): String? {
             ValueType.INTEGER_ZERO_OR_POSITIVE -> (
                     it.toIntOrNull() ?: it.toFloat().toInt()
                     ).toString()
-            ValueType.UNIT_INTERVAL -> it.toFloat().toString()
+            ValueType.UNIT_INTERVAL -> (it.toIntOrNull() ?: it.toFloat()).toString()
             else -> this
         }
     } ?: this

--- a/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
@@ -1,4 +1,4 @@
-package org.dhis2.commons.bindings
+package org.dhis2.Bindings
 
 import org.dhis2.commons.date.DateUtils
 import org.hisp.dhis.android.core.D2


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code