### PR TITLE
fix: [ANDROAPP-5370] hide navigation button when tei have no coordinate

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/form/FormTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/form/FormTest.kt
@@ -277,6 +277,7 @@ class FormTest : BaseTest() {
         enrollmentRobot {
             clickOnPersonAttributesUsingButton("Attributes - Person")
             scrollToBottomProgramForm()
+            clickOnInputDate("DD TEST AGE *")
             clickOnDatePicker()
             clickOnAcceptEnrollmentDate()
             clickOnInputDate("DD TEST DATE *")

--- a/dhis2_android_maps/src/main/java/org/dhis2/maps/carousel/CarouselTeiHolder.kt
+++ b/dhis2_android_maps/src/main/java/org/dhis2/maps/carousel/CarouselTeiHolder.kt
@@ -142,8 +142,10 @@ class CarouselTeiHolder(
     }
 
     override fun showNavigateButton() {
-        dataModel?.setShowNavigationButton(true)
-        binding.mapNavigateFab.show()
+        if (dataModel?.tei?.geometry() != null) {
+            dataModel?.setShowNavigationButton(true)
+            binding.mapNavigateFab.show()
+        }
     }
 
     override fun hideNavigateButton() {


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
