### PR TITLE
feat: [ANDROSDK-1568] Skip profile picture logic when no image values

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/Extensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/Extensions.kt
@@ -25,10 +25,18 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
 
     val attrRepository = d2.trackedEntityModule().trackedEntityAttributes()
     val imageAttributes = if (programUid != null) {
-        attrRepository.byValueType().eq(ValueType.IMAGE).blockingGet().map { it.uid() }
+        attrRepository.byValueType().eq(ValueType.IMAGE).blockingGetUids()
     } else {
-        attrRepository.byDisplayInListNoProgram().isTrue.byValueType().eq(ValueType.IMAGE)
-            .blockingGet().map { it.uid() }
+        attrRepository.byDisplayInListNoProgram().isTrue.byValueType().eq(ValueType.IMAGE).blockingGetUids()
+    }
+
+    val imageAttributeValues = d2.trackedEntityModule().trackedEntityAttributeValues()
+        .byTrackedEntityInstance().eq(uid())
+        .byTrackedEntityAttribute().`in`(imageAttributes)
+        .blockingGet()
+
+    if (imageAttributeValues.isEmpty()) {
+        return ""
     }
 
     var attributes = d2.trackedEntityModule().trackedEntityTypeAttributes()
@@ -69,17 +77,11 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
             .map { it.trackedEntityAttribute()!!.uid() }
     }
 
-    val attributeValue = if (attributes.isNotEmpty()) {
-        d2.trackedEntityModule().trackedEntityAttributeValues()
-            .byTrackedEntityInstance().eq(uid())
-            .byTrackedEntityAttribute().`in`(attributes[0])
-            .byValue().isNotNull
-            .one().blockingGet()
-    } else {
-        null
+    val attributeValue = attributes.firstOrNull()?.let { attributeUid ->
+        imageAttributeValues.find { it.trackedEntityAttribute() == attributeUid }
     }
 
-    if (attributeValue != null) {
+    if (attributeValue?.value() != null) {
         val fileResource =
             d2.fileResourceModule().fileResources().uid(attributeValue.value()).blockingGet()
         if (fileResource != null) {

--- a/app/src/main/java/org/dhis2/Bindings/Extensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/Extensions.kt
@@ -27,7 +27,8 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
     val imageAttributes = if (programUid != null) {
         attrRepository.byValueType().eq(ValueType.IMAGE).blockingGetUids()
     } else {
-        attrRepository.byDisplayInListNoProgram().isTrue.byValueType().eq(ValueType.IMAGE).blockingGetUids()
+        attrRepository.byDisplayInListNoProgram().isTrue.byValueType().eq(ValueType.IMAGE)
+            .blockingGetUids()
     }
 
     val imageAttributeValues = d2.trackedEntityModule().trackedEntityAttributeValues()


### PR DESCRIPTION
## Description
Skips the logic to get the profile picture attribute if the TEI has no image attribute values.

[ANDROSDK-1568](https://jira.dhis2.org/browse/ANDROSDK-1568)

## Solution description
Skip the logic
## Covered unit test cases
----
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [X] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [X] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code