### PR TITLE
ANDROAPP-5533 crash when colorUtils not instantiated in map layer dialog

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/resources/ColorUtils.kt
+++ b/commons/src/main/java/org/dhis2/commons/resources/ColorUtils.kt
@@ -166,21 +166,25 @@ class ColorUtils {
 
     /**/
     fun getPrimaryColor(context: Context, colorType: ColorType): Int {
-        val id = when (colorType) {
-            ColorType.ACCENT -> R.attr.colorAccent
-            ColorType.PRIMARY_DARK -> R.attr.colorPrimaryDark
-            ColorType.PRIMARY_LIGHT -> R.attr.colorPrimaryLight
-            ColorType.PRIMARY -> R.attr.colorPrimary
-            else -> R.attr.colorPrimary
-        }
-        val typedValue = TypedValue()
-        val a = context.obtainStyledAttributes(typedValue.data, intArrayOf(id))
-        val colorToReturn = a.getColor(0, 0)
-        a.recycle()
-        return colorToReturn
+        return context.getPrimaryColor(colorType)
     }
 }
 
 enum class ColorType {
     PRIMARY, PRIMARY_LIGHT, PRIMARY_DARK, ACCENT
+}
+
+fun Context.getPrimaryColor(colorType: ColorType): Int {
+    val id = when (colorType) {
+        ColorType.ACCENT -> R.attr.colorAccent
+        ColorType.PRIMARY_DARK -> R.attr.colorPrimaryDark
+        ColorType.PRIMARY_LIGHT -> R.attr.colorPrimaryLight
+        ColorType.PRIMARY -> R.attr.colorPrimary
+        else -> R.attr.colorPrimary
+    }
+    val typedValue = TypedValue()
+    val a = obtainStyledAttributes(typedValue.data, intArrayOf(id))
+    val colorToReturn = a.getColor(0, 0)
+    a.recycle()
+    return colorToReturn
 }

--- a/dhis2_android_maps/src/main/java/org/dhis2/maps/layer/MapLayerDialog.kt
+++ b/dhis2_android_maps/src/main/java/org/dhis2/maps/layer/MapLayerDialog.kt
@@ -13,7 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.dhis2.commons.resources.ColorType
-import org.dhis2.commons.resources.ColorUtils
+import org.dhis2.commons.resources.getPrimaryColor
 import org.dhis2.maps.R
 import org.dhis2.maps.databinding.DialogMapLayerBinding
 import org.dhis2.maps.databinding.ItemLayerBinding
@@ -29,7 +29,6 @@ import org.dhis2.maps.layer.types.TeiMapLayer
 import org.dhis2.maps.managers.EventMapManager
 import org.dhis2.maps.managers.MapManager
 import org.dhis2.maps.managers.RelationshipMapManager.Companion.RELATIONSHIP_ICON
-import javax.inject.Inject
 
 class MapLayerDialog(
     private val mapManager: MapManager,
@@ -37,9 +36,6 @@ class MapLayerDialog(
 
     private val layerVisibility: HashMap<String, Boolean> = hashMapOf()
     lateinit var binding: DialogMapLayerBinding
-
-    @Inject
-    lateinit var colorUtils: ColorUtils
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,10 +51,7 @@ class MapLayerDialog(
         binding.baseMapCarousel.adapter = BasemapAdapter(mapManager.mapLayerManager)
         binding.acceptButton.setTextColor(
             ColorStateList.valueOf(
-                colorUtils.getPrimaryColor(
-                    requireContext(),
-                    ColorType.PRIMARY,
-                ),
+                requireContext().getPrimaryColor(ColorType.PRIMARY),
             ),
         )
         initProgramData()
@@ -127,6 +120,7 @@ class MapLayerDialog(
                         MapLayerManager.TEI_ICON_ID,
                     ),
                 )
+
                 is EnrollmentMapLayer -> layerMap["ENROLLMENT"]?.add(
                     addCheckBox(
                         source,
@@ -134,12 +128,14 @@ class MapLayerDialog(
                         MapLayerManager.ENROLLMENT_ICON_ID,
                     ),
                 )
+
                 is TeiEventMapLayer -> layerMap["TRACKER_EVENT"]?.add(
                     addCheckBox(
                         source,
                         image = "${MapLayerManager.STAGE_ICON_ID}_$source",
                     ),
                 )
+
                 is HeatmapMapLayer -> layerMap["HEATMAP"]?.add(
                     addCheckBox(
                         source,
@@ -147,6 +143,7 @@ class MapLayerDialog(
                         HEATMAP_ICON,
                     ),
                 )
+
                 is RelationshipMapLayer -> layerMap["RELATIONSHIP"]?.add(
                     addCheckBox(
                         source,
@@ -154,6 +151,7 @@ class MapLayerDialog(
                         "${RELATIONSHIP_ICON}_$source",
                     ),
                 )
+
                 is EventMapLayer -> layerMap["EVENT"]?.add(
                     addCheckBox(
                         source,
@@ -161,6 +159,7 @@ class MapLayerDialog(
                         EventMapManager.ICON_ID,
                     ),
                 )
+
                 is FieldMapLayer -> layerMap["DE"]?.add(
                     addCheckBox(
                         source,
@@ -202,10 +201,7 @@ class MapLayerDialog(
                 CompoundButtonCompat.setButtonTintList(
                     this,
                     ColorStateList.valueOf(
-                        colorUtils.getPrimaryColor(
-                            context,
-                            ColorType.PRIMARY,
-                        ),
+                        requireContext().getPrimaryColor(ColorType.PRIMARY),
                     ),
                 )
                 setOnCheckedChangeListener { _, isChecked ->


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
