### PR TITLE
fix: [ANDROAPP-5663] Tei dashboard event list scrolling getting clipped

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/TeiDetailDashboard.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/TeiDetailDashboard.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -22,84 +21,74 @@ fun TeiDetailDashboard(
     enrollmentData: InfoBarUiModel,
     card: TeiCardUiModel,
 ) {
-    LazyColumn(
+    Column(
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .padding(top = 16.dp),
     ) {
-        item {
-            Column(
+        if (syncData.showInfoBar) {
+            InfoBar(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp),
-            ) {
-                if (syncData.showInfoBar) {
-                    InfoBar(
-                        modifier = Modifier
-                            .padding(start = 8.dp, end = 8.dp)
-                            .testTag(SYNC_INFO_BAR_TEST_TAG),
-                        infoBarData =
-                        InfoBarData(
-                            text = syncData.text,
-                            icon = syncData.icon,
-                            color = syncData.textColor,
-                            backgroundColor = syncData.backgroundColor,
-                            actionText = syncData.actionText,
-                            onClick = syncData.onActionClick,
-                        ),
-                    )
-                    if (followUpData.showInfoBar || enrollmentData.showInfoBar) {
-                        Spacer(modifier = Modifier.padding(top = 8.dp))
-                    }
-                }
-
-                if (followUpData.showInfoBar) {
-                    InfoBar(
-                        modifier = Modifier
-                            .padding(start = 8.dp, end = 8.dp)
-                            .testTag(FOLLOWUP_INFO_BAR_TEST_TAG),
-                        infoBarData = InfoBarData(
-                            text = followUpData.text,
-                            icon = followUpData.icon,
-                            color = followUpData.textColor,
-                            backgroundColor = followUpData.backgroundColor,
-                            actionText = followUpData.actionText,
-                            onClick = followUpData.onActionClick,
-                        ),
-                    )
-                    if (enrollmentData.showInfoBar) {
-                        Spacer(modifier = Modifier.padding(top = 8.dp))
-                    }
-                }
-
-                if (enrollmentData.showInfoBar) {
-                    InfoBar(
-                        modifier = Modifier
-                            .padding(start = 8.dp, end = 8.dp)
-                            .testTag(STATE_INFO_BAR_TEST_TAG),
-                        infoBarData = InfoBarData(
-                            text = enrollmentData.text,
-                            icon = enrollmentData.icon,
-                            color = enrollmentData.textColor,
-                            backgroundColor = enrollmentData.backgroundColor,
-                            actionText = enrollmentData.actionText,
-                        ),
-                    )
-                }
+                    .padding(start = 8.dp, end = 8.dp)
+                    .testTag(SYNC_INFO_BAR_TEST_TAG),
+                infoBarData =
+                InfoBarData(
+                    text = syncData.text,
+                    icon = syncData.icon,
+                    color = syncData.textColor,
+                    backgroundColor = syncData.backgroundColor,
+                    actionText = syncData.actionText,
+                    onClick = syncData.onActionClick,
+                ),
+            )
+            if (followUpData.showInfoBar || enrollmentData.showInfoBar) {
+                Spacer(modifier = Modifier.padding(top = 8.dp))
             }
         }
 
-        item {
-            CardDetail(
-                modifier = Modifier.padding(top = 0.dp),
-                title = card.title,
-                additionalInfoList = card.additionalInfo,
-                avatar = card.avatar,
-                actionButton = card.actionButton,
-                expandLabelText = card.expandLabelText,
-                shrinkLabelText = card.shrinkLabelText,
-                showLoading = card.showLoading,
+        if (followUpData.showInfoBar) {
+            InfoBar(
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp)
+                    .testTag(FOLLOWUP_INFO_BAR_TEST_TAG),
+                infoBarData = InfoBarData(
+                    text = followUpData.text,
+                    icon = followUpData.icon,
+                    color = followUpData.textColor,
+                    backgroundColor = followUpData.backgroundColor,
+                    actionText = followUpData.actionText,
+                    onClick = followUpData.onActionClick,
+                ),
+            )
+            if (enrollmentData.showInfoBar) {
+                Spacer(modifier = Modifier.padding(top = 8.dp))
+            }
+        }
+
+        if (enrollmentData.showInfoBar) {
+            InfoBar(
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp)
+                    .testTag(STATE_INFO_BAR_TEST_TAG),
+                infoBarData = InfoBarData(
+                    text = enrollmentData.text,
+                    icon = enrollmentData.icon,
+                    color = enrollmentData.textColor,
+                    backgroundColor = enrollmentData.backgroundColor,
+                    actionText = enrollmentData.actionText,
+                ),
             )
         }
+
+        CardDetail(
+            title = card.title,
+            additionalInfoList = card.additionalInfo,
+            avatar = card.avatar,
+            actionButton = card.actionButton,
+            expandLabelText = card.expandLabelText,
+            shrinkLabelText = card.shrinkLabelText,
+            showLoading = card.showLoading,
+        )
     }
 }
 

--- a/app/src/main/res/layout-land/fragment_tei_data.xml
+++ b/app/src/main/res/layout-land/fragment_tei_data.xml
@@ -83,6 +83,7 @@
                         <include
                             android:id="@+id/card_front"
                             layout="@layout/fragment_tei_data_card_front"
+                            android:visibility="@{ program != null ? View.GONE : View.VISIBLE}"
                             app:dashboardModel="@{dashboardModel}"
                             app:enrollment="@{enrollment}"
                             app:followup="@{followup}"

--- a/app/src/main/res/layout-land/fragment_tei_data.xml
+++ b/app/src/main/res/layout-land/fragment_tei_data.xml
@@ -46,85 +46,106 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <LinearLayout
-            android:id="@+id/cardLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/tei_data"
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:cardElevation="4dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:layout_height="match_parent">
+
+                <LinearLayout
+                    android:id="@+id/cardLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/detailCard"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/tei_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:cardElevation="4dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <include
+                            android:id="@+id/card_front"
+                            layout="@layout/fragment_tei_data_card_front"
+                            app:dashboardModel="@{dashboardModel}"
+                            app:enrollment="@{enrollment}"
+                            app:followup="@{followup}"
+                            app:presenter="@{presenter}"
+                            app:program="@{program}"
+                            app:trackEntity="@{trackEntity}" />
+                    </androidx.cardview.widget.CardView>
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/filterLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?colorPrimary"
+                        android:visibility="gone"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:listitem="@layout/item_header_filter" />
+
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/tei_recycler"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clipToPadding="false"
+                    android:paddingBottom="200dp"
+                    app:layout_constraintVertical_weight="0"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cardLayout"
+                    tools:listitem="@layout/item_event" />
+
+                <TextView
+                    android:id="@+id/empty_teis"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@color/white"
+                    android:gravity="center"
+                    android:padding="42dp"
+                    android:text="@string/empty_tei_add"
+                    android:textSize="@dimen/primaryTextSize"
+                    android:visibility="visible"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cardLayout" />
 
                 <include
-                    android:id="@+id/card_front"
-                    layout="@layout/fragment_tei_data_card_front"
-                    app:dashboardModel="@{dashboardModel}"
-                    app:enrollment="@{enrollment}"
-                    app:followup="@{followup}"
-                    app:presenter="@{presenter}"
-                    app:program="@{program}"
-                    app:trackEntity="@{trackEntity}" />
-            </androidx.cardview.widget.CardView>
+                    android:id="@+id/loading_progress"
+                    layout="@layout/progress_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cardLayout" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/filterLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?colorPrimary"
-                android:visibility="gone"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:listitem="@layout/item_header_filter" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </LinearLayout>
-
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/tei_recycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:clipToPadding="false"
-            android:paddingBottom="200dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cardLayout"
-            tools:listitem="@layout/item_event" />
-
-        <TextView
-            android:id="@+id/empty_teis"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="@color/white"
-            android:gravity="center"
-            android:padding="42dp"
-            android:text="@string/empty_tei_add"
-            android:textSize="@dimen/primaryTextSize"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cardLayout" />
-
-        <include
-            android:id="@+id/loading_progress"
-            layout="@layout/progress_layout"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cardLayout" />
+        </androidx.core.widget.NestedScrollView>
 
         <org.dhis2.utils.dialFloatingActionButton.DialFloatingActionButtonLayout
             android:id="@+id/dialFabLayout"
@@ -133,8 +154,8 @@
             app:fab_extra_bottom_margin="@{52}"
             app:fab_visibility="@{enrollment==null || enrollment.status() != EnrollmentStatus.ACTIVE || isGrouping || !canAddEvents}"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintEnd_toEndOf="parent" />
 
-        </org.dhis2.utils.dialFloatingActionButton.DialFloatingActionButtonLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>

--- a/app/src/main/res/layout-land/fragment_tei_data.xml
+++ b/app/src/main/res/layout-land/fragment_tei_data.xml
@@ -49,7 +49,8 @@
 
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:overScrollMode="never">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -116,7 +117,8 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cardLayout"
-                    tools:listitem="@layout/item_event" />
+                    tools:listitem="@layout/item_event"
+                    android:overScrollMode="never"/>
 
                 <TextView
                     android:id="@+id/empty_teis"

--- a/app/src/main/res/layout/fragment_tei_data.xml
+++ b/app/src/main/res/layout/fragment_tei_data.xml
@@ -49,7 +49,8 @@
 
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:overScrollMode="never">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -118,7 +119,8 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cardLayout"
-                    tools:listitem="@layout/item_event" />
+                    tools:listitem="@layout/item_event"
+                    android:overScrollMode="never"/>
 
                 <TextView
                     android:id="@+id/empty_teis"

--- a/app/src/main/res/layout/fragment_tei_data.xml
+++ b/app/src/main/res/layout/fragment_tei_data.xml
@@ -46,94 +46,108 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-         <LinearLayout
-            android:id="@+id/cardLayout"
+
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="match_parent">
 
-             <androidx.compose.ui.platform.ComposeView
-                 android:id="@+id/detailCard"
-                 android:layout_width="match_parent"
-                 android:layout_height="wrap_content"
-                 app:layout_constraintEnd_toEndOf="parent"
-                 app:layout_constraintStart_toStartOf="parent"
-                 app:layout_constraintTop_toTopOf="parent"/>
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/tei_data"
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:cardElevation="4dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:layout_height="match_parent">
+
+                <LinearLayout
+                    android:id="@+id/cardLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/detailCard"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/tei_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:cardElevation="4dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <include
+                            android:id="@+id/card_front"
+                            layout="@layout/fragment_tei_data_card_front"
+                            android:visibility="@{ program != null ? View.GONE : View.VISIBLE}"
+                            app:dashboardModel="@{dashboardModel}"
+                            app:enrollment="@{enrollment}"
+                            app:followup="@{followup}"
+                            app:presenter="@{presenter}"
+                            app:program="@{program}"
+                            app:trackEntity="@{trackEntity}" />
+
+                    </androidx.cardview.widget.CardView>
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/filterLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?colorPrimary"
+                        android:visibility="gone"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:listitem="@layout/item_header_filter" />
+
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/tei_recycler"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clipToPadding="false"
+                    android:paddingBottom="200dp"
+                    app:layout_constraintVertical_weight="0"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cardLayout"
+                    tools:listitem="@layout/item_event" />
+
+                <TextView
+                    android:id="@+id/empty_teis"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@color/white"
+                    android:gravity="center"
+                    android:padding="42dp"
+                    android:text="@string/empty_tei_add"
+                    android:textSize="@dimen/primaryTextSize"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cardLayout" />
 
                 <include
-                    android:id="@+id/card_front"
-                    layout="@layout/fragment_tei_data_card_front"
-                    android:visibility="@{ program != null ? View.GONE : View.VISIBLE}"
-                    app:dashboardModel="@{dashboardModel}"
-                    app:enrollment="@{enrollment}"
-                    app:followup="@{followup}"
-                    app:presenter="@{presenter}"
-                    app:program="@{program}"
-                    app:trackEntity="@{trackEntity}" />
-            </androidx.cardview.widget.CardView>
+                    android:id="@+id/loading_progress"
+                    layout="@layout/progress_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cardLayout" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/filterLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?colorPrimary"
-                android:visibility="gone"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:listitem="@layout/item_header_filter" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </LinearLayout>
-
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/tei_recycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:clipToPadding="false"
-            android:paddingBottom="200dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cardLayout"
-            tools:listitem="@layout/item_event" />
-
-        <TextView
-            android:id="@+id/empty_teis"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="@color/white"
-            android:gravity="center"
-            android:padding="42dp"
-            android:text="@string/empty_tei_add"
-            android:textSize="@dimen/primaryTextSize"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cardLayout" />
-
-        <include
-            android:id="@+id/loading_progress"
-            layout="@layout/progress_layout"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cardLayout" />
+        </androidx.core.widget.NestedScrollView>
 
     <org.dhis2.utils.dialFloatingActionButton.DialFloatingActionButtonLayout
         android:id="@+id/dialFabLayout"
@@ -142,8 +156,8 @@
         app:fab_extra_bottom_margin="@{16}"
         app:fab_visibility="@{enrollment==null || enrollment.status() != EnrollmentStatus.ACTIVE || isGrouping || !canAddEvents}"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    </org.dhis2.utils.dialFloatingActionButton.DialFloatingActionButtonLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>


### PR DESCRIPTION
## Description
The scroll functionality on the event list seems to be causing issues, hiding elements beneath the dashboard. This scrolling shouldn't exist.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-5663)

## Solution description
We can change the `LazyColumn` to `Column` for the card layout, and we can use nested scroll view to make the events list and card layout scrollable.

## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [x] 11.X - 13.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
