### PR TITLE
fix: [ANDROAPP-6379] Adds no zulu date format expression for notes stored date

### DIFF
--- a/app/src/main/java/org/dhis2/bindings/StringExtensions.kt
+++ b/app/src/main/java/org/dhis2/bindings/StringExtensions.kt
@@ -45,6 +45,13 @@ fun String.toDate(): Date {
     }
     if (date == null) {
         try {
+            date = DateUtils.databaseDateFormatNoZulu().parse(this)
+        } catch (e: Exception) {
+            Timber.d("wrong format")
+        }
+    }
+    if (date == null) {
+        try {
             date = DateUtils.dateTimeFormat().parse(this)
         } catch (e: Exception) {
             Timber.d("wrong format")

--- a/app/src/main/java/org/dhis2/bindings/StringExtensions.kt
+++ b/app/src/main/java/org/dhis2/bindings/StringExtensions.kt
@@ -38,13 +38,6 @@ fun String.toDate(): Date {
     }
     if (date == null) {
         try {
-            date = DateUtils.databaseDateFormat().parse(this)
-        } catch (e: Exception) {
-            Timber.d("wrong format")
-        }
-    }
-    if (date == null) {
-        try {
             date = DateUtils.databaseDateFormatNoZulu().parse(this)
         } catch (e: Exception) {
             Timber.d("wrong format")

--- a/commons/src/main/java/org/dhis2/commons/date/DateUtils.java
+++ b/commons/src/main/java/org/dhis2/commons/date/DateUtils.java
@@ -37,6 +37,7 @@ public class DateUtils {
     }
 
     public static final String DATABASE_FORMAT_EXPRESSION = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String DATABASE_FORMAT_EXPRESSION_NO_ZULU = "yyyy-MM-dd'T'HH:mm:ss.SSS";
     public static final String DATABASE_FORMAT_NO_TIME = "yyyy-MM-dd";
     public static final String DATABASE_FORMAT_EXPRESSION_NO_MILLIS = "yyyy-MM-dd'T'HH:mm:ss";
     public static final String DATABASE_FORMAT_EXPRESSION_NO_SECONDS = "yyyy-MM-dd'T'HH:mm";
@@ -206,6 +207,11 @@ public class DateUtils {
     @NonNull
     public static SimpleDateFormat databaseDateFormat() {
         return new SimpleDateFormat(DATABASE_FORMAT_EXPRESSION, Locale.US);
+    }
+
+    @NonNull
+    public static SimpleDateFormat databaseDateFormatNoZulu() {
+        return new SimpleDateFormat(DATABASE_FORMAT_EXPRESSION_NO_ZULU, Locale.US);
     }
 
     @NonNull


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
