### PR TITLE
[ANDROAPP-5130] Follow-up clicks can be skipped by the app when entering data into tables

### DIFF
--- a/compose-table/src/main/java/org/dhis2/composetable/model/TableModel.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/model/TableModel.kt
@@ -137,5 +137,4 @@ fun TableModel.areAllValuesEmpty(): Boolean {
     return true
 }
 
-val LocalSelectedCell = compositionLocalOf<TableCell?> { null }
-val LocalUpdatingCell = compositionLocalOf<TableCell?> { null }
+val LocalCurrentCellValue = compositionLocalOf<() -> String?> { {""} }

--- a/compose-table/src/main/java/org/dhis2/composetable/model/TableModel.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/model/TableModel.kt
@@ -137,4 +137,5 @@ fun TableModel.areAllValuesEmpty(): Boolean {
     return true
 }
 
-val LocalCurrentCellValue = compositionLocalOf<() -> String?> { {""} }
+val LocalCurrentCellValue = compositionLocalOf<() -> String?> { { "" } }
+val LocalUpdatingCell = compositionLocalOf<TableCell?> { null }

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/DataSetTableScreen.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/DataSetTableScreen.kt
@@ -32,8 +32,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.dhis2.composetable.TableScreenState
 import org.dhis2.composetable.actions.TableInteractions
-import org.dhis2.composetable.model.LocalSelectedCell
-import org.dhis2.composetable.model.LocalUpdatingCell
+import org.dhis2.composetable.model.LocalCurrentCellValue
 import org.dhis2.composetable.model.TableCell
 import org.dhis2.composetable.model.TableDialogModel
 import org.dhis2.composetable.model.TextInputModel
@@ -64,7 +63,6 @@ fun DataSetTableScreen(
     )
 
     var currentCell by remember { mutableStateOf<TableCell?>(null) }
-    var updatingCell by remember { mutableStateOf<TableCell?>(null) }
     var currentInputType by remember { mutableStateOf(TextInputModel()) }
     var displayDescription by remember { mutableStateOf<TableDialogModel?>(null) }
     val coroutineScope = rememberCoroutineScope()
@@ -184,7 +182,6 @@ fun DataSetTableScreen(
                                     successValidation = result is ValidationResult.Success
                                 )?.let { (tableCell, nextCell) ->
                                     if (nextCell != cellSelected) {
-                                        updatingCell = currentCell
                                         tableSelection = nextCell
                                         onCellClick(
                                             tableSelection.tableId,
@@ -225,9 +222,8 @@ fun DataSetTableScreen(
             }
         }
         CompositionLocalProvider(
-            LocalSelectedCell provides currentCell,
             LocalTableSelection provides tableSelection,
-            LocalUpdatingCell provides updatingCell
+            LocalCurrentCellValue provides { currentCell?.value }
         ) {
             DataTable(
                 tableList = tableScreenState.tables,
@@ -242,7 +238,6 @@ fun DataSetTableScreen(
 
                     override fun onClick(tableCell: TableCell) {
                         currentCell?.takeIf { it != tableCell }?.let { onSaveValue(it) }
-                        updatingCell = currentCell
                         onCellClick(
                             tableSelection.tableId,
                             tableCell

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/DataSetTableScreen.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/DataSetTableScreen.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import org.dhis2.composetable.TableScreenState
 import org.dhis2.composetable.actions.TableInteractions
 import org.dhis2.composetable.model.LocalCurrentCellValue
+import org.dhis2.composetable.model.LocalUpdatingCell
 import org.dhis2.composetable.model.TableCell
 import org.dhis2.composetable.model.TableDialogModel
 import org.dhis2.composetable.model.TextInputModel
@@ -63,6 +64,7 @@ fun DataSetTableScreen(
     )
 
     var currentCell by remember { mutableStateOf<TableCell?>(null) }
+    var updatingCell by remember { mutableStateOf<TableCell?>(null) }
     var currentInputType by remember { mutableStateOf(TextInputModel()) }
     var displayDescription by remember { mutableStateOf<TableDialogModel?>(null) }
     val coroutineScope = rememberCoroutineScope()
@@ -182,6 +184,7 @@ fun DataSetTableScreen(
                                     successValidation = result is ValidationResult.Success
                                 )?.let { (tableCell, nextCell) ->
                                     if (nextCell != cellSelected) {
+                                        updatingCell = currentCell
                                         tableSelection = nextCell
                                         onCellClick(
                                             tableSelection.tableId,
@@ -223,7 +226,8 @@ fun DataSetTableScreen(
         }
         CompositionLocalProvider(
             LocalTableSelection provides tableSelection,
-            LocalCurrentCellValue provides { currentCell?.value }
+            LocalCurrentCellValue provides { currentCell?.value },
+            LocalUpdatingCell provides updatingCell
         ) {
             DataTable(
                 tableList = tableScreenState.tables,
@@ -238,6 +242,7 @@ fun DataSetTableScreen(
 
                     override fun onClick(tableCell: TableCell) {
                         currentCell?.takeIf { it != tableCell }?.let { onSaveValue(it) }
+                        updatingCell = currentCell
                         onCellClick(
                             tableSelection.tableId,
                             tableCell

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/DataSetTableUi.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/DataSetTableUi.kt
@@ -89,6 +89,7 @@ import org.dhis2.composetable.model.HeaderMeasures
 import org.dhis2.composetable.model.ItemColumnHeaderUiState
 import org.dhis2.composetable.model.ItemHeaderUiState
 import org.dhis2.composetable.model.LocalCurrentCellValue
+import org.dhis2.composetable.model.LocalUpdatingCell
 import org.dhis2.composetable.model.ResizingCell
 import org.dhis2.composetable.model.RowHeader
 import org.dhis2.composetable.model.TableCell
@@ -694,8 +695,12 @@ fun TableCell(
     onOptionSelected: (TableCell, String, String) -> Unit,
     onTextChange: (() -> String?)? = null
 ) {
+    val localUpdatingCell = LocalUpdatingCell.current
     val (dropDownExpanded, setExpanded) = remember { mutableStateOf(false) }
-    var cellValue = cell.value
+    var cellValue = when (localUpdatingCell?.id) {
+        cell.id -> localUpdatingCell?.value
+        else -> cell.value
+    }
     onTextChange?.let {
         cellValue = it()
     }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-5130)

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
