### PR TITLE
chore: [ANDROAPP-5074] Adds desugar to move out zxing-android-embedded from jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,12 +61,6 @@ allprojects {
 
     repositories {
         google()
-        jcenter() {
-            content {
-                includeModule("com.journeyapps", "zxing-android-embedded")
-                //Only works for API 24+ using Maven Repository, 19+ can be used but we have to downgrade zxing to 3.3.0
-            }
-        }
         mavenCentral()
         maven {
             url = uri("https://maven.google.com")

--- a/form/build.gradle.kts
+++ b/form/build.gradle.kts
@@ -37,6 +37,7 @@ android {
     flavorDimensions("default")
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
