### PR TITLE
fix: [ANDROAPP-6273] Moves dataset groups calls to background thread

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetDetail/datasetList/DataSetListViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetDetail/datasetList/DataSetListViewModel.kt
@@ -4,14 +4,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.withContext
 import org.dhis2.commons.filters.FilterManager
 import org.dhis2.commons.matomo.Actions
 import org.dhis2.commons.matomo.Categories
 import org.dhis2.commons.matomo.Labels
 import org.dhis2.commons.matomo.MatomoAnalyticsController
-import org.dhis2.commons.schedulers.SchedulerProvider
 import org.dhis2.commons.viewmodel.DispatcherProvider
 import org.dhis2.usescases.datasets.datasetDetail.DataSetDetailModel
 import org.dhis2.usescases.datasets.datasetDetail.DataSetDetailRepository
@@ -20,11 +22,9 @@ import timber.log.Timber
 
 class DataSetListViewModel(
     private val dataSetDetailRepository: DataSetDetailRepository,
-    schedulerProvider: SchedulerProvider,
     val filterManager: FilterManager,
     val matomoAnalyticsController: MatomoAnalyticsController,
     dispatcher: DispatcherProvider,
-
 ) : ViewModel() {
 
     private val _datasets = MutableLiveData<List<DataSetDetailModel>>()
@@ -38,36 +38,34 @@ class DataSetListViewModel(
     val selectedSync = MutableLiveData<Action<DataSetDetailModel>>()
 
     init {
-
         viewModelScope.launch(dispatcher.io()) {
 
-            val datasets = async {
-                filterManager.asFlowable()
-                    .startWith(filterManager)
-                    .flatMap { filterManager: FilterManager ->
-                        dataSetDetailRepository.dataSetGroups(
-                            filterManager.orgUnitUidsFilters,
-                            filterManager.periodFilters,
-                            filterManager.stateFilters,
-                            filterManager.catOptComboFilters,
-                        ).subscribeOn(schedulerProvider.io())
-                    }
-                    .subscribeOn(schedulerProvider.io())
-                    .observeOn(schedulerProvider.ui())
-                    .subscribe({
+            filterManager.asFlowable()
+                .startWith(filterManager)
+                .flatMap { filterManager: FilterManager ->
+                    dataSetDetailRepository.dataSetGroups(
+                        filterManager.orgUnitUidsFilters,
+                        filterManager.periodFilters,
+                        filterManager.stateFilters,
+                        filterManager.catOptComboFilters,
+                    )
+                }
+                .asFlow()
+                .catch { Timber.d(it) }
+                .collectLatest {
+                    withContext(dispatcher.ui()) {
                         _datasets.value = it
-                    }) { t: Throwable? -> Timber.d(t) }
-            }
-            val permissions = async {
-                dataSetDetailRepository.canWriteAny()
-                    .subscribeOn(schedulerProvider.io())
-                    .observeOn(schedulerProvider.ui())
-                    .subscribe({
+                    }
+                }
+
+            dataSetDetailRepository.canWriteAny()
+                .asFlow()
+                .catch { Timber.d(it) }
+                .collectLatest {
+                    withContext(dispatcher.ui()) {
                         _canWrite.value = it
-                    }) { t: Throwable? -> Timber.e(t) }
-            }
-            datasets.await()
-            permissions.await()
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/org/dhis2/usescases/datasets/datasetDetail/datasetList/DataSetListViewModelFactory.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/datasetDetail/datasetList/DataSetListViewModelFactory.kt
@@ -21,7 +21,6 @@ class DataSetListViewModelFactory(
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return DataSetListViewModel(
             dataSetDetailRepository,
-            schedulerProvider,
             filterManager,
             matomoAnalyticsController,
             dispatchers,

--- a/app/src/test/java/org/dhis2/usescases/datasets/datasetDetail/datasetlist/DataSetListViewModelTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/datasets/datasetDetail/datasetlist/DataSetListViewModelTest.kt
@@ -15,7 +15,6 @@ import org.dhis2.commons.matomo.Categories
 import org.dhis2.commons.matomo.Labels
 import org.dhis2.commons.matomo.MatomoAnalyticsController
 import org.dhis2.commons.viewmodel.DispatcherProvider
-import org.dhis2.data.schedulers.TrampolineSchedulerProvider
 import org.dhis2.usescases.datasets.datasetDetail.DataSetDetailModel
 import org.dhis2.usescases.datasets.datasetDetail.DataSetDetailRepository
 import org.dhis2.usescases.datasets.datasetDetail.datasetList.DataSetListViewModel
@@ -37,11 +36,9 @@ class DataSetListViewModelTest {
 
     private lateinit var viewModel: DataSetListViewModel
     private val repository: DataSetDetailRepository = mock()
-    private val scheduler = TrampolineSchedulerProvider()
     private val filterManager: FilterManager = mock()
     private val matomoAnalyticsController: MatomoAnalyticsController = mock()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private val testingDispatcher = StandardTestDispatcher()
 
     private val filterProcessor: FlowableProcessor<FilterManager> = PublishProcessor.create()
@@ -56,7 +53,6 @@ class DataSetListViewModelTest {
         whenever(repository.canWriteAny()) doReturn Flowable.just(true)
         viewModel = DataSetListViewModel(
             repository,
-            scheduler,
             filterManager,
             matomoAnalyticsController,
             object : DispatcherProvider {
@@ -75,7 +71,6 @@ class DataSetListViewModelTest {
         )
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `Should get the list of dataSet`() {
         val dataSets = listOf(dummyDataSet(), dummyDataSet(), dummyDataSet())
@@ -84,7 +79,6 @@ class DataSetListViewModelTest {
         ) doReturn Flowable.just(dataSets)
         viewModel = DataSetListViewModel(
             repository,
-            scheduler,
             filterManager,
             matomoAnalyticsController,
             object : DispatcherProvider {
@@ -105,7 +99,6 @@ class DataSetListViewModelTest {
         assert(viewModel.datasets.value == dataSets)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `Should get write permissions`() {
         whenever(repository.canWriteAny()) doReturn Flowable.just(true)


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
