### PR TITLE
fix: [ANDROAPP-4939] Removes enrollment date's filter count when resetting filters

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/filters/FilterManager.java
+++ b/commons/src/main/java/org/dhis2/commons/filters/FilterManager.java
@@ -569,6 +569,7 @@ public class FilterManager implements Serializable {
         observableFollowUp.set(false);
 
         eventStatusFiltersApplied.set(eventStatusFilters.size());
+        enrollmentPeriodFiltersApplied.set(enrollmentPeriodFilters.size());
         enrollmentStatusFiltersApplied.set(enrollmentStatusFilters.size());
         catOptCombFiltersApplied.set(catOptComboFilters.size());
         stateFiltersApplied.set(stateFilters.size());


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://jira.dhis2.org/browse/

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code