### PR TITLE
[ANDROAPP-6986] Set current day when creating event

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dhis2.org.analytics.charts.Charts
 import org.dhis2.animations.CarouselViewAnimations
+import org.dhis2.commons.date.DateUtils
 import org.dhis2.commons.di.dagger.PerActivity
 import org.dhis2.commons.filters.DisableHomeFiltersFromSettingsApp
 import org.dhis2.commons.filters.FilterManager
@@ -198,8 +199,14 @@ class ProgramEventDetailModule(
     fun provideCreateEventUseCase(
         dispatcher: DispatcherProvider,
         d2: D2,
+        dateUtils: DateUtils,
     ) = CreateEventUseCase(
         dispatcher = dispatcher,
         d2 = d2,
+        dateUtils = dateUtils,
     )
+
+    @Provides
+    @PerActivity
+    fun provideDateUtils() = DateUtils.getInstance()
 }

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/usecase/CreateEventUseCase.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/usecase/CreateEventUseCase.kt
@@ -1,6 +1,7 @@
 package org.dhis2.usescases.programEventDetail.usecase
 
 import kotlinx.coroutines.withContext
+import org.dhis2.commons.date.DateUtils
 import org.dhis2.commons.viewmodel.DispatcherProvider
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.event.EventCreateProjection
@@ -9,6 +10,7 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 class CreateEventUseCase(
     private val dispatcher: DispatcherProvider,
     private val d2: D2,
+    private val dateUtils: DateUtils,
 ) {
     suspend operator fun invoke(
         programUid: String,
@@ -25,6 +27,9 @@ class CreateEventUseCase(
                     organisationUnit(orgUnitUid)
                 }.build(),
             )
+
+            val eventRepository = d2.eventModule().events().uid(eventUid)
+            eventRepository.setEventDate(dateUtils.today)
 
             Result.success(eventUid)
         } catch (error: D2Error) {

--- a/app/src/main/java/org/dhis2/usescases/programStageSelection/ProgramStageSelectionInjector.kt
+++ b/app/src/main/java/org/dhis2/usescases/programStageSelection/ProgramStageSelectionInjector.kt
@@ -3,6 +3,7 @@ package org.dhis2.usescases.programStageSelection
 import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
+import org.dhis2.commons.date.DateUtils
 import org.dhis2.commons.di.dagger.PerActivity
 import org.dhis2.commons.network.NetworkUtils
 import org.dhis2.commons.resources.D2ErrorUtils
@@ -73,9 +74,14 @@ class ProgramStageSelectionModule(
     fun provideCreateEventUseCase(
         dispatcherProvider: DispatcherProvider,
         d2: D2,
-    ) = CreateEventUseCase(dispatcherProvider, d2)
+        dateUtils: DateUtils,
+    ) = CreateEventUseCase(dispatcherProvider, d2, dateUtils)
 
     @Provides
     @PerActivity
     fun provideD2ErrorUtils() = D2ErrorUtils(view.context, NetworkUtils(view.context))
+
+    @Provides
+    @PerActivity
+    fun provideDateUitls() = DateUtils.getInstance()
 }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataModule.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultRegistry
 import dagger.Module
 import dagger.Provides
 import org.dhis2.commons.data.EntryMode
+import org.dhis2.commons.date.DateUtils
 import org.dhis2.commons.di.dagger.PerFragment
 import org.dhis2.commons.network.NetworkUtils
 import org.dhis2.commons.reporting.CrashReportController
@@ -171,11 +172,16 @@ class TEIDataModule(
     fun provideCreateEventUseCase(
         dispatcherProvider: DispatcherProvider,
         d2: D2,
+        dateUtils: DateUtils,
     ) = CreateEventUseCase(
         dispatcher = dispatcherProvider,
         d2 = d2,
+        dateUtils = dateUtils,
     )
 
     @Provides
     fun provideD2ErrorUtils() = D2ErrorUtils(view.context, NetworkUtils(view.context))
+
+    @Provides
+    fun provideDateUtils() = DateUtils.getInstance()
 }

--- a/app/src/test/java/org/dhis2/usescases/programEventDetail/usecase/CreateEventUseCaseTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/programEventDetail/usecase/CreateEventUseCaseTest.kt
@@ -2,6 +2,7 @@ package org.dhis2.usescases.programEventDetail.usecase
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import org.dhis2.commons.date.DateUtils
 import org.dhis2.commons.viewmodel.DispatcherProvider
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.event.EventCreateProjection
@@ -18,6 +19,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.Date
 
 class CreateEventUseCaseTest {
 
@@ -41,9 +43,14 @@ class CreateEventUseCaseTest {
         on { eventModule() } doReturn eventModule
     }
 
+    private val dateUtils: DateUtils = mock {
+        on { today } doReturn Date()
+    }
+
     private val createEventUseCase: CreateEventUseCase = CreateEventUseCase(
         dispatcher = dispatcherProvider,
         d2 = d2,
+        dateUtils = dateUtils,
     )
 
     @Test
@@ -67,6 +74,8 @@ class CreateEventUseCaseTest {
                     this.organisationUnit() == orgUnitUid
             },
         )
+
+        verify(eventRepository).setEventDate(any<Date>())
     }
 
     @Test
@@ -88,6 +97,8 @@ class CreateEventUseCaseTest {
                     this.organisationUnit() == orgUnitUid
             },
         )
+
+        verify(eventRepository).setEventDate(any<Date>())
     }
 
     @Test


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
When a new event is created set today as event date
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [x] 11.X - 13.X
- [ ] Other
## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
