### PR TITLE
Improve performance in program bottom menu evaluation

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfigurator.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfigurator.kt
@@ -33,7 +33,7 @@ class SearchPageConfigurator(
     }
 
     internal fun programHasCoordinates(): Boolean {
-        val program = searchRepository.currentProgram()?.let {programId ->
+        val program = searchRepository.currentProgram()?.let { programId ->
             searchRepository.getProgram(programId)
         } ?: return false
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfigurator.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfigurator.kt
@@ -12,7 +12,7 @@ class SearchPageConfigurator(
 
     fun initVariables(): SearchPageConfigurator {
         canDisplayMap = programHasCoordinates()
-        canDisplayAnalytics = searchRepository.programHasAnalytics()
+        canDisplayAnalytics = programHasAnalytics()
         return this
     }
 
@@ -67,5 +67,11 @@ class SearchPageConfigurator(
             teTypeHasCoordinates ||
             teAttributesHaveCoordinates ||
             eventsHaveCoordinates
+    }
+
+    internal fun programHasAnalytics(): Boolean {
+        val programUid = searchRepository.currentProgram() ?: return false
+
+        return searchRepository.getProgramVisualizationGroups(programUid).isNotEmpty()
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepository.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepository.java
@@ -59,9 +59,13 @@ public interface SearchRepository {
 
     void setCurrentProgram(@Nullable String currentProgram);
     boolean programHasAnalytics();
-    boolean programHasCoordinates();
+    boolean programStagesHaveCoordinates(String programUid);
+    boolean teTypeAttributesHaveCoordinates(String typeId);
+    boolean programAttributesHaveCoordinates(String programUid);
+    boolean eventsHaveCoordinates(String programUid);
 
     @Nullable Program getProgram(@Nullable String programUid);
+    @Nullable String currentProgram();
 
     @NotNull Map<String, String> filterQueryForProgram(@NotNull Map<String, String> queryData, @org.jetbrains.annotations.Nullable String programUid);
 

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepository.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepository.java
@@ -13,6 +13,7 @@ import org.dhis2.data.search.SearchParametersModel;
 import org.hisp.dhis.android.core.arch.call.D2Progress;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.program.Program;
+import org.hisp.dhis.android.core.settings.AnalyticsDhisVisualizationsGroup;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType;
 import org.jetbrains.annotations.NotNull;
 
@@ -58,11 +59,12 @@ public interface SearchRepository {
     TeiDownloadResult download(String teiUid, @Nullable String enrollmentUid, String reason);
 
     void setCurrentProgram(@Nullable String currentProgram);
-    boolean programHasAnalytics();
     boolean programStagesHaveCoordinates(String programUid);
     boolean teTypeAttributesHaveCoordinates(String typeId);
     boolean programAttributesHaveCoordinates(String programUid);
     boolean eventsHaveCoordinates(String programUid);
+
+    List<AnalyticsDhisVisualizationsGroup> getProgramVisualizationGroups(String programUid);
 
     @Nullable Program getProgram(@Nullable String programUid);
     @Nullable String currentProgram();

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -836,7 +836,8 @@ public class SearchRepositoryImpl implements SearchRepository {
         this.currentProgram = currentProgram;
     }
 
-    private String currentProgram() {
+    @Override
+    public String currentProgram() {
         return currentProgram;
     }
 
@@ -852,87 +853,52 @@ public class SearchRepositoryImpl implements SearchRepository {
     }
 
     @Override
-    public boolean programHasCoordinates() {
-        String programUid = currentProgram();
+    public boolean programStagesHaveCoordinates(String programUid) {
+        return !d2.programModule().programStages()
+                .byProgramUid().eq(programUid)
+                .byFeatureType().notIn(FeatureType.NONE)
+                .blockingIsEmpty();
+    }
 
-        if (programUid == null) return false;
-
-        boolean teTypeHasCoordinates = false;
-        FeatureType teTypeFeatureType = d2.trackedEntityModule().trackedEntityTypes()
-                .uid(teiType)
-                .blockingGet()
-                .featureType();
-
-        if (teTypeFeatureType != null && teTypeFeatureType != FeatureType.NONE) {
-            teTypeHasCoordinates = true;
-        }
-
-        boolean enrollmentHasCoordinates = false;
-        FeatureType enrollmentFeatureType = d2.programModule().programs()
-                .uid(programUid)
-                .blockingGet()
-                .featureType();
-
-        if (enrollmentFeatureType != null && enrollmentFeatureType != FeatureType.NONE) {
-            enrollmentHasCoordinates = true;
-        }
-
+    @Override
+    public boolean teTypeAttributesHaveCoordinates(String typeId) {
         List<TrackedEntityTypeAttribute> teAttributes = d2.trackedEntityModule().trackedEntityTypeAttributes()
-                .byTrackedEntityTypeUid().eq(teiType)
+                .byTrackedEntityTypeUid().eq(typeId)
                 .blockingGet();
         List<String> teAttributeUids = new ArrayList<>();
         for (TrackedEntityTypeAttribute teTypeAttr : teAttributes) {
             teAttributeUids.add(teTypeAttr.trackedEntityAttribute().uid());
         }
 
-        boolean teAttributeHasCoordinates = !d2.trackedEntityModule().trackedEntityAttributes()
+        return !d2.trackedEntityModule().trackedEntityAttributes()
                 .byUid().in(teAttributeUids)
-                .byValueType().eq(ValueType.COORDINATE)
+                .byValueType().in(ValueType.COORDINATE, ValueType.GEOJSON)
                 .blockingIsEmpty();
+    }
 
-        boolean programAttributeHasCoordinates = false;
-        boolean eventHasCoordinates = false;
-        boolean eventDataElementHasCoordinates = false;
-        if (programUid != null) {
-            List<ProgramTrackedEntityAttribute> programAttributes = d2.programModule().programTrackedEntityAttributes()
-                    .byProgram().eq(programUid)
-                    .blockingGet();
-            List<String> programAttributeUids = new ArrayList<>();
-            for (ProgramTrackedEntityAttribute programAttr : programAttributes) {
-                programAttributeUids.add(programAttr.trackedEntityAttribute().uid());
-            }
-
-            programAttributeHasCoordinates = !d2.trackedEntityModule().trackedEntityAttributes()
-                    .byUid().in(programAttributeUids)
-                    .byValueType().eq(ValueType.COORDINATE)
-                    .blockingIsEmpty();
-
-            eventHasCoordinates = !d2.programModule().programStages()
-                    .byProgramUid().eq(programUid)
-                    .byFeatureType().notIn(FeatureType.NONE)
-                    .blockingIsEmpty();
-
-
-            List<Event> events = d2.eventModule().eventQuery().byIncludeDeleted()
-                    .eq(false)
-                    .byProgram()
-                    .eq(programUid)
-                    .blockingGet();
-            for (Event event : events) {
-                if (event.geometry() != null) {
-                    eventDataElementHasCoordinates = true;
-                    break;
-                }
-            }
-
+    @Override
+    public boolean programAttributesHaveCoordinates(String programUid) {
+        List<ProgramTrackedEntityAttribute> programAttributes = d2.programModule().programTrackedEntityAttributes()
+                .byProgram().eq(programUid)
+                .blockingGet();
+        List<String> programAttributeUids = new ArrayList<>();
+        for (ProgramTrackedEntityAttribute programAttr : programAttributes) {
+            programAttributeUids.add(programAttr.trackedEntityAttribute().uid());
         }
 
-        return teTypeHasCoordinates ||
-                enrollmentHasCoordinates ||
-                teAttributeHasCoordinates ||
-                programAttributeHasCoordinates ||
-                eventHasCoordinates ||
-                eventDataElementHasCoordinates;
+        return !d2.trackedEntityModule().trackedEntityAttributes()
+                .byUid().in(programAttributeUids)
+                .byValueType().in(ValueType.COORDINATE, ValueType.GEOJSON)
+                .blockingIsEmpty();
+    }
+
+    @Override
+    public boolean eventsHaveCoordinates(String programUid) {
+        return !d2.eventModule().events()
+                .byDeleted().isFalse()
+                .byProgramUid().eq(programUid)
+                .byGeometryCoordinates().isNotNull()
+                .blockingIsEmpty();
     }
 
     @Nullable

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -9,9 +9,9 @@ import androidx.paging.DataSource;
 import androidx.paging.LivePagedListBuilder;
 import androidx.paging.PagedList;
 
-import org.dhis2.bindings.ValueExtensionsKt;
 import org.dhis2.R;
 import org.dhis2.bindings.ExtensionsKt;
+import org.dhis2.bindings.ValueExtensionsKt;
 import org.dhis2.commons.Constants;
 import org.dhis2.commons.data.EntryMode;
 import org.dhis2.commons.data.EventViewModel;
@@ -69,6 +69,7 @@ import org.hisp.dhis.android.core.relationship.Relationship;
 import org.hisp.dhis.android.core.relationship.RelationshipItem;
 import org.hisp.dhis.android.core.relationship.RelationshipItemTrackedEntityInstance;
 import org.hisp.dhis.android.core.relationship.RelationshipType;
+import org.hisp.dhis.android.core.settings.AnalyticsDhisVisualizationsGroup;
 import org.hisp.dhis.android.core.settings.ProgramConfigurationSetting;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue;
@@ -842,13 +843,11 @@ public class SearchRepositoryImpl implements SearchRepository {
     }
 
     @Override
-    public boolean programHasAnalytics() {
-        String programUid = currentProgram();
-        if (programUid != null) {
-            boolean hasCharts = charts != null && !charts.getProgramVisualizations(null, programUid).isEmpty();
-            return hasCharts;
+    public List<AnalyticsDhisVisualizationsGroup> getProgramVisualizationGroups(String programUid) {
+        if (charts != null) {
+            return charts.getVisualizationGroups(programUid);
         } else {
-            return false;
+            return Collections.emptyList();
         }
     }
 

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfiguratorTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfiguratorTest.kt
@@ -1,0 +1,79 @@
+package org.dhis2.usescases.searchTrackEntity
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.common.FeatureType
+import org.hisp.dhis.android.core.program.Program
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityType
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+
+class SearchPageConfiguratorTest {
+
+    private val searchRepository: SearchRepository = mock()
+    private val program: Program = mock()
+    private val teType: TrackedEntityType = mock()
+
+    private val programUid: String = "programUid"
+    private val teTypeUid: String = "teTypeUid"
+
+    private lateinit var configurator: SearchPageConfigurator
+
+    @Before
+    fun setup() {
+        whenever(searchRepository.currentProgram()).doReturn(programUid)
+        whenever(searchRepository.getProgram(programUid)).doReturn(program)
+        whenever(program.featureType()).doReturn(FeatureType.POINT)
+        whenever(program.uid()).doReturn(programUid)
+        whenever(program.trackedEntityType()).doReturn(teType)
+        whenever(teType.uid()).doReturn(teTypeUid)
+
+        configurator = SearchPageConfigurator(searchRepository)
+    }
+
+    @Test
+    fun shortcut_to_false_if_no_program() {
+        whenever(searchRepository.currentProgram()).doReturn(null)
+
+        val hasCoordinates = configurator.programHasCoordinates()
+
+        assertThat(hasCoordinates).isFalse()
+
+        verify(searchRepository).currentProgram()
+        verifyNoMoreInteractions(searchRepository)
+    }
+
+    @Test
+    fun shortcut_to_true_if_program_has_coordinates() {
+        val hasCoordinates = configurator.programHasCoordinates()
+
+        assertThat(hasCoordinates).isTrue()
+
+        verify(searchRepository).currentProgram()
+        verify(searchRepository).getProgram(programUid)
+        verifyNoMoreInteractions(searchRepository)
+    }
+
+    @Test
+    fun do_not_shortcut_if_no_coordinates() {
+        whenever(program.featureType()).doReturn(FeatureType.NONE)
+
+        val hasCoordinates = configurator.programHasCoordinates()
+
+        assertThat(hasCoordinates).isFalse()
+
+        verify(searchRepository).currentProgram()
+        verify(searchRepository).getProgram(programUid)
+        verify(searchRepository).programStagesHaveCoordinates(programUid)
+        verify(searchRepository).programAttributesHaveCoordinates(programUid)
+        verify(searchRepository).trackedEntityType
+        verify(searchRepository).teTypeAttributesHaveCoordinates(any())
+        verify(searchRepository).eventsHaveCoordinates(programUid)
+        verifyNoMoreInteractions(searchRepository)
+    }
+}

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfiguratorTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchPageConfiguratorTest.kt
@@ -3,6 +3,7 @@ package org.dhis2.usescases.searchTrackEntity
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.program.Program
+import org.hisp.dhis.android.core.settings.AnalyticsDhisVisualizationsGroup
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType
 import org.junit.Before
 import org.junit.Test
@@ -18,6 +19,7 @@ class SearchPageConfiguratorTest {
     private val searchRepository: SearchRepository = mock()
     private val program: Program = mock()
     private val teType: TrackedEntityType = mock()
+    private val visualizationGroup: AnalyticsDhisVisualizationsGroup = mock()
 
     private val programUid: String = "programUid"
     private val teTypeUid: String = "teTypeUid"
@@ -37,7 +39,7 @@ class SearchPageConfiguratorTest {
     }
 
     @Test
-    fun shortcut_to_false_if_no_program() {
+    fun display_map_shortcut_to_false_if_no_program() {
         whenever(searchRepository.currentProgram()).doReturn(null)
 
         val hasCoordinates = configurator.programHasCoordinates()
@@ -49,7 +51,7 @@ class SearchPageConfiguratorTest {
     }
 
     @Test
-    fun shortcut_to_true_if_program_has_coordinates() {
+    fun display_map_shortcut_to_true_if_program_has_coordinates() {
         val hasCoordinates = configurator.programHasCoordinates()
 
         assertThat(hasCoordinates).isTrue()
@@ -60,7 +62,7 @@ class SearchPageConfiguratorTest {
     }
 
     @Test
-    fun do_not_shortcut_if_no_coordinates() {
+    fun display_map_do_not_shortcut_if_no_coordinates() {
         whenever(program.featureType()).doReturn(FeatureType.NONE)
 
         val hasCoordinates = configurator.programHasCoordinates()
@@ -74,6 +76,18 @@ class SearchPageConfiguratorTest {
         verify(searchRepository).trackedEntityType
         verify(searchRepository).teTypeAttributesHaveCoordinates(any())
         verify(searchRepository).eventsHaveCoordinates(programUid)
+        verifyNoMoreInteractions(searchRepository)
+    }
+
+    @Test
+    fun display_analytics_shortcut_to_false_if_no_program() {
+        whenever(searchRepository.currentProgram()).doReturn(null)
+
+        val hasAnalytics = configurator.programHasAnalytics()
+
+        assertThat(hasAnalytics).isFalse()
+
+        verify(searchRepository).currentProgram()
         verifyNoMoreInteractions(searchRepository)
     }
 }


### PR DESCRIPTION
## Description
There are two expensive evaluations performed before displaying the Program home screen (the TEI list). They are the evaluation of `displayMap` and `displayAnalytics`, which determined if these tabs must be shown in the bottom menu. This PR improves the performance of both variables.

[ANDROAPP-5660](https://dhis2.atlassian.net/browse/ANDROAPP-5660)

## Solution description
Improvements for displayMap:
- Early return when the conditions are enough to determine if the result is true or false.
- Single DB query instead of traversing all the events in the program.

Some measurements:
- Physical device, Android 8, program without coordinates with ~2000 teis: it improves from ~8s to ~0.070s (no early return, improvement thanks to single DB query).
- Physical device, Android 8, program with coordinates with 50 teis: it improves from ~0.300s to ~0.005s (thanks to early return to true).

Improvements for displayAnalytics:
- Do not evaluate the visualizations, just check if there are visualizations defined for this program. The evaluation was needed in previous versions because failed visualizations were skipped from the list and you could end up with an empty list. Now, they are not skipped anymore but displayed with an error message.

Some measurements:
- Physical device, Android 8: the improvement goes from the time it takes the evaluation (wide range, from 0.3s to several minutes) to just ~0.005s (it only checks the configuration).

## Covered unit test cases
The unit test proves that there is an early return.
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [X] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [X] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROAPP-5660]: https://dhis2.atlassian.net/browse/ANDROAPP-5660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ