### PR TITLE
feat: Update to DHIS2 Android SDK 1.9.1-20231215.100321-10

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/settings/SettingsRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/settings/SettingsRepository.kt
@@ -43,7 +43,7 @@ class SettingsRepository(
             null
         }
     private val smsConfig: ConfigCase.SmsConfig
-        get() = d2.smsModule().configCase().smsModuleConfig.blockingGet()
+        get() = d2.smsModule().configCase().getSmsModuleConfig().blockingGet()
 
     fun dataSync(): Single<DataSettingsViewModel> {
         return Single.just(

--- a/app/src/main/java/org/dhis2/utils/granularsync/SMSSyncProvider.kt
+++ b/app/src/main/java/org/dhis2/utils/granularsync/SMSSyncProvider.kt
@@ -36,11 +36,11 @@ interface SMSSyncProvider {
     }
 
     fun expectsResponseSMS(): Boolean {
-        return d2.smsModule().configCase().smsModuleConfig.blockingGet().isWaitingForResult
+        return d2.smsModule().configCase().getSmsModuleConfig().blockingGet().isWaitingForResult
     }
 
     fun getGatewayNumber(): String {
-        return d2.smsModule().configCase().smsModuleConfig.blockingGet().gateway
+        return d2.smsModule().configCase().getSmsModuleConfig().blockingGet().gateway
     }
 
     fun isSMSEnabled(isTrackerSync: Boolean): Boolean {
@@ -51,7 +51,7 @@ interface SMSSyncProvider {
         }
 
         val smsModuleIsEnabled =
-            d2.smsModule().configCase().smsModuleConfig.blockingGet().isModuleEnabled
+            d2.smsModule().configCase().getSmsModuleConfig().blockingGet().isModuleEnabled
 
         return hasCorrectSmsVersion && smsModuleIsEnabled
     }

--- a/app/src/main/java/org/dhis2/utils/granularsync/SMSSyncProviderImpl.kt
+++ b/app/src/main/java/org/dhis2/utils/granularsync/SMSSyncProviderImpl.kt
@@ -46,7 +46,7 @@ class SMSSyncProviderImpl(
                     reportState(SmsSendingService.State.SENT, 0, 0),
                 )
             }
-            .andThen(d2.smsModule().configCase().smsModuleConfig)
+            .andThen(d2.smsModule().configCase().getSmsModuleConfig())
             .flatMapCompletable { config ->
                 if (config.isWaitingForResult) {
                     doOnNewState(

--- a/app/src/test/java/org/dhis2/usescases/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/settings/SettingsRepositoryTest.kt
@@ -383,15 +383,15 @@ class SettingsRepositoryTest {
     }
 
     private fun configureSMSConfig() {
-        whenever(localDbRepository.isModuleEnabled) doReturn
+        whenever(localDbRepository.isModuleEnabled()) doReturn
             Single.just(true)
-        whenever(localDbRepository.gatewayNumber) doReturn
+        whenever(localDbRepository.getGatewayNumber()) doReturn
             Single.just("gatewaynumber")
-        whenever(localDbRepository.waitingForResultEnabled) doReturn
+        whenever(localDbRepository.getWaitingForResultEnabled()) doReturn
             Single.just(true)
-        whenever(localDbRepository.confirmationSenderNumber) doReturn
+        whenever(localDbRepository.getConfirmationSenderNumber()) doReturn
             Single.just("confirmationNumber")
-        whenever(localDbRepository.waitingResultTimeout) doReturn
+        whenever(localDbRepository.getWaitingResultTimeout()) doReturn
             Single.just(120)
         whenever(d2.smsModule().configCase()) doReturn
             ConfigCase(

--- a/app/src/test/java/org/dhis2/utils/granularsync/SMSSyncProviderTest.kt
+++ b/app/src/test/java/org/dhis2/utils/granularsync/SMSSyncProviderTest.kt
@@ -233,7 +233,7 @@ class SMSSyncProviderTest {
             d2.smsModule().configCase(),
         ) doReturn mock()
         whenever(
-            d2.smsModule().configCase().smsModuleConfig,
+            d2.smsModule().configCase().getSmsModuleConfig(),
         ) doReturn Single.just(smsConfig)
     }
 
@@ -298,7 +298,7 @@ class SMSSyncProviderTest {
             d2.smsModule().configCase(),
         ) doReturn mock()
         whenever(
-            d2.smsModule().configCase().smsModuleConfig,
+            d2.smsModule().configCase().getSmsModuleConfig(),
         ) doReturn Single.just(smsConfig)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ hiltCompiler = '1.0.0'
 jacoco = '0.8.10'
 
 designSystem = "1.0-20231116.084101-124"
-dhis2sdk = "1.9.0"
+dhis2sdk = "1.9.1-20231215.100321-10"
 ruleEngine = "2.1.9"
 appcompat = "1.6.1"
 annotation = "1.6.0"


### PR DESCRIPTION
## Description
Adapt to changes in the SDK due to the refactor from Java to Kotlin. They are mainly caused by Kotlin-Java interoperability shortcuts: a java method called "getName()" is suggested as just ".name" by Android Studio in Kotlin code. If the method keeps the signature "getName()" when refactored to Kotlin, the shortcut does not work anymore and the method must be accessed by "getName()" in Kotlin as well.

## Solution description
## Covered unit test cases

## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [X] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
