### PR TITLE
fix: [ANDROAPP-5138] CatComboOption not properly set for autogenerated events

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataContracts.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataContracts.java
@@ -44,8 +44,6 @@ public class TEIDataContracts {
 
         Consumer<EnrollmentStatus> enrollmentCompleted();
 
-        void showCatComboDialog(String eventUid, Date eventDate, String categoryComboUid);
-
         void switchFollowUp(boolean followUp);
 
         void displayGenerateEvent(String eventUid);
@@ -81,15 +79,13 @@ public class TEIDataContracts {
         void setEnrollment(Enrollment enrollment);
 
         void showSyncDialog(String uid);
+
+        void displayCatComboOptionSelectorForEvents(List<EventViewModel> data);
     }
 
     public interface Presenter extends AbstractActivityContracts.Presenter {
 
         void init();
-
-        void getCatComboOptions(Event event);
-
-        void setDefaultCatOptCombToEvent(String eventUid);
 
         void changeCatOption(String eventUid, String catOptionComboUid);
 

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.java
@@ -1,9 +1,21 @@
 package org.dhis2.usescases.teiDashboard.dashboardfragments.teidata;
 
+import static android.app.Activity.RESULT_OK;
+import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
+import static org.dhis2.commons.Constants.ENROLLMENT_UID;
+import static org.dhis2.commons.Constants.EVENT_CREATION_TYPE;
+import static org.dhis2.commons.Constants.EVENT_PERIOD_TYPE;
+import static org.dhis2.commons.Constants.EVENT_REPEATABLE;
+import static org.dhis2.commons.Constants.EVENT_SCHEDULE_INTERVAL;
+import static org.dhis2.commons.Constants.ORG_UNIT;
+import static org.dhis2.commons.Constants.PROGRAM_UID;
+import static org.dhis2.commons.Constants.TRACKED_ENTITY_INSTANCE;
+import static org.dhis2.utils.analytics.AnalyticsConstants.CREATE_EVENT_TEI;
+import static org.dhis2.utils.analytics.AnalyticsConstants.TYPE_EVENT_TEI;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 import androidx.databinding.ObservableBoolean;
+import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.DividerItemDecoration;
 
@@ -22,38 +35,37 @@ import com.bumptech.glide.load.resource.bitmap.CircleCrop;
 
 import org.dhis2.App;
 import org.dhis2.R;
+import org.dhis2.commons.Constants;
 import org.dhis2.commons.animations.ViewAnimationsKt;
-import org.dhis2.commons.sync.ConflictType;
+import org.dhis2.commons.data.EventCreationType;
 import org.dhis2.commons.data.EventViewModel;
 import org.dhis2.commons.data.StageSection;
 import org.dhis2.commons.dialogs.CustomDialog;
 import org.dhis2.commons.dialogs.DialogClickListener;
+import org.dhis2.commons.dialogs.imagedetail.ImageDetailBottomDialog;
+import org.dhis2.commons.filters.FilterItem;
+import org.dhis2.commons.filters.FilterManager;
+import org.dhis2.commons.filters.FiltersAdapter;
+import org.dhis2.commons.orgunitselector.OUTreeFragment;
+import org.dhis2.commons.orgunitselector.OnOrgUnitSelectionFinished;
+import org.dhis2.commons.resources.ObjectStyleUtils;
+import org.dhis2.commons.sync.ConflictType;
 import org.dhis2.databinding.FragmentTeiDataBinding;
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity;
 import org.dhis2.usescases.general.FragmentGlobalAbstract;
-import org.dhis2.commons.orgunitselector.OUTreeFragment;
-import org.dhis2.commons.orgunitselector.OnOrgUnitSelectionFinished;
 import org.dhis2.usescases.programStageSelection.ProgramStageSelectionActivity;
 import org.dhis2.usescases.teiDashboard.DashboardProgramModel;
 import org.dhis2.usescases.teiDashboard.DashboardViewModel;
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity;
+import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents.CategoryDialogInteractions;
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents.EventAdapter;
-import org.dhis2.commons.data.EventViewModelType;
+import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents.EventCatComboOptionSelector;
 import org.dhis2.usescases.teiDashboard.ui.DetailsButtonKt;
-import org.dhis2.commons.Constants;
 import org.dhis2.utils.DateUtils;
-import org.dhis2.commons.data.EventCreationType;
-import org.dhis2.commons.resources.ObjectStyleUtils;
-import org.dhis2.utils.category.CategoryDialog;
-import org.dhis2.commons.dialogs.imagedetail.ImageDetailBottomDialog;
 import org.dhis2.utils.dialFloatingActionButton.DialItem;
-import org.dhis2.commons.filters.FilterItem;
-import org.dhis2.commons.filters.FilterManager;
-import org.dhis2.commons.filters.FiltersAdapter;
 import org.dhis2.utils.granularsync.SyncStatusDialog;
 import org.hisp.dhis.android.core.enrollment.Enrollment;
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus;
-import org.hisp.dhis.android.core.event.Event;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.program.Program;
 import org.hisp.dhis.android.core.program.ProgramStage;
@@ -71,20 +83,8 @@ import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.functions.Consumer;
 import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 import timber.log.Timber;
-
-import static android.app.Activity.RESULT_OK;
-import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
-import static org.dhis2.commons.Constants.ENROLLMENT_UID;
-import static org.dhis2.commons.Constants.EVENT_CREATION_TYPE;
-import static org.dhis2.commons.Constants.EVENT_PERIOD_TYPE;
-import static org.dhis2.commons.Constants.EVENT_REPEATABLE;
-import static org.dhis2.commons.Constants.EVENT_SCHEDULE_INTERVAL;
-import static org.dhis2.commons.Constants.ORG_UNIT;
-import static org.dhis2.commons.Constants.PROGRAM_UID;
-import static org.dhis2.commons.Constants.TRACKED_ENTITY_INSTANCE;
-import static org.dhis2.utils.analytics.AnalyticsConstants.CREATE_EVENT_TEI;
-import static org.dhis2.utils.analytics.AnalyticsConstants.TYPE_EVENT_TEI;
 
 public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataContracts.View, OnOrgUnitSelectionFinished {
 
@@ -116,9 +116,8 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
     private CustomDialog dialog;
     private ProgramStage programStageFromEvent;
     private final ObservableBoolean followUp = new ObservableBoolean(false);
+    private EventCatComboOptionSelector eventCatComboOptionSelector;
 
-    private boolean hasCatComb;
-    private final ArrayList<Event> catComboShowed = new ArrayList<>();
     private Context context;
     private DashboardViewModel dashboardViewModel;
     private DashboardProgramModel dashboardModel;
@@ -260,8 +259,22 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
         if (nprogram != null && nprogram.getCurrentEnrollment() != null) {
             binding.dialFabLayout.setFabVisible(true);
             presenter.setDashboardProgram(this.dashboardModel);
-            SharedPreferences prefs = context.getSharedPreferences(Constants.SHARE_PREFS, Context.MODE_PRIVATE);
-            hasCatComb = nprogram.getCurrentProgram() != null && !nprogram.getCurrentProgram().categoryComboUid().equals(prefs.getString(Constants.DEFAULT_CAT_COMBO, ""));
+            eventCatComboOptionSelector = new EventCatComboOptionSelector(nprogram.getCurrentProgram().categoryComboUid(),
+                    getChildFragmentManager(),
+                    new CategoryDialogInteractions() {
+                        @Override
+                        public void showDialog(
+                                @NonNull String categoryComboUid,
+                                @Nullable Date dateControl,
+                                @NonNull FragmentManager fragmentManager,
+                                @NonNull Function1<? super String, Unit> onItemSelected) {
+                            CategoryDialogInteractions.DefaultImpls.showDialog(this,
+                                    categoryComboUid,
+                                    dateControl,
+                                    fragmentManager,
+                                    onItemSelected);
+                        }
+                    });
             binding.setDashboardModel(nprogram);
             updateFabItems();
         } else if (nprogram != null) {
@@ -339,27 +352,18 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
             adapter.submitList(events);
 
             for (EventViewModel eventViewModel : events) {
-                if (eventViewModel.getType() == EventViewModelType.EVENT) {
-                    Event event = eventViewModel.getEvent();
-                    if (event.eventDate() != null) {
-                        if (event.eventDate().after(DateUtils.getInstance().getToday()))
-                            binding.teiRecycler.scrollToPosition(events.indexOf(event));
-                    }
-                    if (hasCatComb && event.attributeOptionCombo() == null && !catComboShowed.contains(event)) {
-                        presenter.getCatComboOptions(event);
-                        catComboShowed.add(event);
-                    } else if (!hasCatComb && event.attributeOptionCombo() == null)
-                        presenter.setDefaultCatOptCombToEvent(event.uid());
+                if (eventViewModel.isAfterToday(DateUtils.getInstance().getToday())) {
+                    binding.teiRecycler.scrollToPosition(events.indexOf(eventViewModel));
                 }
             }
         }
         showLoadingProgress(false);
     }
 
-    private void showLoadingProgress(boolean showProgress){
-        if(showProgress){
+    private void showLoadingProgress(boolean showProgress) {
+        if (showProgress) {
             binding.loadingProgress.getRoot().setVisibility(View.VISIBLE);
-        }else{
+        } else {
             binding.loadingProgress.getRoot().setVisibility(View.GONE);
         }
     }
@@ -467,22 +471,6 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
             intent.putExtras(bundle);
             startActivityForResult(intent, REQ_EVENT);
         }
-    }
-
-    @Override
-    public void showCatComboDialog(String eventId, Date eventDate, String categoryComboUid) {
-        CategoryDialog categoryDialog = new CategoryDialog(
-                CategoryDialog.Type.CATEGORY_OPTION_COMBO,
-                categoryComboUid,
-                true,
-                eventDate,
-                selectedCatOptComboUid -> {
-                    presenter.changeCatOption(eventId, selectedCatOptComboUid);
-                    return null;
-                }
-        );
-        categoryDialog.setCancelable(false);
-        categoryDialog.show(getChildFragmentManager(), CategoryDialog.Companion.getTAG());
     }
 
     @Override
@@ -649,6 +637,17 @@ public class TEIDataFragment extends FragmentGlobalAbstract implements TEIDataCo
                 .build();
 
         dialog.show(getChildFragmentManager(), uid);
+    }
+
+    @Override
+    public void displayCatComboOptionSelectorForEvents(List<EventViewModel> data) {
+        eventCatComboOptionSelector.setEventsWithoutCatComboOption(data);
+        eventCatComboOptionSelector.requestCatComboOption(
+                (eventUid, categoryOptionComboUid) -> {
+                    presenter.changeCatOption(eventUid, categoryOptionComboUid);
+                    return null;
+                }
+        );
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenterImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataPresenterImpl.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityOptionsCompat;
 
 import com.google.gson.reflect.TypeToken;
@@ -214,6 +215,9 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
                                     Timber::e
                             )
             );
+
+            getEventsWithoutCatCombo();
+
         } else {
             view.setEnrollmentData(null, null);
         }
@@ -285,25 +289,17 @@ public class TEIDataPresenterImpl implements TEIDataContracts.Presenter {
         return events;
     }
 
-    @Override
-    public void getCatComboOptions(Event event) {
-        if (dashboardRepository.isStageFromProgram(event.programStage())) {
-            compositeDisposable.add(
-                    dashboardRepository.catComboForProgram(event.program())
-                            .filter(categoryCombo -> categoryCombo.isDefault() != Boolean.TRUE && !categoryCombo.name().equals("default"))
-                            .subscribeOn(schedulerProvider.io())
-                            .observeOn(schedulerProvider.ui())
-                            .subscribe(categoryCombo ->
-                                            view.showCatComboDialog(event.uid(),
-                                                    event.eventDate() == null ? event.dueDate() : event.eventDate(),
-                                                    categoryCombo.uid()),
-                                    Timber::e));
-        }
-    }
-
-    @Override
-    public void setDefaultCatOptCombToEvent(String eventUid) {
-        dashboardRepository.setDefaultCatOptCombToEvent(eventUid);
+    @VisibleForTesting()
+    public void getEventsWithoutCatCombo(){
+        compositeDisposable.add(
+                teiDataRepository.eventsWithoutCatCombo()
+                        .subscribeOn(schedulerProvider.io())
+                        .observeOn(schedulerProvider.ui())
+                        .subscribe(
+                                view::displayCatComboOptionSelectorForEvents,
+                                Timber::e
+                        )
+        );
     }
 
     @Override

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepository.kt
@@ -30,4 +30,5 @@ interface TeiDataRepository {
     fun getEnrollmentProgram(): Single<Program>
     fun getTrackedEntityInstance(): Single<TrackedEntityInstance>
     fun enrollingOrgUnit(): Single<OrganisationUnit>
+    fun eventsWithoutCatCombo(): Single<List<EventViewModel>>
 }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
@@ -113,7 +113,10 @@ class TeiDataRepositoryImpl(
                         .byEnrollmentUid().eq(enrollmentUid)
                         .byAttributeOptionComboUid().isNull
                         .get()
-                    val eventSource = Single.zip(eventsWithDefaultCatCombo, eventsWithNoCatCombo) { sourceA, sourceB ->
+                    val eventSource = Single.zip(
+                        eventsWithDefaultCatCombo,
+                        eventsWithNoCatCombo
+                    ) { sourceA, sourceB ->
                         mutableListOf<Event>().apply {
                             addAll(sourceA)
                             addAll(sourceB)

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/CategoryDialogInteractions.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/CategoryDialogInteractions.kt
@@ -1,0 +1,23 @@
+package org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents
+
+import androidx.fragment.app.FragmentManager
+import java.util.Date
+import org.dhis2.utils.category.CategoryDialog
+
+interface CategoryDialogInteractions {
+    fun showDialog(
+        categoryComboUid: String,
+        dateControl: Date?,
+        fragmentManager: FragmentManager,
+        onItemSelected: (selectedCatOptComboUid: String) -> Unit
+    ) {
+        val categoryDialog = CategoryDialog(
+            CategoryDialog.Type.CATEGORY_OPTION_COMBO,
+            categoryComboUid,
+            true,
+            dateControl
+        ) { selectedCatOptComboUid -> onItemSelected(selectedCatOptComboUid) }
+        categoryDialog.isCancelable = false
+        categoryDialog.show(fragmentManager, CategoryDialog.TAG)
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventCatComboOptionSelector.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventCatComboOptionSelector.kt
@@ -1,0 +1,41 @@
+package org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents
+
+import androidx.annotation.VisibleForTesting
+import androidx.fragment.app.FragmentManager
+import java.util.LinkedList
+import java.util.Queue
+import org.dhis2.commons.data.EventViewModel
+
+class EventCatComboOptionSelector(
+    private val categoryComboUid: String,
+    private val fragmentManager: FragmentManager,
+    private val categoryDialogInteractions: CategoryDialogInteractions = object :
+        CategoryDialogInteractions {}
+) {
+
+    private val eventsWithoutCatComboOptionQueue: Queue<EventViewModel> = LinkedList()
+
+    fun setEventsWithoutCatComboOption(events: List<EventViewModel>) {
+        eventsWithoutCatComboOptionQueue.clear()
+        eventsWithoutCatComboOptionQueue.addAll(events)
+    }
+
+    fun requestCatComboOption(
+        onCatOptionComboSelected: (eventUid: String, selectedCatOptComboUid: String) -> Unit
+    ) {
+        pollEvent()?.let { eventModel ->
+            val event = eventModel.event
+            categoryDialogInteractions.showDialog(
+                categoryComboUid,
+                event!!.eventDate() ?: event.dueDate(),
+                fragmentManager
+            ) { selectedCatOptComboUid ->
+                onCatOptionComboSelected(event.uid(), selectedCatOptComboUid)
+                requestCatComboOption(onCatOptionComboSelected)
+            }
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun pollEvent(): EventViewModel? = eventsWithoutCatComboOptionQueue.poll()
+}

--- a/app/src/main/java/org/dhis2/utils/category/CategoryDialog.kt
+++ b/app/src/main/java/org/dhis2/utils/category/CategoryDialog.kt
@@ -93,6 +93,12 @@ class CategoryDialog(
             this,
             Observer {
                 adapter?.submitList(it)
+                binding.layoutSearch.visibility =
+                    if ((adapter?.itemCount ?: 0) < DEFAULT_COUNT_LIMIT) {
+                        View.GONE
+                    } else {
+                        View.VISIBLE
+                    }
             }
         )
     }

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/data/TeiDataPresenterImplTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/data/TeiDataPresenterImplTest.kt
@@ -8,8 +8,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import io.reactivex.Observable
-import java.util.Date
+import io.reactivex.Single
 import org.dhis2.commons.filters.FilterManager
 import org.dhis2.commons.filters.data.FilterRepository
 import org.dhis2.commons.prefs.PreferenceProvider
@@ -22,8 +21,6 @@ import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.TEIDataPresen
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.TeiDataRepository
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
-import org.hisp.dhis.android.core.category.CategoryCombo
-import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.program.ProgramStage
 import org.junit.Assert.assertTrue
@@ -46,7 +43,7 @@ class TeiDataPresenterImplTest {
     private val analytics: AnalyticsHelper = mock()
     private val filterManager: FilterManager = mock()
     private val filterRepository: FilterRepository = mock()
-    private lateinit var teiDataPresenterImpl: TEIDataContracts.Presenter
+    private lateinit var teiDataPresenterImpl: TEIDataPresenterImpl
     private val valueStore: FormValueStore = mock()
 
     @Before
@@ -114,92 +111,10 @@ class TeiDataPresenterImplTest {
 
     @Test
     fun `Should show category combo dialog`() {
-        val testingDate = Date()
-        val testingEvent = Event.builder()
-            .uid("eventUid")
-            .eventDate(testingDate)
-            .program("programUid")
-            .programStage("stageUid")
-            .build()
         whenever(
-            dashboardRepository.isStageFromProgram("stageUid")
-        ) doReturn true
-        whenever(
-            dashboardRepository.catComboForProgram(any())
-        ) doReturn Observable.just(
-            CategoryCombo.builder()
-                .uid("catComboUid")
-                .name("catComboName")
-                .isDefault(false)
-                .build()
-        )
-        teiDataPresenterImpl.getCatComboOptions(testingEvent)
-        verify(view).showCatComboDialog("eventUid", testingDate, "catComboUid")
-    }
-
-    @Test
-    fun `Should not show category combo dialog if default catCombo`() {
-        val testingDate = Date()
-        val testingEvent = Event.builder()
-            .uid("eventUid")
-            .eventDate(testingDate)
-            .program("programUid")
-            .programStage("stageUid")
-            .build()
-        whenever(
-            dashboardRepository.isStageFromProgram(any())
-        ) doReturn true
-        whenever(
-            dashboardRepository.catComboForProgram("programUid")
-        ) doReturn Observable.just(
-            CategoryCombo.builder()
-                .uid("catComboUid")
-                .name("default")
-                .isDefault(true)
-                .build()
-        )
-        teiDataPresenterImpl.getCatComboOptions(testingEvent)
-        verify(view, times(0)).showCatComboDialog("eventUid", testingDate, "catComboUid")
-    }
-
-    @Test
-    fun `Should not show category combo dialog if default catCombo by name`() {
-        val testingDate = Date()
-        val testingEvent = Event.builder()
-            .uid("eventUid")
-            .eventDate(testingDate)
-            .program("programUid")
-            .programStage("stageUid")
-            .build()
-        whenever(
-            dashboardRepository.isStageFromProgram(any())
-        ) doReturn true
-        whenever(
-            dashboardRepository.catComboForProgram("programUid")
-        ) doReturn Observable.just(
-            CategoryCombo.builder()
-                .uid("catComboUid")
-                .name("default")
-                .isDefault(false)
-                .build()
-        )
-        teiDataPresenterImpl.getCatComboOptions(testingEvent)
-        verify(view, times(0)).showCatComboDialog("eventUid", testingDate, "catComboUid")
-    }
-
-    @Test
-    fun `Should not show category combo dialog if stage not in program`() {
-        val testingDate = Date()
-        val testingEvent = Event.builder()
-            .uid("eventUid")
-            .eventDate(testingDate)
-            .program("programUid")
-            .programStage("stageUid")
-            .build()
-        whenever(
-            dashboardRepository.isStageFromProgram(any())
-        ) doReturn false
-        teiDataPresenterImpl.getCatComboOptions(testingEvent)
-        verify(view, times(0)).showCatComboDialog("eventUid", testingDate, "catComboUid")
+            teiDataRepository.eventsWithoutCatCombo()
+        ) doReturn Single.just(mock())
+        teiDataPresenterImpl.getEventsWithoutCatCombo()
+        verify(view).displayCatComboOptionSelectorForEvents(any())
     }
 }

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventCatComboOptionSelectorTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventCatComboOptionSelectorTest.kt
@@ -1,0 +1,65 @@
+package org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.teievents
+
+import androidx.fragment.app.FragmentManager
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.dhis2.commons.data.EventViewModel
+import org.hisp.dhis.android.core.event.Event
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EventCatComboOptionSelectorTest {
+
+    private val catComboUid: String = "catComboUid"
+    private val fragmentManager: FragmentManager = mock()
+    private val categoryDialogInteractions: CategoryDialogInteractions = mock()
+    private val eventCatComboOptionSelector = EventCatComboOptionSelector(
+        catComboUid,
+        fragmentManager,
+        categoryDialogInteractions
+    )
+
+    @Test
+    fun should_set_events() {
+        val list = listOf(mock<EventViewModel>())
+        eventCatComboOptionSelector.setEventsWithoutCatComboOption(list)
+        assertTrue(eventCatComboOptionSelector.pollEvent() == list.first())
+    }
+
+    @Test
+    fun should_clear_previous_queue_and_set_events() {
+        val prevList = listOf(mock<EventViewModel>())
+        val list = listOf(mock<EventViewModel>())
+        eventCatComboOptionSelector.setEventsWithoutCatComboOption(prevList)
+        assertTrue(eventCatComboOptionSelector.pollEvent() == prevList.first())
+        eventCatComboOptionSelector.setEventsWithoutCatComboOption(list)
+        assertTrue(eventCatComboOptionSelector.pollEvent() != prevList.first())
+        assertTrue(eventCatComboOptionSelector.pollEvent() == list.first())
+    }
+
+    @Test
+    fun should_request_cat_option_combo() {
+        val mockedEvent = mock<Event> {
+            on { eventDate() } doReturn mock()
+            on { uid() } doReturn "eventUid"
+        }
+        val mockedEventViewModel = mock<EventViewModel> {
+            on { event } doReturn mockedEvent
+        }
+        val list = listOf(mockedEventViewModel)
+        eventCatComboOptionSelector.setEventsWithoutCatComboOption(list)
+        eventCatComboOptionSelector.requestCatComboOption { eventUid, selectedCatOptComboUid -> }
+        verify(categoryDialogInteractions).showDialog(any(), any(), any(), any())
+    }
+
+    @Test
+    fun should_not_request_cat_option_combo() {
+        val list = emptyList<EventViewModel>()
+        eventCatComboOptionSelector.setEventsWithoutCatComboOption(list)
+        eventCatComboOptionSelector.requestCatComboOption { eventUid, selectedCatOptComboUid -> }
+        verify(categoryDialogInteractions, times(0)).showDialog(any(), any(), any(), any())
+    }
+}

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventCatComboOptionSelectorTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/teievents/EventCatComboOptionSelectorTest.kt
@@ -36,8 +36,11 @@ class EventCatComboOptionSelectorTest {
         eventCatComboOptionSelector.setEventsWithoutCatComboOption(prevList)
         assertTrue(eventCatComboOptionSelector.pollEvent() == prevList.first())
         eventCatComboOptionSelector.setEventsWithoutCatComboOption(list)
-        assertTrue(eventCatComboOptionSelector.pollEvent() != prevList.first())
-        assertTrue(eventCatComboOptionSelector.pollEvent() == list.first())
+        eventCatComboOptionSelector.pollEvent().let {
+            assertTrue(it != null)
+            assertTrue(it != prevList.first())
+            assertTrue(it == list.first())
+        }
     }
 
     @Test

--- a/commons/src/main/java/org/dhis2/commons/data/EventViewModel.kt
+++ b/commons/src/main/java/org/dhis2/commons/data/EventViewModel.kt
@@ -32,6 +32,11 @@ data class EventViewModel(
             true
         }
     }
+
+    fun isAfterToday(today: Date): Boolean {
+        return type == EventViewModelType.EVENT && event?.eventDate() != null &&
+            event.eventDate()?.after(today) == true
+    }
 }
 
 fun List<EventViewModel>.uids(): List<String> {


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
