### PR TITLE
feat: [NO-MERGE] [ANDROSDK-1568] Add expirable cache

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/Extensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/Extensions.kt
@@ -39,23 +39,7 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
         .blockingGet().map { it.trackedEntityAttribute()?.uid() }
 
     if (attributes.isEmpty() && programUid != null) {
-        val sections = d2.programModule().programSections().withAttributes().byProgramUid()
-            .eq(programUid).blockingGet()
-        attributes = if (sections.isEmpty()) {
-            d2.programModule().programTrackedEntityAttributes()
-                .byDisplayInList().isTrue
-                .byProgram().eq(programUid)
-                .byTrackedEntityAttribute().`in`(imageAttributes)
-                .blockingGet().filter { it.trackedEntityAttribute() != null }
-                .map { it.trackedEntityAttribute()!!.uid() }
-        } else {
-            d2.programModule().programSections().withAttributes().byProgramUid().eq(programUid)
-                .blockingGet()
-                .mapNotNull { section ->
-                    section.attributes()?.filter { imageAttributes.contains(it.uid()) }
-                        ?.map { it.uid() }
-                }.flatten()
-        }
+        attributes = TrackedEntityInstanceExtensionHelper.getProfilePictureAttributes(d2, programUid, imageAttributes)
     } else if (attributes.isEmpty() && programUid == null) {
         val enrollmentProgramUids = d2.enrollmentModule().enrollments()
             .byTrackedEntityInstance().eq(uid())

--- a/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensionHelper.kt
+++ b/app/src/main/java/org/dhis2/Bindings/TrackedEntityInstanceExtensionHelper.kt
@@ -1,0 +1,37 @@
+package org.dhis2.Bindings
+
+import org.dhis2.utils.cache.AppExpirableCache
+import org.hisp.dhis.android.core.D2
+import java.util.concurrent.TimeUnit
+
+object TrackedEntityInstanceExtensionHelper {
+
+    private val profileImageCache = AppExpirableCache<Pair<String, List<String>>, List<String>>(TimeUnit.SECONDS.toMillis(5))
+
+    fun getProfilePictureAttributes(d2: D2, programUid: String, imageAttributes: List<String>): List<String> {
+        val key = Pair(programUid, imageAttributes)
+        return profileImageCache[key]
+            ?: internalGetProfilePictureAttributes(d2, programUid, imageAttributes)
+                .also { profileImageCache[key] = it }
+    }
+
+    private fun internalGetProfilePictureAttributes(d2: D2, programUid: String, imageAttributes: List<String>): List<String> {
+        val sections = d2.programModule().programSections().withAttributes().byProgramUid()
+            .eq(programUid).blockingGet()
+        return if (sections.isEmpty()) {
+            d2.programModule().programTrackedEntityAttributes()
+                .byDisplayInList().isTrue
+                .byProgram().eq(programUid)
+                .byTrackedEntityAttribute().`in`(imageAttributes)
+                .blockingGet().filter { it.trackedEntityAttribute() != null }
+                .map { it.trackedEntityAttribute()!!.uid() }
+        } else {
+            d2.programModule().programSections().withAttributes().byProgramUid().eq(programUid)
+                .blockingGet()
+                .mapNotNull { section ->
+                    section.attributes()?.filter { imageAttributes.contains(it.uid()) }
+                        ?.map { it.uid() }
+                }.flatten()
+        }
+    }
+}

--- a/app/src/main/java/org/dhis2/utils/cache/AppCache.kt
+++ b/app/src/main/java/org/dhis2/utils/cache/AppCache.kt
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.dhis2.utils.cache
+
+internal interface AppCache<K, V> {
+
+    operator fun set(key: K, value: V)
+
+    operator fun get(key: K): V?
+
+    fun remove(key: K): V?
+
+    fun clear()
+}

--- a/app/src/main/java/org/dhis2/utils/cache/AppExpirableCache.kt
+++ b/app/src/main/java/org/dhis2/utils/cache/AppExpirableCache.kt
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.dhis2.utils.cache
+
+import java.util.concurrent.TimeUnit
+
+internal class AppExpirableCache<K, V>(
+    private val flushInterval: Long = TimeUnit.MINUTES.toMillis(2)
+) : AppCache<K, V> {
+
+    private val cache = HashMap<K, V>()
+
+    private var lastFlushTime = System.nanoTime()
+
+    override fun set(key: K, value: V) {
+        this.cache[key] = value
+    }
+
+    override fun get(key: K): V? {
+        removeIfExpired()
+        return this.cache[key]
+    }
+
+    override fun remove(key: K): V? {
+        removeIfExpired()
+        return this.cache.remove(key)
+    }
+
+    override fun clear() = this.cache.clear()
+
+    private fun removeIfExpired() {
+        val now = System.nanoTime()
+        val shouldRemove = now - lastFlushTime >= TimeUnit.MILLISECONDS.toNanos(flushInterval)
+        if (shouldRemove) {
+            clear()
+            lastFlushTime = now
+        }
+    }
+}


### PR DESCRIPTION
## Description
Do not merge this PR. It is a prof of concept about the use of an internal cache for expensive operations, such as determining the attribute that should be used as profile picture for a particular event.

[ANDROSDK-1568](https://jira.dhis2.org/browse/ANDROSDK-1568)

## Solution description
Implement an expirable cache (it is copy/pasted from the SDK) to store an expensive computation result. This result is the same for a particular program as long as the metadata does not change.
## Covered unit test cases
----
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [X] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [X] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code