### PR TITLE
fix: [ANDROAPP-6101] Do not allow to save form with errors in completed events

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/domain/ConfigureEventCompletionDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/domain/ConfigureEventCompletionDialog.kt
@@ -37,9 +37,9 @@ class ConfigureEventCompletionDialog(
             !canComplete && onCompleteMessage != null,
         )
         val mainButton = getMainButton(dialogType, eventState)
-        val secondaryButton = if (canSkipErrorFix || eventState == EventStatus.COMPLETED) {
+        val secondaryButton = if (canSkipErrorFix || dialogType == WARNING) {
             EventCompletionButtons(
-                SecondaryButton(if (eventState == EventStatus.COMPLETED) provider.provideSaveAnyway() else provider.provideNotNow()),
+                SecondaryButton(provider.provideNotNow()),
                 FormBottomDialog.ActionType.FINISH,
             )
         } else {

--- a/compose-table/src/androidTest/java/org/dhis2/composetable/CellTableTest.kt
+++ b/compose-table/src/androidTest/java/org/dhis2/composetable/CellTableTest.kt
@@ -40,6 +40,7 @@ class CellTableTest {
         }
     }
 
+    @Ignore("Flaky test, to be resolved in a separate ticket")
     @Test
     fun shouldUpdateValueWhenTypingInComponent() {
         tableRobot(composeTestRule) {


### PR DESCRIPTION
…rs, only with warnings

## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
