### PR TITLE
Analytics: evaluate isLogged and dhis2Version in each failed call 

### DIFF
--- a/app/src/main/java/org/dhis2/utils/analytics/AnalyticsInterceptor.kt
+++ b/app/src/main/java/org/dhis2/utils/analytics/AnalyticsInterceptor.kt
@@ -32,8 +32,7 @@ import org.hisp.dhis.android.core.D2Manager
 
 class AnalyticsInterceptor(private val analyticHelper: AnalyticsHelper) : Interceptor {
 
-    val appVersionName = BuildConfig.VERSION_NAME
-    var serverVersionName: String? = null
+    private val appVersionName = BuildConfig.VERSION_NAME
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
@@ -50,11 +49,7 @@ class AnalyticsInterceptor(private val analyticHelper: AnalyticsHelper) : Interc
     }
 
     private fun getDhis2Version(): String? {
-        if (serverVersionName == null) {
-            serverVersionName =
-                D2Manager.getD2().systemInfoModule().systemInfo().blockingGet()?.version()
-        }
-        return serverVersionName
+        return D2Manager.getD2().systemInfoModule().systemInfo().blockingGet()?.version()
     }
 
     private fun isLogged(): Boolean {

--- a/app/src/main/java/org/dhis2/utils/analytics/AnalyticsInterceptor.kt
+++ b/app/src/main/java/org/dhis2/utils/analytics/AnalyticsInterceptor.kt
@@ -34,17 +34,12 @@ class AnalyticsInterceptor(private val analyticHelper: AnalyticsHelper) : Interc
 
     val appVersionName = BuildConfig.VERSION_NAME
     var serverVersionName: String? = null
-    var isLogged = false
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response = chain.proceed(request)
 
-        if (response.code >= 400 && !isLogged) {
-            isLogged = D2Manager.getD2().userModule().blockingIsLogged()
-        }
-
-        if (response.code >= 400 && isLogged) {
+        if (response.code >= 400 && isLogged()) {
             analyticHelper.trackMatomoEvent(
                 API_CALL,
                 "${request.method}_${request.url}",
@@ -60,5 +55,9 @@ class AnalyticsInterceptor(private val analyticHelper: AnalyticsHelper) : Interc
                 D2Manager.getD2().systemInfoModule().systemInfo().blockingGet()?.version()
         }
         return serverVersionName
+    }
+
+    private fun isLogged(): Boolean {
+        return D2Manager.getD2().userModule().blockingIsLogged()
     }
 }


### PR DESCRIPTION
## Description
The class AnalyticsInterceptor has two properties (`isLogged` and `dhis2Version`) that are evaluated just once. In this way, these properties are not evaluated each time they are used and this works fine if there is a single server.

In the case the user started a session in a server, then logout and login in a different server, these properties are not evaluated again. It has two consequences:
- the apps gets `isLogged=true` even when it is not true, which causes issues accessing the DB.
- the app might include the wrong dhis2Version in the matomo event.

[ANDROAPP-5648](https://dhis2.atlassian.net/browse/ANDROAPP-5648)

## Solution description
The solution is to evaluate this properties in each failed called. The evaluation of these properties is very light and it only happens if the response code is an error (code >= 400).

## Covered unit test cases

## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROAPP-5648]: https://dhis2.atlassian.net/browse/ANDROAPP-5648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ