### PR TITLE
fix: [ANDROAPP-5253] Removes event status filter check when resetting filters

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/filters/FilterManager.java
+++ b/commons/src/main/java/org/dhis2/commons/filters/FilterManager.java
@@ -539,7 +539,7 @@ public class FilterManager implements Serializable {
 
     public void clearAllFilters() {
         eventStatusFilters.clear();
-        observableEventStatus.set(eventStatusFilters);
+        observableEventStatus.set(null);
         enrollmentStatusFilters.clear();
         observableEnrollmentStatus.set(null);
         catOptComboFilters.clear();


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
