### PR TITLE
fix: [ANDROAPP-6210] UninitializedPropertyAccessException on BreakingTheGlassDialog

### DIFF
--- a/app/src/main/java/org/dhis2/utils/customviews/BreakTheGlassBottomDialog.kt
+++ b/app/src/main/java/org/dhis2/utils/customviews/BreakTheGlassBottomDialog.kt
@@ -1,5 +1,6 @@
 package org.dhis2.utils.customviews
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -15,13 +16,11 @@ import org.dhis2.commons.resources.ColorType
 import org.dhis2.commons.resources.ColorUtils
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.databinding.BreakTheGlassBottomDialogBindingImpl
-import javax.inject.Inject
 
 class BreakTheGlassBottomDialog : BottomSheetDialogFragment() {
 
     private lateinit var programUid: String
 
-    @Inject
     lateinit var resourceManager: ResourceManager
 
     val colorUtils: ColorUtils = ColorUtils()
@@ -42,11 +41,19 @@ class BreakTheGlassBottomDialog : BottomSheetDialogFragment() {
         isCancelable = false
     }
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        resourceManager = ResourceManager(
+            context,
+            colorUtils,
+        )
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
+    ): View {
         return BreakTheGlassBottomDialogBindingImpl.inflate(inflater, container, false).apply {
             message.text = resourceManager.formatWithEnrollmentLabel(
                 programUid,


### PR DESCRIPTION
BreakTheGlassBottomDialog was thoring an exception when trying to use resourceManager which was injected.
Given that this dialog does not have a module, the solution has been to manually instantiate the property.