### PR TITLE
fix: [ANDROAPP-5976] crash after discard or delete event

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureActivity.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import org.dhis2.R
 import org.dhis2.bindings.app
@@ -303,16 +302,12 @@ class EventCaptureActivity :
     }
 
     override fun showSnackBar(messageId: Int, programStage: String) {
-        val mySnackbar =
-            Snackbar.make(
-                binding.root,
-                resourceManager.formatWithEventLabel(
-                    messageId,
-                    programStage,
-                ),
-                BaseTransientBottomBar.LENGTH_SHORT,
-            )
-        mySnackbar.show()
+        showToast(
+            resourceManager.formatWithEventLabel(
+                messageId,
+                programStage,
+            ),
+        )
     }
 
     override fun restartDataEntry() {

--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterImpl.kt
@@ -180,13 +180,14 @@ class EventCapturePresenterImpl(
     }
 
     override fun deleteEvent() {
+        val programStage = programStage()
         compositeDisposable.add(
             eventCaptureRepository.deleteEvent()
                 .defaultSubscribe(
                     schedulerProvider,
                     { result ->
                         if (result) {
-                            view.showSnackBar(R.string.event_label_was_deleted, programStage())
+                            view.showSnackBar(R.string.event_label_was_deleted, programStage)
                         }
                     },
                     Timber::e,

--- a/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCapturePresenterTest.kt
@@ -138,6 +138,7 @@ class EventCapturePresenterTest {
     @Test
     fun `Should close form if it could not delete an event`() {
         whenever(eventRepository.deleteEvent()) doReturn Observable.just(false)
+        whenever(eventRepository.programStage()) doReturn Observable.just("programStage")
 
         presenter.deleteEvent()
         verify(view).finishDataEntry()


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
