### PR TITLE
fix: [ANDROAPP-5704] Overdue date in patient line list follows inconsistent format

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapper.kt
@@ -20,7 +20,7 @@ import org.dhis2.R
 import org.dhis2.bindings.hasFollowUp
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.date.toDateSpan
-import org.dhis2.commons.date.toUiText
+import org.dhis2.commons.date.toOverdueUiText
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.commons.ui.model.ListCardUiModel
 import org.hisp.dhis.android.core.common.State
@@ -282,11 +282,7 @@ class TEICardMapper(
         overdueDate: Date?,
     ) {
         if (hasOverdue) {
-            val text = resourceManager.getString(
-                R.string.overdue,
-                overdueDate?.toUiText(context) ?: "",
-            )
-
+            val text = overdueDate.toOverdueUiText(resourceManager)
             list.add(
                 AdditionalInfoItem(
                     icon = {

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import org.dhis2.R
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.date.toDateSpan
-import org.dhis2.commons.date.toUiText
+import org.dhis2.commons.date.toOverdueUiText
 import org.dhis2.commons.resources.ResourceManager
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
@@ -39,9 +39,7 @@ class TEICardMapperTest {
             resourceManager.getString(R.string.enrollment_completed),
         ) doReturn "Enrollment Completed"
         whenever(
-            resourceManager.getString(
-                R.string.overdue, currentDate.toUiText(context),
-            ),
+            resourceManager.getString(R.string.overdue_today),
         ) doReturn "Today"
         whenever(resourceManager.getString(R.string.marked_follow_up)) doReturn "Marked for follow-up"
 
@@ -71,12 +69,10 @@ class TEICardMapperTest {
             result.additionalInfo[3].value,
             resourceManager.getString(R.string.enrollment_completed),
         )
+
         assertEquals(
             result.additionalInfo[4].value,
-            resourceManager.getString(
-                R.string.overdue,
-                model.overdueDate?.toUiText(context) ?: "",
-            ),
+            model.overdueDate.toOverdueUiText(resourceManager),
         )
         assertEquals(
             result.additionalInfo[5].value,

--- a/commons/src/main/java/org/dhis2/commons/date/DateExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/date/DateExtensions.kt
@@ -2,12 +2,14 @@ package org.dhis2.commons.date
 
 import android.content.Context
 import org.dhis2.commons.R
+import org.dhis2.commons.resources.ResourceManager
 import org.joda.time.Days
 import org.joda.time.Hours
 import org.joda.time.Instant
 import org.joda.time.Interval
 import org.joda.time.LocalDate
 import org.joda.time.Minutes
+import org.joda.time.PeriodType
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -60,6 +62,46 @@ fun Date?.toUiText(context: Context, currentDate: Date = defaultCurrentDate): St
             else -> {
                 SimpleDateFormat("d/M/yyyy", Locale.getDefault()).format(this)
             }
+        }
+    }
+}
+
+fun Date?.toOverdueUiText(
+    resourceManager: ResourceManager,
+    currentDate: Date = defaultCurrentDate,
+): String {
+    if (this == null) return ""
+    val period = Interval(this.time, currentDate.time).toPeriod(PeriodType.yearMonthDayTime())
+    return when {
+        period.years >= 1 -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_years,
+                period.years,
+                period.years,
+            )
+        }
+        period.months >= 3 && period.years < 1 -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_months,
+                period.months,
+                period.months,
+            )
+        }
+        period.days < 90 -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_days,
+                period.days,
+                period.days,
+            )
+        }
+        period.days == 1 -> resourceManager.getString(R.string.overdue_yesterday)
+        period.days == 0 -> resourceManager.getString(R.string.overdue_today)
+        else -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_days,
+                period.days,
+                period.days,
+            )
         }
     }
 }

--- a/commons/src/main/java/org/dhis2/commons/resources/ResourceManager.kt
+++ b/commons/src/main/java/org/dhis2/commons/resources/ResourceManager.kt
@@ -22,6 +22,9 @@ class ResourceManager(
     fun getPlural(@PluralsRes pluralResource: Int, quantity: Int) =
         getWrapperContext().resources.getQuantityString(pluralResource, quantity)
 
+    fun getPlural(@PluralsRes pluralResource: Int, quantity: Int, vararg arguments: Any) =
+        getWrapperContext().resources.getQuantityString(pluralResource, quantity, *arguments)
+
     fun getObjectStyleDrawableResource(icon: String?, @DrawableRes defaultResource: Int): Int {
         return icon?.let {
             val iconName = if (icon.startsWith("ic_")) icon else "ic_$icon"

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -225,4 +225,19 @@
     <string name="default_empty_dataset_section_label">Data</string>
     <string name="title_network_connection_unavailable">Network connection unavailable</string>
     <string name="msg_network_connection_maps">An internet connection is required in order to use maps.</string>
+
+    <string name="overdue_today">Today</string>
+    <string name="overdue_yesterday">Yesterday</string>
+    <plurals name="overdue_days">
+        <item quantity="one">%d day overdue</item>
+        <item quantity="other">%d days overdue</item>
+    </plurals>
+    <plurals name="overdue_months">
+        <item quantity="one">%d month overdue</item>
+        <item quantity="other">%d months overdue</item>
+    </plurals>
+    <plurals name="overdue_years">
+        <item quantity="one">%d year overdue</item>
+        <item quantity="other">%d years overdue</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
- I have create a new extension to create `overdueUiText` and added strings to the `common` module. Without those strings we would have pass a type like `OverduePeriod` and use a when block at call site to extract the string. I initially tried that, but if there are multiple places with this extension we will be duplicating the conditional and potentially using wrong strings. So, made it it part of the extension it self.

- There is also a overdue string usage in `EventCardMapper`, since this story only showed TEI card, wasn't sure if that required updating. So, didn't change it. Let me know if that needs to be changed as well.