### PR TITLE
[ANDROAPP-5172] Avoid ConcurrentModificationException by using iterators

### DIFF
--- a/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
@@ -285,13 +285,11 @@ class FormRepositoryImpl(
             mandatory.value == sectionFieldUiModel.uid
         }?.size ?: 0
 
-        val errorCount = getFieldsWithError().associate {
-            it.fieldUid to it.message
-        }.filter { error ->
+        val errorCount = ruleEffectsResult?.errorMap()?.filter { error ->
             fields.firstOrNull { field ->
                 field.uid == error.key && field.programStageSection == sectionFieldUiModel.uid
             } != null
-        }.size
+        }?.size ?: 0
 
         return dataEntryRepository?.updateSection(
             sectionFieldUiModel,

--- a/form/src/main/java/org/dhis2/form/data/RuleUtilsProviderResult.kt
+++ b/form/src/main/java/org/dhis2/form/data/RuleUtilsProviderResult.kt
@@ -18,12 +18,24 @@ data class RuleUtilsProviderResult(
     val optionGroupsToHide: Map<String, List<String>>,
     val optionGroupsToShow: Map<String, List<String>>
 ) {
-    fun errorMap(): Map<String, String> = fieldsWithErrors.associate {
-        it.fieldUid to it.errorMessage
+    fun errorMap(): Map<String, String> {
+        val map: MutableMap<String, String> = mutableMapOf()
+        val iterator = fieldsWithErrors.toMutableList().listIterator()
+        while (iterator.hasNext()) {
+            val item = iterator.next()
+            map[item.fieldUid] = item.errorMessage
+        }
+        return map
     }
 
-    fun warningMap(): Map<String, String> = fieldsWithWarnings.associate {
-        it.fieldUid to it.errorMessage
+    fun warningMap(): Map<String, String> {
+        val map: MutableMap<String, String> = mutableMapOf()
+        val iterator = fieldsWithWarnings.toMutableList().listIterator()
+        while (iterator.hasNext()) {
+            val item = iterator.next()
+            map[item.fieldUid] = item.errorMessage
+        }
+        return map
     }
 
     fun optionsToHide(fieldUid: String): List<String> {


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-5172)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [x] 11.X - 13.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
