### PR TITLE
fix: [ANDROAPP-6332] Navigates directly to form when user only have access to one org unit when creating an event

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/programevent/ProgramEventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/programevent/ProgramEventTest.kt
@@ -39,14 +39,10 @@ class ProgramEventTest : BaseTest() {
 
     @Test
     fun shouldCreateNewEventAndCompleteIt() {
-        val eventOrgUnit = "Ngelehun CHC"
         prepareProgramAndLaunchActivity(antenatalCare)
 
         programEventsRobot(composeTestRule) {
             clickOnAddEvent()
-        }
-        orgUnitSelectorRobot(composeTestRule) {
-            selectTreeOrgUnit(eventOrgUnit)
         }
         eventRobot(composeTestRule) {
             typeOnDateParameter(

--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventDetailModule.kt
@@ -15,6 +15,8 @@ import org.dhis2.commons.filters.data.FilterRepository
 import org.dhis2.commons.filters.workingLists.EventFilterToWorkingListItemMapper
 import org.dhis2.commons.filters.workingLists.WorkingListViewModelFactory
 import org.dhis2.commons.matomo.MatomoAnalyticsController
+import org.dhis2.commons.orgunitselector.OURepositoryConfiguration
+import org.dhis2.commons.orgunitselector.OrgUnitSelectorScope
 import org.dhis2.commons.resources.DhisPeriodUtils
 import org.dhis2.commons.resources.MetadataIconProvider
 import org.dhis2.commons.resources.ResourceManager
@@ -40,6 +42,7 @@ import org.hisp.dhis.android.core.D2
 class ProgramEventDetailModule(
     private val view: ProgramEventDetailView,
     private val programUid: String,
+    private val orgUnitSelectorScope: OrgUnitSelectorScope,
 ) {
     @Provides
     @PerActivity
@@ -209,4 +212,9 @@ class ProgramEventDetailModule(
     @Provides
     @PerActivity
     fun provideDateUtils() = DateUtils.getInstance()
+
+    @Provides
+    @PerActivity
+    fun provideOURepositoryConfiguration(d2: D2) =
+        OURepositoryConfiguration(d2, orgUnitSelectorScope)
 }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
