### PR TITLE
fix: [ANDROAPP-6040] Remove scroll to first empty item functionality

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
@@ -3,6 +3,7 @@ package org.dhis2.usescases.event
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -30,6 +31,7 @@ class EventRegistrationRobot : BaseRobot() {
 
     fun checkEventDataEntryIsOpened(completion: Int, email: String, composeTestRule: ComposeTestRule) {
         onView(withId(R.id.completion)).check(matches(hasCompletedPercentage(completion)))
+        composeTestRule.onNodeWithText(email).performScrollTo()
         composeTestRule.onNodeWithText(email).assertIsDisplayed()
     }
 

--- a/form/src/main/java/org/dhis2/form/ui/Form.kt
+++ b/form/src/main/java/org/dhis2/form/ui/Form.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -90,14 +89,6 @@ fun Form(
                 items = sections,
                 key = { _, fieldUiModel -> fieldUiModel.uid },
             ) { _, section ->
-                val isSectionOpen = remember(section.state) {
-                    derivedStateOf { section.state == SectionState.OPEN }
-                }
-
-                LaunchIfTrue(isSectionOpen.value) {
-                    scrollState.animateScrollToItem(sections.indexOf(section))
-                    focusManager.moveFocusNext(focusNext)
-                }
 
                 val onNextSection: () -> Unit = {
                     getNextSection(section, sections)?.let {


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [x] 11.X - 13.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
