### PR TITLE
fix: [ANDROAPP-6121] Align numeric values to the left in all tables

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/flow/syncFlow/robot/SyncFlowRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/flow/syncFlow/robot/SyncFlowRobot.kt
@@ -34,7 +34,7 @@ class SyncFlowRobot(val composeTestRule: ComposeTestRule) : BaseRobot() {
     fun checkSyncWasSuccessfully() {
         val expectedTitle = InstrumentationRegistry.getInstrumentation()
             .targetContext.getString(R.string.sync_dialog_title_synced)
-        composeTestRule.waitUntilAtLeastOneExists(hasText(expectedTitle))
+        composeTestRule.waitUntilAtLeastOneExists(hasText(expectedTitle), 2_000L)
         composeTestRule.onNodeWithTag(TITLE, useUnmergedTree = true).assert(hasText(expectedTitle, true))
     }
 

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/TableCell.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/TableCell.kt
@@ -40,6 +40,7 @@ import org.dhis2.composetable.model.TableCell
 import org.dhis2.composetable.ui.compositions.LocalCurrentCellValue
 import org.dhis2.composetable.ui.compositions.LocalInteraction
 import org.dhis2.composetable.ui.compositions.LocalUpdatingCell
+import org.dhis2.composetable.ui.extensions.isNumeric
 import org.dhis2.composetable.ui.modifiers.cellBorder
 import org.dhis2.composetable.ui.semantics.CELL_ERROR_UNDERLINE_TEST_TAG
 import org.dhis2.composetable.ui.semantics.CELL_TEST_TAG
@@ -173,7 +174,7 @@ fun TableCell(
             overflow = TextOverflow.Ellipsis,
             style = TextStyle.Default.copy(
                 fontSize = TableTheme.dimensions.defaultCellTextSize,
-                textAlign = TextAlign.End,
+                textAlign = if (cellValue.isNumeric()) TextAlign.End else TextAlign.Start,
                 color = LocalTableColors.current.cellTextColor(
                     hasError = cell.error != null,
                     hasWarning = cell.warning != null,

--- a/compose-table/src/main/java/org/dhis2/composetable/ui/extensions/StringExtensions.kt
+++ b/compose-table/src/main/java/org/dhis2/composetable/ui/extensions/StringExtensions.kt
@@ -1,0 +1,3 @@
+package org.dhis2.composetable.ui.extensions
+
+fun String?.isNumeric() = this?.toDoubleOrNull() != null

--- a/compose-table/src/test/java/org/dhis2/extensions/StringExtensionsTest.kt
+++ b/compose-table/src/test/java/org/dhis2/extensions/StringExtensionsTest.kt
@@ -1,0 +1,23 @@
+package org.dhis2.extensions
+
+import org.dhis2.composetable.ui.extensions.isNumeric
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StringExtensionsTest {
+
+    @Test
+    fun shouldReturnTrueIfTextIsNumericFalseOtherwise() {
+        assertTrue("0".isNumeric())
+        assertTrue("231".isNumeric())
+        assertTrue("11.33".isNumeric())
+        assertTrue("-123.3".isNumeric())
+        assertTrue("11232.54".isNumeric())
+        assertFalse("1,1232.54".isNumeric())
+        assertFalse("One".isNumeric())
+        assertFalse("[89.23, -14.20]".isNumeric())
+        assertFalse("12/01/2020".isNumeric())
+        assertFalse("has 1.2".isNumeric())
+    }
+}


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
