### PR TITLE
chore: [ANDROAPP-5267] Disables support for Flipper for devices lower than Android 7 (API 22)

### DIFF
--- a/app/src/debug/java/org.dhis2/data/appinspector/AppInspector.kt
+++ b/app/src/debug/java/org.dhis2/data/appinspector/AppInspector.kt
@@ -1,6 +1,7 @@
 package org.dhis2.data.appinspector
 
 import android.content.Context
+import android.os.Build
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin
 import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
@@ -17,25 +18,27 @@ class AppInspector(private val context: Context) {
         private set
 
     fun init(): AppInspector {
-        SoLoader.init(context, false)
-        if (BuildConfig.DEBUG && BuildConfig.FLAVOR != "dhisUITesting") {
-            AndroidFlipperClient.getInstance(context).apply {
-                addPlugin(
-                    layoutInspectorPlugin()
-                )
-                addPlugin(
-                    databaseInspectorPlugin()
-                )
-                addPlugin(
-                    networkInspectorPlugin()
-                )
-                addPlugin(
-                    sharedPreferencesPlugin()
-                )
-                addPlugin(
-                    crashPlugin()
-                )
-                start()
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) {
+            SoLoader.init(context, false)
+            if (BuildConfig.DEBUG && BuildConfig.FLAVOR != "dhisUITesting") {
+                AndroidFlipperClient.getInstance(context).apply {
+                    addPlugin(
+                        layoutInspectorPlugin()
+                    )
+                    addPlugin(
+                        databaseInspectorPlugin()
+                    )
+                    addPlugin(
+                        networkInspectorPlugin()
+                    )
+                    addPlugin(
+                        sharedPreferencesPlugin()
+                    )
+                    addPlugin(
+                        crashPlugin()
+                    )
+                    start()
+                }
             }
         }
         return this


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
