### PR TITLE
fix: [ANDROAPP-5330] Handles indexOutOfBounds when checking for errors in cells

### DIFF
--- a/compose-table/src/main/java/org/dhis2/composetable/model/TableModel.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/model/TableModel.kt
@@ -54,8 +54,12 @@ data class TableModel(
         }
     }
 
-    fun cellHasError(cell: TableSelection.CellSelection): TableCell? =
-        tableRows[cell.rowIndex].values[cell.columnIndex]?.takeIf { it.error != null }
+    fun cellHasError(cell: TableSelection.CellSelection): TableCell? {
+        return when {
+            cell.globalIndex > tableRows.size -> null
+            else -> tableRows[cell.rowIndex].values[cell.columnIndex]?.takeIf { it.error != null }
+        }
+    }
 
     fun hasCellWithId(cellId: String?): Boolean {
         return tableRows.any { row ->

--- a/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
+++ b/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
@@ -115,7 +115,7 @@ class TableModelTest {
 
     @Test
     fun returnNullWhenSelectionIsLastCell() {
-        val currentSelection = TableSelection.CellSelection("table", 4, 2, 1)
+        val currentSelection = TableSelection.CellSelection("table", 3, 2, 1)
         assert(tableModel.getNextCell(currentSelection, true) == null)
     }
 

--- a/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
+++ b/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
@@ -48,7 +48,7 @@ class TableModelTest {
                 values = mapOf(
                     Pair(0, TableCell("10", 1, 0, "4")),
                     Pair(1, TableCell("11", 1, 1, "5", editable = false)),
-                    Pair(2, TableCell("12", 1, 2, "6")),
+                    Pair(2, TableCell("12", 1, 2, "6"))
                 )
             ),
             TableRowModel(
@@ -104,22 +104,6 @@ class TableModelTest {
     }
 
     @Test
-    fun shouldReturnCellWithError() {
-        val currentSelection = TableSelection.CellSelection("table", 3, 2, 0)
-        tableModel.cellHasError(currentSelection)?.let {
-            assert(it.id == "13")
-            assert(it.error == "error")
-        }
-    }
-
-    @Test
-    fun shouldNotReturnCellWhenCellIsNoLongerPartOfTableRows() {
-        val currentSelection = TableSelection.CellSelection("table", 4, 2, 0)
-        assert(tableModel.cellHasError(currentSelection) == null)
-
-    }
-
-    @Test
     fun moveToCellOnTheNextRow() {
         val currentSelection = TableSelection.CellSelection("table", 3, 0, 0)
         tableModel.getNextCell(currentSelection, true)?.let { (tableCell, nextSelection) ->
@@ -160,6 +144,21 @@ class TableModelTest {
             assert(nextSelection.rowIndex == 1)
             assert(nextSelection.columnIndex == 0)
         }
+    }
+
+    @Test
+    fun shouldReturnCellWithError() {
+        val currentSelection = TableSelection.CellSelection("table", 3, 2, 0)
+        tableModel.cellHasError(currentSelection)?.let {
+            assert(it.id == "13")
+            assert(it.error == "error")
+        }
+    }
+
+    @Test
+    fun shouldNotReturnCellWhenCellIsNoLongerPartOfTableRows() {
+        val currentSelection = TableSelection.CellSelection("table", 4, 2, 0)
+        assert(tableModel.cellHasError(currentSelection) == null)
     }
 
     @Test

--- a/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
+++ b/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
@@ -115,7 +115,7 @@ class TableModelTest {
 
     @Test
     fun returnNullWhenSelectionIsLastCell() {
-        val currentSelection = TableSelection.CellSelection("table", 3, 1, 1)
+        val currentSelection = TableSelection.CellSelection("table", 4, 2, 1)
         assert(tableModel.getNextCell(currentSelection, true) == null)
     }
 

--- a/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
+++ b/compose-table/src/test/java/org/dhis2/composetable/TableModelTest.kt
@@ -48,7 +48,19 @@ class TableModelTest {
                 values = mapOf(
                     Pair(0, TableCell("10", 1, 0, "4")),
                     Pair(1, TableCell("11", 1, 1, "5", editable = false)),
-                    Pair(2, TableCell("12", 1, 2, "6"))
+                    Pair(2, TableCell("12", 1, 2, "6")),
+                )
+            ),
+            TableRowModel(
+                rowHeader = RowHeader(
+                    id = "2",
+                    title = "Row 3",
+                    row = 2
+                ),
+                values = mapOf(
+                    Pair(0, TableCell("13", 2, 0, "7", error = "error")),
+                    Pair(1, TableCell("14", 2, 1, "8")),
+                    Pair(2, TableCell("15", 2, 2, "9"))
                 )
             )
         )
@@ -89,6 +101,22 @@ class TableModelTest {
             assert(nextSelection.rowIndex == 0)
             assert(nextSelection.columnIndex == 1)
         }
+    }
+
+    @Test
+    fun shouldReturnCellWithError() {
+        val currentSelection = TableSelection.CellSelection("table", 3, 2, 0)
+        tableModel.cellHasError(currentSelection)?.let {
+            assert(it.id == "13")
+            assert(it.error == "error")
+        }
+    }
+
+    @Test
+    fun shouldNotReturnCellWhenCellIsNoLongerPartOfTableRows() {
+        val currentSelection = TableSelection.CellSelection("table", 4, 2, 0)
+        assert(tableModel.cellHasError(currentSelection) == null)
+
     }
 
     @Test


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
