### PR TITLE
fix: [ANDROAPP-4861] Crash when clicking Account Recovery when the device has interne…

### DIFF
--- a/app/src/main/java/org/dhis2/utils/WebViewActivity.kt
+++ b/app/src/main/java/org/dhis2/utils/WebViewActivity.kt
@@ -1,6 +1,7 @@
 package org.dhis2.utils
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebResourceRequest
@@ -9,9 +10,8 @@ import android.webkit.WebViewClient
 import androidx.databinding.DataBindingUtil
 import org.dhis2.R
 import org.dhis2.databinding.ActivityWebviewBinding
-import org.dhis2.usescases.general.ActivityGlobalAbstract
 
-class WebViewActivity : ActivityGlobalAbstract() {
+class WebViewActivity : Activity() {
 
     companion object {
         const val WEB_VIEW_URL = "url"


### PR DESCRIPTION
…t connection

## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4861](https://jira.dhis2.org/browse/ANDROAPP-4861)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code