### PR TITLE
fix: Fix for slow counting of org units for search results.

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -937,6 +937,6 @@ public class SearchRepositoryImpl implements SearchRepository {
     private boolean displayOrgUnit() {
         return d2.organisationUnitModule().organisationUnits()
                 .byProgramUids(Collections.singletonList(currentProgram))
-                .count().blockingGet() > 1;
+                .blockingCount() > 1;
     }
 }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -937,6 +937,6 @@ public class SearchRepositoryImpl implements SearchRepository {
     private boolean displayOrgUnit() {
         return d2.organisationUnitModule().organisationUnits()
                 .byProgramUids(Collections.singletonList(currentProgram))
-                .blockingGet().size() > 1;
+                .count().blockingGet() > 1;
     }
 }


### PR DESCRIPTION
## Description

A performance issue within the `SearchTEActivity`:

* When opening a Program with a large numbers (hundreds) on Tracked Entity Instances (TEIs) in an instance with a large number of Organization Units, the list of TEIs takes a long time (up to tens of seconds) to load.
* After adding a new TEI and navigating back to the list, the changes take similarly long time to appear in the list.

The underlying cause: in `SearchRepositoryImpl`, while a TEI is loaded, visibility of its Org Unit is computed non-optimally: Org Units are retrieved from the `d2` data layer and then counted, but can be counted in `d2` directly and then the number retrieved instead.

The affected code was intruduced as part of the [ANDROAPP-5724](https://dhis2.atlassian.net/browse/ANDROAPP-5724) UX improvement feature, the exact line of code in the corresponding PR is [here](https://github.com/dhis2/dhis2-android-capture-app/pull/3459/files#diff-ea895a67063b379e5a1b677889df995f59fd5333c349527593ee3a5a5007b03dR956).

_About Jira issue: I am an external contributor and do not have access to create one. Will happily specify one if instructed to._

## Solution description

Org Units were retrieved from the `d2` data layer and then counted, but can be counted in `d2` directly and then the number retrieved instead. This solves long load times for programs with large number of TEIs and Org Units.

## Covered unit test cases
The modified class does not appear to have unit test coverage. No new tests added.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [x] Other: 14
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


[ANDROAPP-5724]: https://dhis2.atlassian.net/browse/ANDROAPP-5724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ