### PR TITLE
Refactor filter methods in dataSource

### DIFF
--- a/app/src/main/java/org/dhis2/utils/category/CategoryDialogPresenter.kt
+++ b/app/src/main/java/org/dhis2/utils/category/CategoryDialogPresenter.kt
@@ -153,17 +153,11 @@ class CategoryDialogPresenter(
         )
     }
 
-    private fun filterByDate(options: MutableList<CategoryOption>): MutableList<CategoryOption>? {
-        val iterator = options.iterator()
-        while (iterator.hasNext()) {
-            val option = iterator.next()
-            if (date != null &&
-                (isBeforeDate(option) || isAfterDate(option))
-            ) {
-                iterator.remove()
-            }
+    private fun filterByDate(options: List<CategoryOption>): List<CategoryOption> {
+        return options.filter {
+            date == null ||
+                (!isBeforeDate(it) && !isAfterDate(it))
         }
-        return options
     }
 
     private fun isBeforeDate(option: CategoryOption): Boolean {

--- a/stock-usecase/src/main/java/org/dhis2/android/rtsm/services/StockManagerImpl.kt
+++ b/stock-usecase/src/main/java/org/dhis2/android/rtsm/services/StockManagerImpl.kt
@@ -126,15 +126,11 @@ class StockManagerImpl @Inject constructor(
     }
 
     private fun filterDeleted(
-        list: MutableList<TrackedEntityInstance>,
+        list: List<TrackedEntityInstance>,
     ): List<TrackedEntityInstance> {
-        val iterator = list.iterator()
-        while (iterator.hasNext()) {
-            val tei = iterator.next()
-            if (tei.deleted() != null && tei.deleted()!!) iterator.remove()
+        return list.filter {
+            it.deleted() == null || !it.deleted()!!
         }
-
-        return list
     }
 
     private fun createEventProjection(


### PR DESCRIPTION
## Description
The SDK has refactored their dataSource classes and now returns a `List<T>` instead of a `MutableList<T>` (Java / Kotlin). It is required to adapt a few methods.

[ANDROSDK-1742](https://dhis2.atlassian.net/browse/ANDROSDK-1742)

## Solution description
## Covered unit test cases
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROSDK-1742]: https://dhis2.atlassian.net/browse/ANDROSDK-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ