### PR TITLE
fix: [ANDROAPP-4898] Remove focus on text input component when clicking back

### DIFF
--- a/compose-table/src/androidTest/java/org/dhis2/composetable/TableRobot.kt
+++ b/compose-table/src/androidTest/java/org/dhis2/composetable/TableRobot.kt
@@ -19,12 +19,14 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToLog
+import androidx.test.espresso.Espresso.pressBack
 import org.dhis2.composetable.actions.TableInteractions
 import org.dhis2.composetable.data.TableAppScreenOptions
 import org.dhis2.composetable.model.FakeModelType
@@ -171,6 +173,11 @@ class TableRobot(
     fun assertClickOnEditOpensInputKeyboard() {
         clickOnEditValue()
         assertInputIcon(R.drawable.ic_finish_edit_input)
+    }
+
+    fun assertClickOnBackClearsFocus() {
+        pressBack()
+        assertInputIcon(R.drawable.ic_edit_input)
     }
 
     fun assertClickOnSaveHidesKeyboardAndSaveValue(valueToType: String) {

--- a/compose-table/src/androidTest/java/org/dhis2/composetable/TableRobot.kt
+++ b/compose-table/src/androidTest/java/org/dhis2/composetable/TableRobot.kt
@@ -275,7 +275,7 @@ class TableRobot(
     }
 
     fun assertInputIcon(@DrawableRes id: Int) {
-        composeTestRule.onNode(SemanticsMatcher.expectValue(DrawableId, id)).assertExists()
+        composeTestRule.onNode(SemanticsMatcher.expectValue(DrawableId, id)).assertIsDisplayed()
     }
 
     fun assertIconIsVisible(@DrawableRes id: Int) {

--- a/compose-table/src/androidTest/java/org/dhis2/composetable/ui/TextInputUiTest.kt
+++ b/compose-table/src/androidTest/java/org/dhis2/composetable/ui/TextInputUiTest.kt
@@ -61,6 +61,18 @@ class TextInputUiTest {
         }
     }
 
+    @Test
+    fun shouldClearFocusWhenKeyboardIsHidden(){
+        composeTestRule.setContent {
+            TextInputUiTestScreen { }
+        }
+        tableRobot(composeTestRule){
+            assertClickOnCellShouldOpenInputComponent(0, 0)
+            assertClickOnEditOpensInputKeyboard()
+            assertClickOnBackClearsFocus()
+        }
+    }
+
     @OptIn(ExperimentalMaterialApi::class)
     @Composable
     private fun TextInputUiTestScreen(onSave: (TableCell) -> Unit) {

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/TextInputUi.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/TextInputUi.kt
@@ -68,7 +68,7 @@ fun TextInput(
         val isKeyboardOpen by keyboardAsState()
 
         LaunchedEffect(isKeyboardOpen) {
-            if(isKeyboardOpen == Keyboard.Closed) {
+            if (isKeyboardOpen == Keyboard.Closed) {
                 focusManager.clearFocus(true)
             }
         }

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/TextInputUi.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/TextInputUi.kt
@@ -68,9 +68,8 @@ fun TextInput(
         val isKeyboardOpen by keyboardAsState()
 
         LaunchedEffect(isKeyboardOpen) {
-            when (isKeyboardOpen) {
-                Keyboard.Opened -> {}
-                Keyboard.Closed -> focusManager.clearFocus(true)
+            if(isKeyboardOpen == Keyboard.Closed){
+                focusManager.clearFocus(true)
             }
         }
 

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/TextInputUi.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/TextInputUi.kt
@@ -68,7 +68,7 @@ fun TextInput(
         val isKeyboardOpen by keyboardAsState()
 
         LaunchedEffect(isKeyboardOpen) {
-            if(isKeyboardOpen == Keyboard.Closed){
+            if(isKeyboardOpen == Keyboard.Closed) {
                 focusManager.clearFocus(true)
             }
         }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code