### PR TITLE
fix: [ANDROSDK-1687] Adapt analytics to changes in SDK; remove unused period

### DIFF
--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/mappers/VisualizationToGraph.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/mappers/VisualizationToGraph.kt
@@ -53,9 +53,8 @@ class VisualizationToGraph(
         selectedRelativePeriod: RelativePeriod?,
         selectedOrgUnits: List<String>?
     ): Graph {
-        val period = visualization.relativePeriods()?.filter { it.value }?.keys?.first()
         val categories = getCategories(visualization.type(), gridAnalyticsResponse)
-        val formattedCategory = formatCategories(period, categories, gridAnalyticsResponse.metadata)
+        val formattedCategory = formatCategories(categories, gridAnalyticsResponse.metadata)
 
         return Graph(
             title = customTitle ?: visualization.displayName() ?: "",
@@ -115,21 +114,18 @@ class VisualizationToGraph(
     }
 
     private fun formatCategories(
-        period: RelativePeriod?,
         categories: List<String>,
         metadata: Map<String, MetadataItem>
     ): List<String> {
-        return period?.let {
-            categories.map { category ->
-                when (val metadataItem = metadata[category]) {
-                    is MetadataItem.PeriodItem -> periodStepProvider.periodUIString(
-                        Locale.getDefault(),
-                        metadataItem.item
-                    )
-                    else -> category
-                }
+        return categories.map { category ->
+            when (val metadataItem = metadata[category]) {
+                is MetadataItem.PeriodItem -> periodStepProvider.periodUIString(
+                    Locale.getDefault(),
+                    metadataItem.item
+                )
+                else -> category
             }
-        } ?: categories
+        }
     }
 
     private fun getSeries(


### PR DESCRIPTION
## Description
The property `relationPeriods` has been removed in the SDK from the Visualization model as part of [ANDROSDK-1687](https://dhis2.atlassian.net/browse/ANDROSDK-1687). There was just one usage of this property in the Android app, which is removed in the PR.

## Solution description
The parameter has been removed from the function as it didn't have any effect on the result.

## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet

## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other


[ANDROSDK-1687]: https://dhis2.atlassian.net/browse/ANDROSDK-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ