### PR TITLE
fix: [ANDROAPP-4944] Search viewModel's init now runs in background thread

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagedList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -68,7 +67,7 @@ class SearchTEIViewModel(
     val filtersOpened: LiveData<Boolean> = _filtersOpened
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatchers.io()) {
             createButtonScrollVisibility.postValue(
                 searchRepository.canCreateInProgramWithoutSearch()
             )

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEIViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagedList
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -67,9 +68,11 @@ class SearchTEIViewModel(
     val filtersOpened: LiveData<Boolean> = _filtersOpened
 
     init {
-        viewModelScope.launch {
-            createButtonScrollVisibility.value = searchRepository.canCreateInProgramWithoutSearch()
-            _pageConfiguration.value = searchNavPageConfigurator.initVariables()
+        viewModelScope.launch(Dispatchers.IO) {
+            createButtonScrollVisibility.postValue(
+                searchRepository.canCreateInProgramWithoutSearch()
+            )
+            _pageConfiguration.postValue(searchNavPageConfigurator.initVariables())
         }
     }
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ANDROAPP-4944](https://dhis2.atlassian.net/browse/ANDROAPP-4944?atlOrigin=eyJpIjoiODFmYzg2NDU0NzBjNGFlNzg5MTY4OWVlOTgxZjU2MjkiLCJwIjoiaiJ9)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code