### PR TITLE
Empty onImageClick implementation

### DIFF
--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/ImageInputProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/ImageInputProvider.kt
@@ -48,6 +48,7 @@ internal fun ProvideInputImage(
             uploadState = UploadState.UPLOADING
             fieldUiModel.invokeUiEvent(UiEventType.ADD_PICTURE)
         },
+        onImageClick = {},
     )
 }
 

--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/SignatureProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/SignatureProvider.kt
@@ -45,5 +45,6 @@ fun ProvideInputSignature(
         onDownloadButtonClick = { fieldUiModel.invokeUiEvent(UiEventType.SHOW_PICTURE) },
         onResetButtonClicked = { fieldUiModel.onClear() },
         onAddButtonClicked = { fieldUiModel.invokeUiEvent(UiEventType.ADD_SIGNATURE) },
+        onImageClick = {},
     )
 }


### PR DESCRIPTION
## Description

Add empty imageClick implementation for input Image and Input signature
[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
