### PR TITLE
fix: [ANDROAPP-5251] Close sync dialog after form section is opened

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
@@ -158,7 +158,7 @@ class EventCaptureActivity :
 
     fun openForm() {
         supportFragmentManager.findFragmentByTag("EVENT_SYNC")?.let {
-            if(it is SyncStatusDialog){
+            if (it is SyncStatusDialog) {
                 it.dismiss()
             }
         }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
@@ -157,6 +157,11 @@ class EventCaptureActivity :
     }
 
     fun openForm() {
+        supportFragmentManager.findFragmentByTag("EVENT_SYNC")?.let {
+            if(it is SyncStatusDialog){
+                it.dismiss()
+            }
+        }
         binding?.navigationBar?.selectItemAt(1)
     }
 


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-ANDROAPP-5251)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
