### PR TITLE
[ANDROSDK-1717] Adapt filter calls to non-nullable items in lists

### DIFF
--- a/app/src/main/java/org/dhis2/Bindings/Extensions.kt
+++ b/app/src/main/java/org/dhis2/Bindings/Extensions.kt
@@ -68,7 +68,7 @@ fun TrackedEntityInstance.profilePicturePath(d2: D2, programUid: String?): Strin
     } else if (attributes.isEmpty() && programUid == null) {
         val enrollmentProgramUids = d2.enrollmentModule().enrollments()
             .byTrackedEntityInstance().eq(uid())
-            .blockingGet().map { it.program() }.distinct()
+            .blockingGet().mapNotNull { it.program() }.distinct()
         attributes = d2.programModule().programTrackedEntityAttributes()
             .byDisplayInList().isTrue
             .byProgram().`in`(enrollmentProgramUids)

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/dataSetSection/DataValueRepository.kt
@@ -53,7 +53,7 @@ class DataValueRepository(
                 ?.dataSetElements()
         val categoryCombos = when (sectionUid) {
             "NO_SECTION" -> {
-                dataSetElements?.map {
+                dataSetElements?.mapNotNull {
                     it.categoryCombo()?.uid()
                         ?: d2.dataElementModule().dataElements()
                             .uid(it.dataElement().uid())
@@ -70,7 +70,7 @@ class DataValueRepository(
                     ?.map { it.uid() }
                 dataSetElements
                     ?.filter { dataElementsSectionUid?.contains(it.dataElement().uid()) == true }
-                    ?.map {
+                    ?.mapNotNull {
                         it.categoryCombo()?.uid()
                             ?: d2.dataElementModule().dataElements()
                                 .uid(it.dataElement().uid())

--- a/app/src/main/java/org/dhis2/utils/granularsync/GranularSyncPresenter.kt
+++ b/app/src/main/java/org/dhis2/utils/granularsync/GranularSyncPresenter.kt
@@ -369,7 +369,7 @@ class GranularSyncPresenter(
         return d2.dataSetModule().dataSets().withDataSetElements().uid(syncContext.recordUid())
             .get()
             .map {
-                it.dataSetElements()?.map { dataSetElement ->
+                it.dataSetElements()?.mapNotNull { dataSetElement ->
                     if (dataSetElement.categoryCombo() != null) {
                         dataSetElement.categoryCombo()?.uid()
                     } else {


### PR DESCRIPTION
## Description
The SDK has refactored their repository filters and some nullability checks are stricter than before. In particular, list filters used to accept `List<T?>?` because Java didn't specify nullability. In Kotlin, it has been refactored to `List<T>?`, accepting nullable lists of nonNullable items.

[ANDROSDK-1717](https://dhis2.atlassian.net/browse/ANDROSDK-1717)

## Solution description
Replace `map` by `mapNotNull` to ensure nonNull items.
## Covered unit test cases

## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROSDK-1717]: https://dhis2.atlassian.net/browse/ANDROSDK-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ