### PR TITLE
fix: [ANDROAPP-5821] Add no options available category selector

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/EventInitialTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/EventInitialTest.kt
@@ -23,6 +23,7 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.domain.Configu
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.domain.ConfigureEventTemp
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.domain.ConfigureOrgUnit
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.domain.CreateOrUpdateEventDetails
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventInputDateUiModel
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.EventDetailResourcesProvider
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.INPUT_EVENT_INITIAL_DATE
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideInputDate
@@ -213,14 +214,16 @@ class EventInitialTest {
             val date by viewModel.eventDate.collectAsState()
             val details by viewModel.eventDetails.collectAsState()
             ProvideInputDate(
-                eventDate = date,
-                detailsEnabled = details.enabled,
-                onDateClick = { viewModel.onDateClick() },
-                onDateSet = { dateValues ->
-                    viewModel.onDateSet(dateValues.year, dateValues.month, dateValues.day)
-                },
-                onClear = { viewModel.onClearEventReportDate() },
-                required = true,
+                EventInputDateUiModel(
+                    eventDate = date,
+                    detailsEnabled = details.enabled,
+                    onDateClick = { viewModel.onDateClick() },
+                    onDateSet = { dateValues ->
+                        viewModel.onDateSet(dateValues.year, dateValues.month, dateValues.day)
+                    },
+                    onClear = { viewModel.onClearEventReportDate() },
+                    required = true,
+                )
             )
 
         }
@@ -244,14 +247,17 @@ class EventInitialTest {
             val date by viewModel.eventDate.collectAsState()
             val details by viewModel.eventDetails.collectAsState()
             ProvideInputDate(
-                eventDate = date,
-                detailsEnabled = details.enabled,
-                onDateClick = { viewModel.onDateClick() },
-                onDateSet = { dateValues ->
-                    viewModel.onDateSet(dateValues.year, dateValues.month, dateValues.day)
-                },
-                onClear = { viewModel.onClearEventReportDate() },
-                required = true,
+                EventInputDateUiModel(
+                    eventDate = date,
+                    detailsEnabled = details.enabled,
+                    onDateClick = { viewModel.onDateClick() },
+                    onDateSet = { dateValues ->
+                        viewModel.onDateSet(dateValues.year, dateValues.month, dateValues.day)
+                    },
+                    onClear = { viewModel.onClearEventReportDate() },
+                    required = true,
+                )
+
             )
 
         }

--- a/app/src/main/java/org/dhis2/usescases/events/ScheduledEventActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/events/ScheduledEventActivity.kt
@@ -6,11 +6,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.DatePicker
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.unit.dp
 import androidx.databinding.DataBindingUtil
 import org.dhis2.App
 import org.dhis2.R
@@ -111,7 +107,6 @@ class ScheduledEventActivity : ActivityGlobalAbstract(), ScheduledEventContract.
                             ?: getString(R.string.report_date),
                         dateValue = "",
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
 
                     ProvideInputDate(
                         eventDate = eventDate,
@@ -126,7 +121,6 @@ class ScheduledEventActivity : ActivityGlobalAbstract(), ScheduledEventContract.
                             label = programStage.dueDateLabel() ?: getString(R.string.due_date),
                             dateValue = DateUtils.uiDateFormat().format(event.dueDate() ?: ""),
                         )
-                        Spacer(modifier = Modifier.height(16.dp))
                         ProvideInputDate(
                             eventDate = dueDate,
                             detailsEnabled = true,

--- a/app/src/main/java/org/dhis2/usescases/events/ScheduledEventActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/events/ScheduledEventActivity.kt
@@ -16,6 +16,7 @@ import org.dhis2.commons.dialogs.calendarpicker.OnDatePickerListener
 import org.dhis2.databinding.ActivityEventScheduledBinding
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDate
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventInputDateUiModel
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideInputDate
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
 import org.dhis2.usescases.general.ActivityGlobalAbstract
@@ -109,12 +110,15 @@ class ScheduledEventActivity : ActivityGlobalAbstract(), ScheduledEventContract.
                     )
 
                     ProvideInputDate(
-                        eventDate = eventDate,
-                        allowsManualInput = false,
-                        detailsEnabled = true,
-                        onDateClick = { setEvenDateListener(programStage.periodType()) },
-                        onDateSet = {},
-                        onClear = {},
+                        EventInputDateUiModel(
+                            eventDate = eventDate,
+                            allowsManualInput = false,
+                            detailsEnabled = true,
+                            onDateClick = { setEvenDateListener(programStage.periodType()) },
+                            onDateSet = {},
+                            onClear = {},
+                        ),
+
                     )
                     if (programStage.hideDueDate() == false) {
                         val dueDate = EventDate(
@@ -122,11 +126,13 @@ class ScheduledEventActivity : ActivityGlobalAbstract(), ScheduledEventContract.
                             dateValue = DateUtils.uiDateFormat().format(event.dueDate() ?: ""),
                         )
                         ProvideInputDate(
-                            eventDate = dueDate,
-                            detailsEnabled = true,
-                            onDateClick = { setDueDateListener(programStage.periodType()) },
-                            onDateSet = {},
-                            onClear = {},
+                            EventInputDateUiModel(
+                                eventDate = dueDate,
+                                detailsEnabled = true,
+                                onDateClick = { setDueDateListener(programStage.periodType()) },
+                                onDateSet = {},
+                                onClear = {},
+                            ),
                         )
                     }
                 }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/data/EventDetailsRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/data/EventDetailsRepository.kt
@@ -202,6 +202,11 @@ class EventDetailsRepository(
             .one().blockingGet()?.uid()
     }
 
+    fun getCatOptionComboDisplayName(categoryComboUid: String): String? {
+        return d2.categoryModule().categoryCombos().uid(categoryComboUid)
+            .blockingGet()?.displayName()
+    }
+
     fun getCatOption(selectedOption: String?): CategoryOption? {
         return d2.categoryModule().categoryOptions().uid(selectedOption).blockingGet()
     }

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/domain/ConfigureEventCatCombo.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/domain/ConfigureEventCatCombo.kt
@@ -19,12 +19,13 @@ class ConfigureEventCatCombo(
         repository.catCombo().apply {
             val categories = getCategories(this?.categories())
             val categoryOptions = getCategoryOptions()
-
+            val catComboUid = getCatComboUid(this?.uid() ?: "", this?.isDefault ?: false)
+            val catComboDisplayName = getCatComboDisplayName(this?.uid() ?: "")
             updateSelectedOptions(categoryOption, categories, categoryOptions)
 
             return flowOf(
                 EventCatCombo(
-                    uid = getCatComboUid(this?.uid() ?: "", this?.isDefault ?: false),
+                    uid = catComboUid,
                     isDefault = this?.isDefault ?: false,
                     categories = categories,
                     categoryOptions = categoryOptions,
@@ -34,6 +35,7 @@ class ConfigureEventCatCombo(
                         categories = this?.categories(),
                         selectedCategoryOptions = selectedCategoryOptions,
                     ),
+                    displayName = catComboDisplayName,
                 ),
             )
         }
@@ -71,6 +73,10 @@ class ConfigureEventCatCombo(
         }
 
         return null
+    }
+
+    private fun getCatComboDisplayName(categoryComboUid: String): String? {
+        return repository.getCatOptionComboDisplayName(categoryComboUid)
     }
 
     private fun updateSelectedOptions(

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventCatCombo.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventCatCombo.kt
@@ -9,4 +9,5 @@ data class EventCatCombo(
     val categoryOptions: Map<String, CategoryOption>? = null,
     val selectedCategoryOptions: Map<String, CategoryOption?> = HashMap(),
     val isCompleted: Boolean = false,
+    val displayName: String? = "",
 )

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventCatComboUiModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventCatComboUiModel.kt
@@ -1,0 +1,19 @@
+package org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models
+
+import org.hisp.dhis.android.core.category.CategoryOption
+import java.util.Date
+
+data class EventCatComboUiModel(
+    val category: EventCategory,
+    val eventCatCombo: EventCatCombo,
+    val detailsEnabled: Boolean,
+    val currentDate: Date?,
+    val selectedOrgUnit: String?,
+    val onShowCategoryDialog: (EventCategory) -> Unit,
+    val onClearCatCombo: (EventCategory) -> Unit,
+    val onOptionSelected: (CategoryOption?) -> Unit,
+    val required: Boolean = false,
+    val noOptionsText: String,
+    val catComboText: String,
+    val showField: Boolean = true,
+)

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventInputDateUiModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/models/EventInputDateUiModel.kt
@@ -1,0 +1,14 @@
+package org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models
+
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.InputDateValues
+
+data class EventInputDateUiModel(
+    val eventDate: EventDate,
+    val detailsEnabled: Boolean,
+    val onDateClick: () -> Unit,
+    val allowsManualInput: Boolean = true,
+    val onDateSet: (InputDateValues) -> Unit,
+    val onClear: () -> Unit,
+    val required: Boolean = false,
+    val showField: Boolean = true,
+)

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
@@ -1,6 +1,8 @@
 package org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
@@ -14,14 +16,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import org.dhis2.R
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.data.dhislogic.inDateRange
 import org.dhis2.data.dhislogic.inOrgUnit
 import org.dhis2.form.model.UiEventType
 import org.dhis2.form.model.UiRenderType
-import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCatCombo
-import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCategory
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCatComboUiModel
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCoordinates
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDate
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventOrgUnit
@@ -30,7 +32,6 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventTe
 import org.dhis2.utils.category.CategoryDialog.Companion.DEFAULT_COUNT_LIMIT
 import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.arch.helpers.Result
-import org.hisp.dhis.android.core.category.CategoryOption
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.common.ValueType
@@ -51,7 +52,6 @@ import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
-import java.util.Date
 
 @Composable
 fun ProvideInputDate(
@@ -62,52 +62,56 @@ fun ProvideInputDate(
     onDateSet: (InputDateValues) -> Unit,
     onClear: () -> Unit,
     required: Boolean = false,
+    showField: Boolean = true,
 ) {
-    var value by remember(eventDate.dateValue) {
-        mutableStateOf(eventDate.dateValue?.let { formatStoredDateToUI(it) })
-    }
+    if (showField) {
+        Spacer(modifier = Modifier.height(16.dp))
+        var value by remember(eventDate.dateValue) {
+            mutableStateOf(eventDate.dateValue?.let { formatStoredDateToUI(it) })
+        }
 
-    var state by remember {
-        mutableStateOf(getInputState(detailsEnabled))
-    }
+        var state by remember {
+            mutableStateOf(getInputState(detailsEnabled))
+        }
 
-    InputDateTime(
-        title = eventDate.label ?: "",
-        allowsManualInput = allowsManualInput,
-        value = value,
-        actionIconType = DateTimeActionIconType.DATE,
-        onActionClicked = onDateClick,
-        state = state,
-        visualTransformation = DateTransformation(),
-        onValueChanged = {
-            value = it
-            if (it.isEmpty()) {
-                onClear()
-            } else if (isValid(it)) {
-                if (isValidDateFormat(it)) {
-                    state = InputShellState.FOCUSED
-                    formatUIDateToStored(it)?.let { dateValues ->
-                        onDateSet(dateValues)
-                    }
-                } else {
-                    state = InputShellState.ERROR
-                }
-            } else {
-                state = InputShellState.FOCUSED
-            }
-        },
-        isRequired = required,
-        modifier = Modifier.testTag(INPUT_EVENT_INITIAL_DATE),
-        onFocusChanged = { focused ->
-            if (!focused) {
-                value?.let {
-                    if (!isValid(it)) {
+        InputDateTime(
+            title = eventDate.label ?: "",
+            allowsManualInput = allowsManualInput,
+            value = value,
+            actionIconType = DateTimeActionIconType.DATE,
+            onActionClicked = onDateClick,
+            state = state,
+            visualTransformation = DateTransformation(),
+            onValueChanged = {
+                value = it
+                if (it.isEmpty()) {
+                    onClear()
+                } else if (isValid(it)) {
+                    if (isValidDateFormat(it)) {
+                        state = InputShellState.FOCUSED
+                        formatUIDateToStored(it)?.let { dateValues ->
+                            onDateSet(dateValues)
+                        }
+                    } else {
                         state = InputShellState.ERROR
                     }
+                } else {
+                    state = InputShellState.FOCUSED
                 }
-            }
-        },
-    )
+            },
+            isRequired = required,
+            modifier = Modifier.testTag(INPUT_EVENT_INITIAL_DATE),
+            onFocusChanged = { focused ->
+                if (!focused) {
+                    value?.let {
+                        if (!isValid(it)) {
+                            state = InputShellState.ERROR
+                        }
+                    }
+                }
+            },
+        )
+    }
 }
 
 fun isValidDateFormat(dateString: String): Boolean {
@@ -175,60 +179,56 @@ fun ProvideOrgUnit(
     resources: ResourceManager,
     onClear: () -> Unit,
     required: Boolean = false,
+    showField: Boolean = true,
 ) {
-    val state = getInputState(detailsEnabled && orgUnit.enable && orgUnit.orgUnits.size > 1)
+    if (showField) {
+        Spacer(modifier = Modifier.height(16.dp))
+        val state = getInputState(detailsEnabled && orgUnit.enable && orgUnit.orgUnits.size > 1)
 
-    var inputFieldValue by remember(orgUnit.selectedOrgUnit) {
-        mutableStateOf(orgUnit.selectedOrgUnit?.displayName())
+        var inputFieldValue by remember(orgUnit.selectedOrgUnit) {
+            mutableStateOf(orgUnit.selectedOrgUnit?.displayName())
+        }
+
+        InputOrgUnit(
+            title = resources.getString(R.string.org_unit),
+            state = state,
+            inputText = inputFieldValue ?: "",
+            onValueChanged = {
+                inputFieldValue = it
+                if (it.isNullOrEmpty()) {
+                    onClear()
+                }
+            },
+            onOrgUnitActionCLicked = onOrgUnitClick,
+            isRequiredField = required,
+        )
     }
-
-    InputOrgUnit(
-        title = resources.getString(R.string.org_unit),
-        state = state,
-        inputText = inputFieldValue ?: "",
-        onValueChanged = {
-            inputFieldValue = it
-            if (it.isNullOrEmpty()) {
-                onClear()
-            }
-        },
-        onOrgUnitActionCLicked = onOrgUnitClick,
-        isRequiredField = required,
-    )
 }
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ProvideCategorySelector(
     modifier: Modifier = Modifier,
-    category: EventCategory,
-    eventCatCombo: EventCatCombo,
-    detailsEnabled: Boolean,
-    currentDate: Date?,
-    selectedOrgUnit: String?,
-    onShowCategoryDialog: (EventCategory) -> Unit,
-    onClearCatCombo: (EventCategory) -> Unit,
-    onOptionSelected: (CategoryOption?) -> Unit,
-    required: Boolean = false,
-    noOptionsText: String,
+    eventCatComboUiModel: EventCatComboUiModel,
 ) {
     var selectedItem by remember {
         mutableStateOf(
-            eventCatCombo.selectedCategoryOptions[category.uid]?.displayName()
-                ?: eventCatCombo.categoryOptions?.get(category.uid)?.displayName(),
+            eventCatComboUiModel.eventCatCombo.selectedCategoryOptions[eventCatComboUiModel.category.uid]?.displayName()
+                ?: eventCatComboUiModel.eventCatCombo.categoryOptions?.get(eventCatComboUiModel.category.uid)?.displayName(),
         )
     }
 
     var expanded by remember { mutableStateOf(false) }
-    val selectableOptions = category.options
+    val selectableOptions = eventCatComboUiModel.category.options
         .filter { option ->
             option.access().data().write()
         }.filter { option ->
-            option.inDateRange(currentDate)
+            option.inDateRange(eventCatComboUiModel.currentDate)
         }.filter { option ->
-            option.inOrgUnit(selectedOrgUnit)
+            option.inOrgUnit(eventCatComboUiModel.selectedOrgUnit)
         }
 
+    Spacer(modifier = Modifier.height(16.dp))
     if (selectableOptions.isNotEmpty()) {
         ExposedDropdownMenuBox(
             expanded = expanded,
@@ -236,22 +236,22 @@ fun ProvideCategorySelector(
         ) {
             InputDropDown(
                 modifier = modifier,
-                title = category.name,
-                state = getInputState(detailsEnabled),
+                title = eventCatComboUiModel.category.name,
+                state = getInputState(eventCatComboUiModel.detailsEnabled),
                 selectedItem = selectedItem,
                 onResetButtonClicked = {
                     selectedItem = null
-                    onClearCatCombo(category)
+                    eventCatComboUiModel.onClearCatCombo(eventCatComboUiModel.category)
                 },
                 onArrowDropDownButtonClicked = {
                     expanded = !expanded
                 },
-                isRequiredField = required,
+                isRequiredField = eventCatComboUiModel.required,
             )
 
             if (expanded) {
-                if (category.optionsSize > DEFAULT_COUNT_LIMIT) {
-                    onShowCategoryDialog(category)
+                if (eventCatComboUiModel.category.optionsSize > DEFAULT_COUNT_LIMIT) {
+                    eventCatComboUiModel.onShowCategoryDialog(eventCatComboUiModel.category)
                     expanded = false
                 } else {
                     DropdownMenu(
@@ -281,7 +281,7 @@ fun ProvideCategorySelector(
                                     onClick = {
                                         expanded = false
                                         selectedItem = option.displayName()
-                                        onOptionSelected(option)
+                                        eventCatComboUiModel.onOptionSelected(option)
                                     },
                                 )
                             }
@@ -291,7 +291,7 @@ fun ProvideCategorySelector(
             }
         }
     } else {
-        ProvideEmptyCategorySelector(name = category.name, option = noOptionsText)
+        ProvideEmptyCategorySelector(name = eventCatComboUiModel.category.name, option = eventCatComboUiModel.noOptionsText)
     }
 }
 
@@ -368,35 +368,39 @@ fun ProvideCoordinates(
     coordinates: EventCoordinates,
     detailsEnabled: Boolean,
     resources: ResourceManager,
+    showField: Boolean = true,
 ) {
-    when (coordinates.model?.renderingType) {
-        UiRenderType.POLYGON, UiRenderType.MULTI_POLYGON -> {
-            InputPolygon(
-                title = resources.getString(R.string.polygon),
-                state = getInputState(detailsEnabled && coordinates.model.editable),
-                polygonAdded = !coordinates.model.value.isNullOrEmpty(),
-                onResetButtonClicked = { coordinates.model.onClear() },
-                onUpdateButtonClicked = {
-                    coordinates.model.invokeUiEvent(UiEventType.REQUEST_LOCATION_BY_MAP)
-                },
-            )
-        }
+    if (showField) {
+        Spacer(modifier = Modifier.height(16.dp))
+        when (coordinates.model?.renderingType) {
+            UiRenderType.POLYGON, UiRenderType.MULTI_POLYGON -> {
+                InputPolygon(
+                    title = resources.getString(R.string.polygon),
+                    state = getInputState(detailsEnabled && coordinates.model.editable),
+                    polygonAdded = !coordinates.model.value.isNullOrEmpty(),
+                    onResetButtonClicked = { coordinates.model.onClear() },
+                    onUpdateButtonClicked = {
+                        coordinates.model.invokeUiEvent(UiEventType.REQUEST_LOCATION_BY_MAP)
+                    },
+                )
+            }
 
-        else -> {
-            InputCoordinate(
-                title = resources.getString(R.string.coordinates),
-                state = getInputState(detailsEnabled && coordinates.model?.editable == true),
-                coordinates = mapGeometry(coordinates.model?.value, FeatureType.POINT),
-                latitudeText = resources.getString(R.string.latitude),
-                longitudeText = resources.getString(R.string.longitude),
-                addLocationBtnText = resources.getString(R.string.add_location),
-                onResetButtonClicked = {
-                    coordinates.model?.onClear()
-                },
-                onUpdateButtonClicked = {
-                    coordinates.model?.invokeUiEvent(UiEventType.REQUEST_LOCATION_BY_MAP)
-                },
-            )
+            else -> {
+                InputCoordinate(
+                    title = resources.getString(R.string.coordinates),
+                    state = getInputState(detailsEnabled && coordinates.model?.editable == true),
+                    coordinates = mapGeometry(coordinates.model?.value, FeatureType.POINT),
+                    latitudeText = resources.getString(R.string.latitude),
+                    longitudeText = resources.getString(R.string.longitude),
+                    addLocationBtnText = resources.getString(R.string.add_location),
+                    onResetButtonClicked = {
+                        coordinates.model?.onClear()
+                    },
+                    onUpdateButtonClicked = {
+                        coordinates.model?.invokeUiEvent(UiEventType.REQUEST_LOCATION_BY_MAP)
+                    },
+                )
+            }
         }
     }
 }
@@ -421,44 +425,48 @@ fun ProvideRadioButtons(
     detailsEnabled: Boolean,
     resources: ResourceManager,
     onEventTempSelected: (status: EventTempStatus?) -> Unit,
+    showField: Boolean = true,
 ) {
-    val radioButtonData = listOf(
-        RadioButtonData(
-            uid = EventTempStatus.ONE_TIME.name,
-            selected = eventTemp.status == EventTempStatus.ONE_TIME,
-            enabled = true,
-            textInput = resources.getString(R.string.one_time),
-        ),
-        RadioButtonData(
-            uid = EventTempStatus.PERMANENT.name,
-            selected = eventTemp.status == EventTempStatus.PERMANENT,
-            enabled = true,
-            textInput = resources.getString(R.string.permanent),
-        ),
-    )
+    if (showField) {
+        Spacer(modifier = Modifier.height(16.dp))
+        val radioButtonData = listOf(
+            RadioButtonData(
+                uid = EventTempStatus.ONE_TIME.name,
+                selected = eventTemp.status == EventTempStatus.ONE_TIME,
+                enabled = true,
+                textInput = resources.getString(R.string.one_time),
+            ),
+            RadioButtonData(
+                uid = EventTempStatus.PERMANENT.name,
+                selected = eventTemp.status == EventTempStatus.PERMANENT,
+                enabled = true,
+                textInput = resources.getString(R.string.permanent),
+            ),
+        )
 
-    InputRadioButton(
-        title = resources.getString(R.string.referral),
-        radioButtonData = radioButtonData,
-        orientation = Orientation.HORIZONTAL,
-        state = getInputState(detailsEnabled),
-        itemSelected = radioButtonData.find { it.selected },
-        onItemChange = { data ->
-            when (data?.uid) {
-                EventTempStatus.ONE_TIME.name -> {
-                    onEventTempSelected(EventTempStatus.ONE_TIME)
-                }
+        InputRadioButton(
+            title = resources.getString(R.string.referral),
+            radioButtonData = radioButtonData,
+            orientation = Orientation.HORIZONTAL,
+            state = getInputState(detailsEnabled),
+            itemSelected = radioButtonData.find { it.selected },
+            onItemChange = { data ->
+                when (data?.uid) {
+                    EventTempStatus.ONE_TIME.name -> {
+                        onEventTempSelected(EventTempStatus.ONE_TIME)
+                    }
 
-                EventTempStatus.PERMANENT.name -> {
-                    onEventTempSelected(EventTempStatus.PERMANENT)
-                }
+                    EventTempStatus.PERMANENT.name -> {
+                        onEventTempSelected(EventTempStatus.PERMANENT)
+                    }
 
-                else -> {
-                    onEventTempSelected(null)
+                    else -> {
+                        onEventTempSelected(null)
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
+    }
 }
 
 const val INPUT_EVENT_INITIAL_DATE = "INPUT_EVENT_INITIAL_DATE"

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/providers/InputFieldsProvider.kt
@@ -237,7 +237,7 @@ fun ProvideCategorySelector(
             onExpandedChange = {},
         ) {
             InputDropDown(
-                modifier = modifier,
+                modifier = modifier.testTag(CATEGORY_SELECTOR),
                 title = eventCatComboUiModel.category.name,
                 state = getInputState(eventCatComboUiModel.detailsEnabled),
                 selectedItem = selectedItem,
@@ -293,7 +293,7 @@ fun ProvideCategorySelector(
             }
         }
     } else {
-        ProvideEmptyCategorySelector(name = eventCatComboUiModel.category.name, option = eventCatComboUiModel.noOptionsText)
+        ProvideEmptyCategorySelector(modifier = modifier, name = eventCatComboUiModel.category.name, option = eventCatComboUiModel.noOptionsText)
     }
 }
 
@@ -315,7 +315,7 @@ fun ProvideEmptyCategorySelector(
         onExpandedChange = {},
     ) {
         InputDropDown(
-            modifier = modifier,
+            modifier = modifier.testTag(EMPTY_CATEGORY_SELECTOR),
             title = name,
             state = InputShellState.UNFOCUSED,
             selectedItem = selectedItem,
@@ -472,3 +472,5 @@ fun ProvideRadioButtons(
 }
 
 const val INPUT_EVENT_INITIAL_DATE = "INPUT_EVENT_INITIAL_DATE"
+const val EMPTY_CATEGORY_SELECTOR = "EMPTY_CATEGORY_SELECTOR"
+const val CATEGORY_SELECTOR = "CATEGORY_SELECTOR"

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -42,6 +42,7 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCa
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCoordinates
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDate
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDetails
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventInputDateUiModel
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventOrgUnit
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventTemp
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideCategorySelector
@@ -240,15 +241,17 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
     ) {
         Column {
             ProvideInputDate(
-                eventDate = date,
-                detailsEnabled = details.enabled,
-                onDateClick = { viewModel.onDateClick() },
-                onDateSet = { dateValues ->
-                    viewModel.onDateSet(dateValues.year, dateValues.month - 1, dateValues.day)
-                },
-                onClear = { viewModel.onClearEventReportDate() },
-                required = true,
-                showField = date.active,
+                EventInputDateUiModel(
+                    eventDate = date,
+                    detailsEnabled = details.enabled,
+                    onDateClick = { viewModel.onDateClick() },
+                    onDateSet = { dateValues ->
+                        viewModel.onDateSet(dateValues.year, dateValues.month - 1, dateValues.day)
+                    },
+                    onClear = { viewModel.onClearEventReportDate() },
+                    required = true,
+                    showField = date.active,
+                ),
             )
             ProvideOrgUnit(
                 orgUnit = orgUnit,
@@ -288,7 +291,7 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                     )
                 }
             } else if (!catCombo.isDefault) {
-                ProvideEmptyCategorySelector(name = getString(R.string.cat_combo), option = getString(R.string.no_options))
+                ProvideEmptyCategorySelector(name = catCombo.displayName ?: getString(R.string.cat_combo), option = getString(R.string.no_options))
             }
             ProvideCoordinates(
                 coordinates = coordinates,

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -43,6 +43,7 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCa
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDetails
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideCategorySelector
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideCoordinates
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideEmptyCategorySelector
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideInputDate
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideOrgUnit
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideRadioButtons
@@ -171,27 +172,32 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
                 }
 
                 if (!catCombo.isDefault) {
-                    catCombo.categories.forEach { category ->
+                    if (catCombo.categories.isNotEmpty()) {
+                        catCombo.categories.forEach { category ->
+                            Spacer(modifier = Modifier.height(16.dp))
+                            ProvideCategorySelector(
+                                category = category,
+                                eventCatCombo = catCombo,
+                                detailsEnabled = details.enabled,
+                                currentDate = date.currentDate,
+                                selectedOrgUnit = details.selectedOrgUnit,
+                                onShowCategoryDialog = {
+                                    showCategoryDialog(it)
+                                },
+                                onClearCatCombo = {
+                                    viewModel.onClearCatCombo()
+                                },
+                                onOptionSelected = {
+                                    val selectedOption = Pair(category.uid, it?.uid())
+                                    viewModel.setUpCategoryCombo(selectedOption)
+                                },
+                                required = true,
+                                noOptionsText = getString(R.string.no_options),
+                            )
+                        }
+                    } else {
                         Spacer(modifier = Modifier.height(16.dp))
-                        ProvideCategorySelector(
-                            category = category,
-                            eventCatCombo = catCombo,
-                            detailsEnabled = details.enabled,
-                            currentDate = date.currentDate,
-                            selectedOrgUnit = details.selectedOrgUnit,
-                            onShowCategoryDialog = {
-                                showCategoryDialog(it)
-                            },
-                            onClearCatCombo = {
-                                viewModel.onClearCatCombo()
-                            },
-                            onOptionSelected = {
-                                val selectedOption = Pair(category.uid, it?.uid())
-                                viewModel.setUpCategoryCombo(selectedOption)
-                            },
-
-                            required = true,
-                        )
+                        ProvideEmptyCategorySelector(name = getString(R.string.cat_combo), option = getString(R.string.no_options))
                     }
                 }
 

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/ui/EventDetailsFragment.kt
@@ -9,12 +9,9 @@ import android.view.ViewGroup
 import android.widget.DatePicker
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -39,8 +36,14 @@ import org.dhis2.databinding.EventDetailsFragmentBinding
 import org.dhis2.maps.views.MapSelectorActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.injection.EventDetailsComponentProvider
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.injection.EventDetailsModule
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCatCombo
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCatComboUiModel
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCategory
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventCoordinates
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDate
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventDetails
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventOrgUnit
+import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.models.EventTemp
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideCategorySelector
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideCoordinates
 import org.dhis2.usescases.eventsWithoutRegistration.eventDetails.providers.ProvideEmptyCategorySelector
@@ -143,85 +146,14 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
             val coordinates by viewModel.eventCoordinates.collectAsState()
             val eventTemp by viewModel.eventTemp.collectAsState()
 
-            Column {
-                if (date.active) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    ProvideInputDate(
-                        eventDate = date,
-                        detailsEnabled = details.enabled,
-                        onDateClick = { viewModel.onDateClick() },
-                        onDateSet = { dateValues ->
-                            viewModel.onDateSet(dateValues.year, dateValues.month - 1, dateValues.day)
-                        },
-                        onClear = { viewModel.onClearEventReportDate() },
-                        required = true,
-                    )
-                }
-                if (orgUnit.visible) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    ProvideOrgUnit(
-                        orgUnit = orgUnit,
-                        detailsEnabled = details.enabled,
-                        onOrgUnitClick = { viewModel.onOrgUnitClick() },
-                        resources = resourceManager,
-                        onClear = {
-                            viewModel.onClearOrgUnit()
-                        },
-                        required = true,
-                    )
-                }
-
-                if (!catCombo.isDefault) {
-                    if (catCombo.categories.isNotEmpty()) {
-                        catCombo.categories.forEach { category ->
-                            Spacer(modifier = Modifier.height(16.dp))
-                            ProvideCategorySelector(
-                                category = category,
-                                eventCatCombo = catCombo,
-                                detailsEnabled = details.enabled,
-                                currentDate = date.currentDate,
-                                selectedOrgUnit = details.selectedOrgUnit,
-                                onShowCategoryDialog = {
-                                    showCategoryDialog(it)
-                                },
-                                onClearCatCombo = {
-                                    viewModel.onClearCatCombo()
-                                },
-                                onOptionSelected = {
-                                    val selectedOption = Pair(category.uid, it?.uid())
-                                    viewModel.setUpCategoryCombo(selectedOption)
-                                },
-                                required = true,
-                                noOptionsText = getString(R.string.no_options),
-                            )
-                        }
-                    } else {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        ProvideEmptyCategorySelector(name = getString(R.string.cat_combo), option = getString(R.string.no_options))
-                    }
-                }
-
-                if (coordinates.active) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    ProvideCoordinates(
-                        coordinates = coordinates,
-                        detailsEnabled = details.enabled,
-                        resources = resourceManager,
-                    )
-                }
-
-                if (eventTemp.active) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    ProvideRadioButtons(
-                        eventTemp = eventTemp,
-                        detailsEnabled = details.enabled,
-                        resources = resourceManager,
-                        onEventTempSelected = {
-                            viewModel.setUpEventTemp(it)
-                        },
-                    )
-                }
-            }
+            ProvideNewEventForm(
+                date = date,
+                details = details,
+                orgUnit = orgUnit,
+                catCombo = catCombo,
+                coordinates = coordinates,
+                eventTemp = eventTemp,
+            )
         }
         return binding.root
     }
@@ -294,6 +226,85 @@ class EventDetailsFragment : FragmentGlobalAbstract() {
         viewModel.onReopenSuccess = { message ->
             displayMessage(message)
             onEventReopened?.invoke()
+        }
+    }
+
+    @Composable
+    private fun ProvideNewEventForm(
+        date: EventDate,
+        details: EventDetails,
+        orgUnit: EventOrgUnit,
+        catCombo: EventCatCombo,
+        coordinates: EventCoordinates,
+        eventTemp: EventTemp,
+    ) {
+        Column {
+            ProvideInputDate(
+                eventDate = date,
+                detailsEnabled = details.enabled,
+                onDateClick = { viewModel.onDateClick() },
+                onDateSet = { dateValues ->
+                    viewModel.onDateSet(dateValues.year, dateValues.month - 1, dateValues.day)
+                },
+                onClear = { viewModel.onClearEventReportDate() },
+                required = true,
+                showField = date.active,
+            )
+            ProvideOrgUnit(
+                orgUnit = orgUnit,
+                detailsEnabled = details.enabled,
+                onOrgUnitClick = { viewModel.onOrgUnitClick() },
+                resources = resourceManager,
+                onClear = {
+                    viewModel.onClearOrgUnit()
+                },
+                required = true,
+                showField = orgUnit.visible,
+            )
+
+            if (!catCombo.isDefault && catCombo.categories.isNotEmpty()) {
+                catCombo.categories.forEach { category ->
+                    ProvideCategorySelector(
+                        eventCatComboUiModel = EventCatComboUiModel(
+                            category = category,
+                            eventCatCombo = catCombo,
+                            detailsEnabled = details.enabled,
+                            currentDate = date.currentDate,
+                            selectedOrgUnit = details.selectedOrgUnit,
+                            onShowCategoryDialog = {
+                                showCategoryDialog(it)
+                            },
+                            onClearCatCombo = {
+                                viewModel.onClearCatCombo()
+                            },
+                            onOptionSelected = {
+                                val selectedOption = Pair(category.uid, it?.uid())
+                                viewModel.setUpCategoryCombo(selectedOption)
+                            },
+                            required = true,
+                            noOptionsText = getString(R.string.no_options),
+                            catComboText = getString(R.string.cat_combo),
+                        ),
+                    )
+                }
+            } else if (!catCombo.isDefault) {
+                ProvideEmptyCategorySelector(name = getString(R.string.cat_combo), option = getString(R.string.no_options))
+            }
+            ProvideCoordinates(
+                coordinates = coordinates,
+                detailsEnabled = details.enabled,
+                resources = resourceManager,
+                showField = coordinates.active,
+            )
+            ProvideRadioButtons(
+                eventTemp = eventTemp,
+                detailsEnabled = details.enabled,
+                resources = resourceManager,
+                onEventTempSelected = {
+                    viewModel.setUpEventTemp(it)
+                },
+                showField = eventTemp.active,
+            )
         }
     }
 

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailPresenter.kt
@@ -66,12 +66,7 @@ class ProgramEventDetailPresenter(
                 ),
         )
         compositeDisposable.add(
-            Single.zip(
-                Single.just(eventRepository.getAccessDataWrite()),
-                eventRepository.hasAccessToAllCatOptions(),
-            ) { hasWritePermission, hasAccessToAllCatOptions ->
-                hasWritePermission && hasAccessToAllCatOptions
-            }
+            Single.just(eventRepository.getAccessDataWrite())
                 .subscribeOn(schedulerProvider.io())
                 .observeOn(schedulerProvider.ui())
                 .subscribe(

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailRepository.kt
@@ -17,7 +17,6 @@ interface ProgramEventDetailRepository {
     fun filteredEventsForMap(): Flowable<ProgramEventMapData>
     fun program(): Single<Program?>
     fun getAccessDataWrite(): Boolean
-    fun hasAccessToAllCatOptions(): Single<Boolean>
     fun getInfoForEvent(eventUid: String): Flowable<ProgramEventViewModel>
     fun featureType(): Single<FeatureType>
     fun getCatOptCombo(selectedCatOptionCombo: String): CategoryOptionCombo?

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailRepositoryImpl.kt
@@ -118,34 +118,6 @@ class ProgramEventDetailRepositoryImpl internal constructor(
         return canWrite
     }
 
-    override fun hasAccessToAllCatOptions(): Single<Boolean> {
-        return programRepository.get()
-            .map { program ->
-                val catCombo = d2.categoryModule().categoryCombos().withCategories()
-                    .uid(program.categoryComboUid()).blockingGet()
-                var hasAccess = true
-                if (catCombo?.isDefault == false) {
-                    for (category in catCombo.categories() ?: emptyList()) {
-                        val options = d2.categoryModule().categories().withCategoryOptions()
-                            .uid(category.uid()).blockingGet()?.categoryOptions() ?: emptyList()
-                        var accessibleOptions = options.size
-                        for (categoryOption in options) {
-                            if (d2.categoryModule().categoryOptions().uid(categoryOption.uid())
-                                    .blockingGet()?.access()?.data()?.write() == false
-                            ) {
-                                accessibleOptions--
-                            }
-                        }
-                        if (accessibleOptions == 0) {
-                            hasAccess = false
-                            break
-                        }
-                    }
-                }
-                hasAccess
-            }
-    }
-
     override fun workingLists(): Single<List<EventFilter>> {
         return d2.eventModule().eventFilters()
             .withEventDataFilters()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="event_was_deleted">Event deleted successfully</string>
     <string name="total">Total</string>
     <string name="most_recent_event_date">Most recent event date</string>
+    <string name="no_options">No options available</string>
 
     <!--TEI Enrollment list-->
     <string name="enrollment_list">Enrollment List</string>

--- a/app/src/test/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailPresenterTest.kt
@@ -117,7 +117,6 @@ class ProgramEventDetailPresenterTest {
         )
         filterManager.sortingItem = SortingItem(Filters.ORG_UNIT, SortingStatus.NONE)
         whenever(repository.getAccessDataWrite()) doReturn true
-        whenever(repository.hasAccessToAllCatOptions()) doReturn Single.just(true)
         whenever(repository.program()) doReturn Single.just(program)
         whenever(
             repository.filteredProgramEvents(),


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-5821)

Added a an empty Category Selector Provider with name and option as parameters and nothing else. 

App will show this when: there is a catCombo with no categories or a category with no options, and will not allow user to create the event

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [x] 11.X - 13.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
