### PR TITLE
fix: [ANDROAPP-4764] Keep bottom bar selection when rotating in search screen

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEActivity.java
@@ -132,12 +132,18 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
         initSearchForm();
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_search);
+
         searchScreenConfigurator = new SearchScreenConfigurator(
                 binding,
                 isOpen -> {
                     viewModel.setFiltersOpened(isOpen);
                     return Unit.INSTANCE;
                 });
+        int initialPage = 0;
+        if (savedInstanceState != null && savedInstanceState.containsKey("initialPage")) {
+            initialPage = savedInstanceState.getInt("initialPage");
+            binding.setNavigationInitialPage(initialPage);
+        }
         binding.setPresenter(presenter);
         binding.setTotalFilters(FilterManager.getInstance().getTotalFilters());
         ViewExtensionsKt.clipWithRoundedCorners(binding.mainComponent, ExtensionsKt.getDp(16));
@@ -175,7 +181,9 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
         );
 
         configureBottomNavigation();
-        showList();
+        if (initialPage == 0) {
+            showList();
+        }
         observeScreenState();
         observeDownload();
     }
@@ -295,6 +303,7 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(Constants.QUERY_DATA, (Serializable) viewModel.getQueryData());
+        outState.putInt("initialPage", binding.navigationBar.currentPage());
     }
 
     private void openSyncDialog() {
@@ -366,9 +375,7 @@ public class SearchTEActivity extends ActivityGlobalAbstract implements SearchTE
 
         viewModel.getPageConfiguration().observe(this, pageConfigurator -> {
             binding.navigationBar.setOnConfigurationFinishListener(() -> {
-                if (viewModel.canDisplayBottomNavigationBar()) {
-                    binding.navigationBar.show();
-                }
+                binding.navigationBar.show();
                 return Unit.INSTANCE;
             });
             binding.navigationBar.pageConfiguration(pageConfigurator);

--- a/app/src/main/java/org/dhis2/utils/customviews/navigationbar/NavigationBottomBar.kt
+++ b/app/src/main/java/org/dhis2/utils/customviews/navigationbar/NavigationBottomBar.kt
@@ -253,4 +253,8 @@ class NavigationBottomBar @JvmOverloads constructor(
             setCurrentItemIndicatorPosition(it)
         }
     }
+
+    fun currentPage(): Int {
+        return visibleItemCount().indexOfFirst { it.itemId == currentItemId }
+    }
 }

--- a/app/src/main/res/layout-land/activity_search.xml
+++ b/app/src/main/res/layout-land/activity_search.xml
@@ -38,7 +38,9 @@
         <variable
             name="totalFilters"
             type="Integer" />
-
+        <variable
+            name="navigationInitialPage"
+            type="Integer" />
     </data>
 
     <RelativeLayout
@@ -225,6 +227,7 @@
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 app:elevation="12dp"
+                app:initialPage="@{navigationInitialPage}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/backdropGuideDiv"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -14,6 +14,10 @@
         <variable
             name="totalFilters"
             type="Integer" />
+
+        <variable
+            name="navigationInitialPage"
+            type="Integer" />
     </data>
 
     <RelativeLayout
@@ -216,6 +220,7 @@
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 app:elevation="12dp"
+                app:initialPage="@{navigationInitialPage}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:menu="@menu/navigation_search_menu" />
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4764)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code