### PR TITLE
fix: [ANDROAPP-5704] Overdue date in patient line list follows inconsistent format

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapper.kt
@@ -20,7 +20,7 @@ import org.dhis2.R
 import org.dhis2.bindings.hasFollowUp
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.date.toDateSpan
-import org.dhis2.commons.date.toUiText
+import org.dhis2.commons.date.toOverdueUiText
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.commons.ui.model.ListCardUiModel
 import org.hisp.dhis.android.core.common.State
@@ -282,11 +282,7 @@ class TEICardMapper(
         overdueDate: Date?,
     ) {
         if (hasOverdue) {
-            val text = resourceManager.getString(
-                R.string.overdue,
-                overdueDate?.toUiText(context) ?: "",
-            )
-
+            val text = overdueDate.toOverdueUiText(resourceManager)
             list.add(
                 AdditionalInfoItem(
                     icon = {

--- a/app/src/test/java/org/dhis2/bindings/DateExtensionsTest.kt
+++ b/app/src/test/java/org/dhis2/bindings/DateExtensionsTest.kt
@@ -3,7 +3,9 @@ package org.dhis2.bindings
 import android.content.Context
 import org.dhis2.R
 import org.dhis2.commons.date.toDateSpan
+import org.dhis2.commons.date.toOverdueUiText
 import org.dhis2.commons.date.toUiText
+import org.dhis2.commons.resources.ResourceManager
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -17,6 +19,7 @@ import java.util.Locale
 class DateExtensionsTest {
 
     val context: Context = mock()
+    private val resourceManager: ResourceManager = mock()
     private val dateFormat = SimpleDateFormat("d/M/yyyy", Locale.getDefault())
     private val uiFormat = SimpleDateFormat("dd MMM", Locale.getDefault())
 
@@ -110,6 +113,66 @@ class DateExtensionsTest {
             add(Calendar.YEAR, -2)
         }.time
         assert(date.toUiText(context, currentDate) == dateFormat.format(date))
+    }
+
+    @Test
+    fun `Should return 'Today', when the overdue date is current date`() {
+        val currentDate = currentCalendar().time
+        val date: Date? = currentCalendar().apply {
+            add(Calendar.HOUR, -20)
+        }.time
+        whenever(resourceManager.getString(R.string.overdue_today)) doReturn "Today"
+        assert(date.toOverdueUiText(resourceManager, currentDate) == "Today")
+    }
+
+    @Test
+    fun `Should return '1 day overdue', when the overdue date is -1 day from the current date`() {
+        val currentDate = currentCalendar().time
+        val date: Date? = currentCalendar().apply {
+            add(Calendar.DAY_OF_MONTH, -1)
+        }.time
+        whenever(resourceManager.getPlural(R.plurals.overdue_days, 1, 1)) doReturn "1 day overdue"
+        assert(date.toOverdueUiText(resourceManager, currentDate) == "1 day overdue")
+    }
+
+    @Test
+    fun `Should return 'x days overdue', when the overdue date is -x days from the current date and less than 90 days`() {
+        val currentDate = currentCalendar().time
+        val date: Date? = currentCalendar().apply {
+            add(Calendar.DAY_OF_MONTH, -15)
+        }.time
+        whenever(resourceManager.getPlural(R.plurals.overdue_days, 15, 15)) doReturn "15 days overdue"
+        assert(date.toOverdueUiText(resourceManager, currentDate) == "15 days overdue")
+    }
+
+    @Test
+    fun `Should return 'x months overdue', when the overdue date is more than 3 months and less than 1 year`() {
+        val currentDate = currentCalendar().time
+        val date: Date? = currentCalendar().apply {
+            add(Calendar.MONTH, -4)
+        }.time
+        whenever(resourceManager.getPlural(R.plurals.overdue_months, 4, 4)) doReturn "4 months overdue"
+        assert(date.toOverdueUiText(resourceManager, currentDate) == "4 months overdue")
+    }
+
+    @Test
+    fun `Should return '1 year overdue', when the overdue date is 1 year`() {
+        val currentDate = currentCalendar().time
+        val date: Date? = currentCalendar().apply {
+            add(Calendar.YEAR, -1)
+        }.time
+        whenever(resourceManager.getPlural(R.plurals.overdue_years, 1, 1)) doReturn "1 year overdue"
+        assert(date.toOverdueUiText(resourceManager, currentDate) == "1 year overdue")
+    }
+
+    @Test
+    fun `Should return 'x years overdue', when the overdue date is more than 1 year`() {
+        val currentDate = currentCalendar().time
+        val date: Date? = currentCalendar().apply {
+            add(Calendar.YEAR, -3)
+        }.time
+        whenever(resourceManager.getPlural(R.plurals.overdue_years, 3, 3)) doReturn "3 years overdue"
+        assert(date.toOverdueUiText(resourceManager, currentDate) == "3 years overdue")
     }
 
     private fun currentCalendar() = Calendar.getInstance().apply {

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/ui/mapper/TEICardMapperTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import org.dhis2.R
 import org.dhis2.commons.data.SearchTeiModel
 import org.dhis2.commons.date.toDateSpan
-import org.dhis2.commons.date.toUiText
+import org.dhis2.commons.date.toOverdueUiText
 import org.dhis2.commons.resources.ResourceManager
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
@@ -39,9 +39,7 @@ class TEICardMapperTest {
             resourceManager.getString(R.string.enrollment_completed),
         ) doReturn "Enrollment Completed"
         whenever(
-            resourceManager.getString(
-                R.string.overdue, currentDate.toUiText(context),
-            ),
+            resourceManager.getString(R.string.overdue_today),
         ) doReturn "Today"
         whenever(resourceManager.getString(R.string.marked_follow_up)) doReturn "Marked for follow-up"
 
@@ -71,12 +69,10 @@ class TEICardMapperTest {
             result.additionalInfo[3].value,
             resourceManager.getString(R.string.enrollment_completed),
         )
+
         assertEquals(
             result.additionalInfo[4].value,
-            resourceManager.getString(
-                R.string.overdue,
-                model.overdueDate?.toUiText(context) ?: "",
-            ),
+            model.overdueDate.toOverdueUiText(resourceManager),
         )
         assertEquals(
             result.additionalInfo[5].value,

--- a/commons/src/main/java/org/dhis2/commons/date/DateExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/date/DateExtensions.kt
@@ -2,12 +2,14 @@ package org.dhis2.commons.date
 
 import android.content.Context
 import org.dhis2.commons.R
+import org.dhis2.commons.resources.ResourceManager
 import org.joda.time.Days
 import org.joda.time.Hours
 import org.joda.time.Instant
 import org.joda.time.Interval
 import org.joda.time.LocalDate
 import org.joda.time.Minutes
+import org.joda.time.PeriodType
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -60,6 +62,45 @@ fun Date?.toUiText(context: Context, currentDate: Date = defaultCurrentDate): St
             else -> {
                 SimpleDateFormat("d/M/yyyy", Locale.getDefault()).format(this)
             }
+        }
+    }
+}
+
+fun Date?.toOverdueUiText(
+    resourceManager: ResourceManager,
+    currentDate: Date = defaultCurrentDate,
+): String {
+    if (this == null) return ""
+    val period = Interval(this.time, currentDate.time).toPeriod(PeriodType.yearMonthDayTime())
+    return when {
+        period.years >= 1 -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_years,
+                period.years,
+                period.years,
+            )
+        }
+        period.months >= 3 && period.years < 1 -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_months,
+                period.months,
+                period.months,
+            )
+        }
+        period.days in 1..89 -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_days,
+                period.days,
+                period.days,
+            )
+        }
+        period.days == 0 -> resourceManager.getString(R.string.overdue_today)
+        else -> {
+            resourceManager.getPlural(
+                R.plurals.overdue_days,
+                period.days,
+                period.days,
+            )
         }
     }
 }

--- a/commons/src/main/java/org/dhis2/commons/date/DateExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/date/DateExtensions.kt
@@ -70,6 +70,14 @@ fun Date?.toOverdueUiText(
     resourceManager: ResourceManager,
     currentDate: Date = defaultCurrentDate,
 ): String {
+    fun getOverdueDaysString(days: Int): String {
+        return resourceManager.getPlural(
+            R.plurals.overdue_days,
+            days,
+            days,
+        )
+    }
+
     if (this == null) return ""
     val period = Interval(this.time, currentDate.time).toPeriod(PeriodType.yearMonthDayTime())
     return when {
@@ -88,19 +96,11 @@ fun Date?.toOverdueUiText(
             )
         }
         period.days in 1..89 -> {
-            resourceManager.getPlural(
-                R.plurals.overdue_days,
-                period.days,
-                period.days,
-            )
+            getOverdueDaysString(period.days)
         }
         period.days == 0 -> resourceManager.getString(R.string.overdue_today)
         else -> {
-            resourceManager.getPlural(
-                R.plurals.overdue_days,
-                period.days,
-                period.days,
-            )
+            getOverdueDaysString(period.days)
         }
     }
 }

--- a/commons/src/main/java/org/dhis2/commons/resources/ResourceManager.kt
+++ b/commons/src/main/java/org/dhis2/commons/resources/ResourceManager.kt
@@ -22,6 +22,9 @@ class ResourceManager(
     fun getPlural(@PluralsRes pluralResource: Int, quantity: Int) =
         getWrapperContext().resources.getQuantityString(pluralResource, quantity)
 
+    fun getPlural(@PluralsRes pluralResource: Int, quantity: Int, vararg arguments: Any) =
+        getWrapperContext().resources.getQuantityString(pluralResource, quantity, *arguments)
+
     fun getObjectStyleDrawableResource(icon: String?, @DrawableRes defaultResource: Int): Int {
         return icon?.let {
             val iconName = if (icon.startsWith("ic_")) icon else "ic_$icon"

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -225,4 +225,18 @@
     <string name="default_empty_dataset_section_label">Data</string>
     <string name="title_network_connection_unavailable">Network connection unavailable</string>
     <string name="msg_network_connection_maps">An internet connection is required in order to use maps.</string>
+
+    <string name="overdue_today">Today</string>
+    <plurals name="overdue_days">
+        <item quantity="one">%d day overdue</item>
+        <item quantity="other">%d days overdue</item>
+    </plurals>
+    <plurals name="overdue_months">
+        <item quantity="one">%d month overdue</item>
+        <item quantity="other">%d months overdue</item>
+    </plurals>
+    <plurals name="overdue_years">
+        <item quantity="one">%d year overdue</item>
+        <item quantity="other">%d years overdue</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Description

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-5704)

## Solution description

- I have create a new extension to create `overdueUiText` and added strings to the `common` module. Without those strings we would have pass a type like `OverduePeriod` and use a when block at call site to extract the string. I initially tried that, but if there are multiple places with this extension we will be duplicating the conditional and potentially using wrong strings. So, made it it part of the extension it self.

- There is also a overdue string usage in `EventCardMapper`, since this story only showed TEI card, wasn't sure if that required updating. So, didn't change it. Let me know if that needs to be changed as well.

## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [x] 11.X - 13.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
