### PR TITLE
Update SDK to snapshot 52; adapt object repositories

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/data/ProgramConfigurationRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/data/ProgramConfigurationRepository.kt
@@ -17,7 +17,7 @@ class ProgramConfigurationRepository(private val d2: D2) {
     }
 
     private fun getGlobalConfigurationSettings() =
-        d2.settingModule().appearanceSettings().globalProgramConfigurationSetting
+        d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting()
 
     private fun getSpecificProgramSettings(uid: String) = d2.settingModule()
         .appearanceSettings()

--- a/app/src/test/java/org/dhis2/data/filter/FilterRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/data/filter/FilterRepositoryTest.kt
@@ -134,7 +134,7 @@ class FilterRepositoryTest {
                 .eq(true).blockingIsEmpty(),
         ) doReturn false
         whenever(
-            d2.settingModule().appearanceSettings().homeFilters,
+            d2.settingModule().appearanceSettings().getHomeFilters(),
         ) doReturn createWebAppHomeFilters()
         whenever(
             getFiltersApplyingWebAppConfig.execute(
@@ -165,7 +165,7 @@ class FilterRepositoryTest {
     fun `Should get global tracked entity filter when webapp is configured`() {
         whenever(d2.settingModule().appearanceSettings().blockingExists()) doReturn true
         whenever(
-            d2.settingModule().appearanceSettings().trackedEntityTypeFilters,
+            d2.settingModule().appearanceSettings().getTrackedEntityTypeFilters(),
         ) doReturn createWebAppTrackedEntityFilters()
         whenever(
             getFiltersApplyingWebAppConfig.execute(

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/ProgramConfigurationRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/ProgramConfigurationRepositoryTest.kt
@@ -32,7 +32,7 @@ class ProgramConfigurationRepositoryTest {
             d2.settingModule().appearanceSettings().getProgramConfigurationByUid("uid"),
         ) doReturn null
         whenever(
-            d2.settingModule().appearanceSettings().globalProgramConfigurationSetting,
+            d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting(),
         ) doReturn globalConfiguration
 
         val result = programConfigurationRepository.getConfigurationByProgram("uid")
@@ -48,7 +48,7 @@ class ProgramConfigurationRepositoryTest {
             d2.settingModule().appearanceSettings().getProgramConfigurationByUid("uid"),
         ) doReturn specificConfiguration
         whenever(
-            d2.settingModule().appearanceSettings().globalProgramConfigurationSetting,
+            d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting(),
         ) doReturn globalConfiguration
 
         val result = programConfigurationRepository.getConfigurationByProgram("uid")
@@ -62,7 +62,7 @@ class ProgramConfigurationRepositoryTest {
             d2.settingModule().appearanceSettings().getProgramConfigurationByUid("uid"),
         ) doReturn null
         whenever(
-            d2.settingModule().appearanceSettings().globalProgramConfigurationSetting,
+            d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting(),
         ) doReturn null
 
         val result = programConfigurationRepository.getConfigurationByProgram("uid")

--- a/commons/src/main/java/org/dhis2/commons/bindings/SdkExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/SdkExtensions.kt
@@ -252,10 +252,10 @@ fun D2.period(periodId: String) = periodModule().periods()
     .one()
     .blockingGet()
 
-fun D2.disableCollapsableSectionsInProgram(programUid: String): Boolean? {
+fun D2.disableCollapsableSectionsInProgram(programUid: String): Boolean {
     val globalSettingEnabled: Boolean? =
         settingModule().appearanceSettings()
-            .globalProgramConfigurationSetting
+            .getGlobalProgramConfigurationSetting()
             ?.disableCollapsibleSections()
     val specificSettingEnabled: Boolean? =
         settingModule().appearanceSettings()

--- a/commons/src/main/java/org/dhis2/commons/filters/data/FilterRepository.kt
+++ b/commons/src/main/java/org/dhis2/commons/filters/data/FilterRepository.kt
@@ -292,7 +292,9 @@ class FilterRepository @Inject constructor(
         }
 
         val globalTrackedEntityTypeFiltersWebApp =
-            d2.settingModule().appearanceSettings().trackedEntityTypeFilters
+            d2.settingModule().appearanceSettings().getTrackedEntityTypeFilters()
+                ?.toMutableMap() ?: mutableMapOf()
+
         globalTrackedEntityTypeFiltersWebApp.remove(ProgramFilter.ASSIGNED_TO_ME)
         globalTrackedEntityTypeFiltersWebApp.remove(ProgramFilter.ENROLLMENT_DATE)
 
@@ -336,6 +338,7 @@ class FilterRepository @Inject constructor(
 
         val datasetFiltersWebApp =
             d2.settingModule().appearanceSettings().getDataSetFiltersByUid(dataSetUid)
+                ?.toMutableMap() ?: mutableMapOf()
 
         if (orgUnitsCount == 1) {
             datasetFiltersWebApp.remove(DataSetFilter.ORG_UNIT)
@@ -398,7 +401,8 @@ class FilterRepository @Inject constructor(
             return defaultFilters.values.toList()
         }
 
-        val homeFiltersWebApp = d2.settingModule().appearanceSettings().homeFilters
+        val homeFiltersWebApp = d2.settingModule().appearanceSettings().getHomeFilters()
+            ?.toMutableMap() ?: mutableMapOf()
 
         if (orgUnitsCount == 1) {
             homeFiltersWebApp.remove(HomeFilter.ORG_UNIT)
@@ -469,6 +473,7 @@ class FilterRepository @Inject constructor(
 
         val trackerFiltersWebApp =
             d2.settingModule().appearanceSettings().getProgramFiltersByUid(program.uid())
+                ?.toMutableMap() ?: mutableMapOf()
 
         if (orgUnitsCount == 1) {
             trackerFiltersWebApp.remove(ProgramFilter.ORG_UNIT)
@@ -629,6 +634,7 @@ class FilterRepository @Inject constructor(
 
         val eventFiltersWebApp =
             d2.settingModule().appearanceSettings().getProgramFiltersByUid(program.uid())
+                ?.toMutableMap() ?: mutableMapOf()
 
         if (orgUnitsCount == 1) {
             eventFiltersWebApp.remove(ProgramFilter.ORG_UNIT)

--- a/dhis_android_analytics/src/test/java/dhis2/org/analytics/charts/ChartsRepositoryTest.kt
+++ b/dhis_android_analytics/src/test/java/dhis2/org/analytics/charts/ChartsRepositoryTest.kt
@@ -215,9 +215,14 @@ class ChartsRepositoryTest {
 
     @Test
     fun `Should return empty list if no visualization configured`() {
+        val emptyVisualizations = AnalyticsDhisVisualizationsSetting.builder()
+            .home(emptyList())
+            .dataSet(emptyMap())
+            .program(emptyMap())
+            .build()
         whenever(
             d2.settingModule().analyticsSetting().visualizationsSettings().blockingGet(),
-        ) doReturn null
+        ) doReturn emptyVisualizations
         val result = repository.getVisualizationGroups("dataSetUid")
         assertTrue(result.isEmpty())
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ hiltCompiler = '1.0.0'
 jacoco = '0.8.10'
 
 designSystem = "1.0-20231016.090318-76"
-dhis2sdk = "1.9.0-20231006.122641-44"
+dhis2sdk = "1.9.0-20231018.121321-52"
 ruleEngine = "2.1.9"
 appcompat = "1.6.1"
 annotation = "1.6.0"


### PR DESCRIPTION
## Description
Update android SDK to snapshot 52.
Adapt to changes in ObjectRepositories due to refactor to Kotlin.

[ANDROSDK-1768](https://dhis2.atlassian.net/browse/ANDROSDK-1768]

## Solution description
## Covered unit test cases
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROSDK-1768]: https://dhis2.atlassian.net/browse/ANDROSDK-1768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ