### PR TITLE
chore: [ANDROAPP-6341] Use displayContent with fallback to content in rule actions

### DIFF
--- a/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineExtensions.kt
+++ b/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineExtensions.kt
@@ -111,7 +111,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    content()?.let { map["content"] = it }
+                    (displayContent() ?: content())?.let { map["content"] = it }
                 },
             )
 
@@ -122,7 +122,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("location", location() ?: "indicators"),
                 ).also { map ->
-                    content()?.let { map["content"] = it }
+                    (displayContent() ?: content())?.let { map["content"] = it }
                 },
             )
 
@@ -133,7 +133,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("location", location()!!),
                 ).also { map ->
-                    content()?.let { map["content"] = it }
+                    (displayContent() ?: content())?.let { map["content"] = it }
                 },
             )
 
@@ -178,7 +178,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                     values = mutableMapOf(
                         Pair("field", field),
                     ).also { map ->
-                        content()?.let { map["content"] = it }
+                        (displayContent() ?: content())?.let { map["content"] = it }
                     },
                 )
             }
@@ -190,7 +190,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
             values = mutableMapOf(
                 Pair("field", field),
             ).also { map ->
-                content()?.let { map["content"] = it }
+                (displayContent() ?: content())?.let { map["content"] = it }
             },
         )
 
@@ -200,7 +200,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
             values = mutableMapOf(
                 Pair("field", field),
             ).also { map ->
-                content()?.let { map["content"] = it }
+                (displayContent() ?: content())?.let { map["content"] = it }
             },
         )
 
@@ -211,7 +211,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    content()?.let { map["content"] = it }
+                    (displayContent() ?: content())?.let { map["content"] = it }
                 },
             )
 
@@ -222,7 +222,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    content()?.let { map["content"] = it }
+                    (displayContent() ?: content())?.let { map["content"] = it }
                 },
             )
 
@@ -234,7 +234,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                     values = mutableMapOf(
                         Pair("programStage", stageUid),
                     ).also { map ->
-                        content()?.let { map["content"] = it }
+                        (displayContent() ?: content())?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(
@@ -249,7 +249,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    content()?.let { map["content"] = it }
+                    (displayContent() ?: content())?.let { map["content"] = it }
                 },
             )
 
@@ -262,7 +262,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                         Pair("field", field),
                         Pair("option", optionUid),
                     ).also { map ->
-                        content()?.let { map["content"] = it }
+                        (displayContent() ?: content())?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(
@@ -279,7 +279,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                         Pair("field", field),
                         Pair("optionGroup", optionGroupUid),
                     ).also { map ->
-                        content()?.let { map["content"] = it }
+                        (displayContent() ?: content())?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(
@@ -296,7 +296,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                         Pair("field", field),
                         Pair("optionGroup", optionGroupUid),
                     ).also { map ->
-                        content()?.let { map["content"] = it }
+                        (displayContent() ?: content())?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(

--- a/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineExtensions.kt
+++ b/dhis2-mobile-program-rules/src/main/java/org/dhis2/mobileProgramRules/RuleEngineExtensions.kt
@@ -103,6 +103,8 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
             else -> ""
         }
 
+    val contentToDisplay = displayContent() ?: content()
+
     return when (programRuleActionType()) {
         ProgramRuleActionType.HIDEFIELD ->
             RuleAction(
@@ -111,7 +113,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    (displayContent() ?: content())?.let { map["content"] = it }
+                    contentToDisplay?.let { map["content"] = it }
                 },
             )
 
@@ -122,7 +124,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("location", location() ?: "indicators"),
                 ).also { map ->
-                    (displayContent() ?: content())?.let { map["content"] = it }
+                    contentToDisplay?.let { map["content"] = it }
                 },
             )
 
@@ -133,7 +135,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("location", location()!!),
                 ).also { map ->
-                    (displayContent() ?: content())?.let { map["content"] = it }
+                    contentToDisplay?.let { map["content"] = it }
                 },
             )
 
@@ -178,7 +180,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                     values = mutableMapOf(
                         Pair("field", field),
                     ).also { map ->
-                        (displayContent() ?: content())?.let { map["content"] = it }
+                        contentToDisplay?.let { map["content"] = it }
                     },
                 )
             }
@@ -190,7 +192,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
             values = mutableMapOf(
                 Pair("field", field),
             ).also { map ->
-                (displayContent() ?: content())?.let { map["content"] = it }
+                contentToDisplay?.let { map["content"] = it }
             },
         )
 
@@ -200,7 +202,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
             values = mutableMapOf(
                 Pair("field", field),
             ).also { map ->
-                (displayContent() ?: content())?.let { map["content"] = it }
+                contentToDisplay?.let { map["content"] = it }
             },
         )
 
@@ -211,7 +213,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    (displayContent() ?: content())?.let { map["content"] = it }
+                    contentToDisplay?.let { map["content"] = it }
                 },
             )
 
@@ -222,7 +224,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    (displayContent() ?: content())?.let { map["content"] = it }
+                    contentToDisplay?.let { map["content"] = it }
                 },
             )
 
@@ -234,7 +236,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                     values = mutableMapOf(
                         Pair("programStage", stageUid),
                     ).also { map ->
-                        (displayContent() ?: content())?.let { map["content"] = it }
+                        contentToDisplay?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(
@@ -249,7 +251,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                 values = mutableMapOf(
                     Pair("field", field),
                 ).also { map ->
-                    (displayContent() ?: content())?.let { map["content"] = it }
+                    contentToDisplay?.let { map["content"] = it }
                 },
             )
 
@@ -262,7 +264,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                         Pair("field", field),
                         Pair("option", optionUid),
                     ).also { map ->
-                        (displayContent() ?: content())?.let { map["content"] = it }
+                        contentToDisplay?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(
@@ -279,7 +281,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                         Pair("field", field),
                         Pair("optionGroup", optionGroupUid),
                     ).also { map ->
-                        (displayContent() ?: content())?.let { map["content"] = it }
+                        contentToDisplay?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(
@@ -296,7 +298,7 @@ fun ProgramRuleAction.toRuleEngineObject(): RuleAction {
                         Pair("field", field),
                         Pair("optionGroup", optionGroupUid),
                     ).also { map ->
-                        (displayContent() ?: content())?.let { map["content"] = it }
+                        contentToDisplay?.let { map["content"] = it }
                     },
                 )
             } ?: RuleAction(


### PR DESCRIPTION
Show translation of ProgramRuleAction, like Warnings and Errors non-functional, on the  Android app.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-6341)
