### PR TITLE
fix: [ANDROAPP-5727] Defer matomo event tracking to IO thread

### DIFF
--- a/app/src/main/java/org/dhis2/utils/analytics/AnalyticsInterceptor.kt
+++ b/app/src/main/java/org/dhis2/utils/analytics/AnalyticsInterceptor.kt
@@ -56,7 +56,7 @@ class AnalyticsInterceptor(private val analyticHelper: AnalyticsHelper) : Interc
                     analyticHelper.trackMatomoEvent(
                         API_CALL,
                         "${request.method}_${request.url}",
-                        "${response.code}_${appVersionName}_${version}",
+                        "${response.code}_${appVersionName}_$version",
                     )
                     dispose()
                 }


### PR DESCRIPTION
## Description
There is constraint in the access to the database when encryption is enabled: if a thread opens a transaction, the database is locked for other threads and they can't read. This issue seems to be a limitation of SQLCipher and it is not clear if there is a possible workaround to this. This is the reason why it doesn't happen when the database is not encrypted.

In order to minimize changes during the soft freeze, the approach here was to change the way matamo events are sent. The AnalyticsInterceptor class emitted the event in a blocking way, causing a deadlock if the database was locked by other thread. The new approach is to send the matomo event in an IO thread, so the event is sent once the database is unlocked.

The root cause of this issue is still in the SDK ([ANDROSDK-1784](https://dhis2.atlassian.net/browse/ANDROSDK-1784)), but anyway it looks a good practice to move the generation of Matomo events to a different IO thread so the network calls are not blocked.

[ANDROAPP-5727](https://dhis2.atlassian.net/browse/ANDROAPP-5727)

## Covered unit test cases
Real integration tests with play servers
## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROAPP-5727]: https://dhis2.atlassian.net/browse/ANDROAPP-5727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANDROSDK-1784]: https://dhis2.atlassian.net/browse/ANDROSDK-1784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ