### PR TITLE
fix: [ANDROAPP-5310] Adds bottom padding to table to show last item when keyboard is open

### DIFF
--- a/stock-usecase/src/main/java/org/dhis2/android/rtsm/ui/managestock/components/ManageStockTable.kt
+++ b/stock-usecase/src/main/java/org/dhis2/android/rtsm/ui/managestock/components/ManageStockTable.kt
@@ -59,7 +59,7 @@ fun ManageStockTable(
                         rowHeaderWidths = emptyMap(),
                         columnWidth = emptyMap(),
                         defaultRowHeaderWidth = with(localDensity) { 200.dp.toPx() }.toInt(),
-                        tableBottomPadding = 16.dp
+                        tableBottomPadding = 48.dp
                     )
                 )
             }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
