### PR TITLE
fix: [ANDROAPP-4993] Dataset indicator not updating when saving value

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValuePresenter.kt
@@ -76,10 +76,14 @@ class DataValuePresenter(
         val tableData = repository.setTableData(dataTableModel, errors)
         val updatedTableModel = mapper(tableData)
 
+        val updatedIndicators = indicatorTables()
+
         allTableState.postValue(
             allTableState.value?.map { tableModel ->
                 if (tableModel.id == catComboUid) {
                     updatedTableModel
+                } else if (tableModel.id == null && updatedIndicators != null) {
+                    updatedIndicators
                 } else {
                     tableModel
                 }

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/TableDataToTableModelMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/TableDataToTableModelMapper.kt
@@ -80,7 +80,7 @@ class TableDataToTableModelMapper(val mapFieldValueToUser: MapFieldValueToUser) 
         )
         val tableRows = tableData.map { (indicatorName, indicatorValue) ->
             TableRowModel(
-                rowHeader = RowHeader("", title = indicatorName!!),
+                rowHeader = RowHeader(id = indicatorName, title = indicatorName!!),
                 values = mapOf(
                     0 to TableCell(id = indicatorName, value = indicatorValue, editable = false)
                 )


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
