### PR TITLE
fix: [ANDROAPP-6511] App crashing during config change in scheduling dialog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("com.android.application")
     kotlin("android")
     kotlin("kapt")
+    id("kotlin-parcelize")
     id("kotlinx-serialization")
     id("dagger.hilt.android.plugin")
     alias(libs.plugins.kotlin.compose.compiler)

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/dialogs/scheduling/SchedulingDialogUiTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/dialogs/scheduling/SchedulingDialogUiTest.kt
@@ -69,7 +69,7 @@ class SchedulingDialogUiTest {
                 orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
                     enrollment = enrollment,
-                    programStages = programStages,
+                    programStagesUids = programStages,
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -100,7 +100,7 @@ class SchedulingDialogUiTest {
                 orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
                     enrollment = enrollment,
-                    programStages = programStages,
+                    programStagesUids = programStages,
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -125,7 +125,7 @@ class SchedulingDialogUiTest {
                 orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
                     enrollment = enrollment,
-                    programStages = programStages,
+                    programStagesUids = programStages,
                     showYesNoOptions = true,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -155,7 +155,7 @@ class SchedulingDialogUiTest {
                 orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
                     enrollment = enrollment,
-                    programStages = programStages,
+                    programStagesUids = programStages,
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -189,7 +189,7 @@ class SchedulingDialogUiTest {
                 orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
                     enrollment = enrollment,
-                    programStages = programStages,
+                    programStagesUids = programStages,
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/dialogs/scheduling/SchedulingDialogUiTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/dialogs/scheduling/SchedulingDialogUiTest.kt
@@ -62,14 +62,15 @@ class SchedulingDialogUiTest {
         val programStages =
             listOf(ProgramStage.builder().uid("stageUid").displayName("PS A").build())
         whenever(viewModel.programStage).thenReturn(MutableStateFlow(programStages.first()))
+        whenever(viewModel.programStages).thenReturn(MutableStateFlow(programStages))
+        whenever(viewModel.enrollment).thenReturn(MutableStateFlow(enrollment))
+
         composeTestRule.setContent {
             SchedulingDialogUi(
-                programStages = programStages,
                 viewModel = viewModel,
-                orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
-                    enrollment = enrollment,
-                    programStagesUids = programStages,
+                    enrollmentUid = enrollment.uid(),
+                    programStagesUids = programStages.map { it.uid() },
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -93,14 +94,15 @@ class SchedulingDialogUiTest {
             ProgramStage.builder().uid("stageUidB").displayName("PS B").build(),
         )
         whenever(viewModel.programStage).thenReturn(MutableStateFlow(programStages.first()))
+        whenever(viewModel.programStages).thenReturn(MutableStateFlow(programStages))
+        whenever(viewModel.enrollment).thenReturn(MutableStateFlow(enrollment))
+
         composeTestRule.setContent {
             SchedulingDialogUi(
-                programStages = programStages,
                 viewModel = viewModel,
-                orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
-                    enrollment = enrollment,
-                    programStagesUids = programStages,
+                    enrollmentUid = enrollment.uid(),
+                    programStagesUids = programStages.map { it.uid() },
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -118,14 +120,15 @@ class SchedulingDialogUiTest {
             ProgramStage.builder().uid("stageUidB").displayName("PS B").build(),
         )
         whenever(viewModel.programStage).thenReturn(MutableStateFlow(programStages.first()))
+        whenever(viewModel.programStages).thenReturn(MutableStateFlow(programStages))
+        whenever(viewModel.enrollment).thenReturn(MutableStateFlow(enrollment))
+
         composeTestRule.setContent {
             SchedulingDialogUi(
-                programStages = programStages,
                 viewModel = viewModel,
-                orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
-                    enrollment = enrollment,
-                    programStagesUids = programStages,
+                    enrollmentUid = enrollment.uid(),
+                    programStagesUids = programStages.map { it.uid() },
                     showYesNoOptions = true,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -148,14 +151,15 @@ class SchedulingDialogUiTest {
             ProgramStage.builder().uid("stageUidB").displayName("PS B").build(),
         )
         whenever(viewModel.programStage).thenReturn(MutableStateFlow(programStages.first()))
+        whenever(viewModel.programStages).thenReturn(MutableStateFlow(programStages))
+        whenever(viewModel.enrollment).thenReturn(MutableStateFlow(enrollment))
+
         composeTestRule.setContent {
             SchedulingDialogUi(
-                programStages = programStages,
                 viewModel = viewModel,
-                orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
-                    enrollment = enrollment,
-                    programStagesUids = programStages,
+                    enrollmentUid = enrollment.uid(),
+                    programStagesUids = programStages.map { it.uid() },
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )
@@ -181,15 +185,15 @@ class SchedulingDialogUiTest {
             ProgramStage.builder().uid("stageUidB").displayName("PS B").build(),
         )
         whenever(viewModel.programStage).thenReturn(MutableStateFlow(programStages.first()))
+        whenever(viewModel.programStages).thenReturn(MutableStateFlow(programStages))
+        whenever(viewModel.enrollment).thenReturn(MutableStateFlow(enrollment))
 
         composeTestRule.setContent {
             SchedulingDialogUi(
-                programStages = programStages,
                 viewModel = viewModel,
-                orgUnitUid = "orgUnitUid",
                 launchMode = SchedulingDialog.LaunchMode.NewSchedule(
-                    enrollment = enrollment,
-                    programStagesUids = programStages,
+                    enrollmentUid = enrollment.uid(),
+                    programStagesUids = programStages.map { it.uid() },
                     showYesNoOptions = false,
                     eventCreationType = EventCreationType.SCHEDULE,
                 )

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
@@ -438,12 +438,8 @@ class TEIDataFragment : FragmentGlobalAbstract(), TEIDataContracts.View {
         val model = dashboardViewModel.dashboardModel.value
         if (model is DashboardEnrollmentModel) {
             SchedulingDialog.newSchedule(
-                enrollment = model.currentEnrollment,
-                programStages = if (programStage != null) {
-                    listOf(programStage)
-                } else {
-                    presenter.filterAvailableStages(model.programStages)
-                },
+                enrollmentUid = model.currentEnrollment.uid(),
+                programStagesUids = presenter.filterAvailableStages(model.programStages).map { it.uid() },
                 showYesNoOptions = showYesNoOptions,
                 eventCreationType = eventCreationType,
             ).show(parentFragmentManager, SCHEDULING_DIALOG)

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialog.kt
@@ -9,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.DatePicker
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialog.kt
@@ -2,12 +2,13 @@ package org.dhis2.usescases.teiDashboard.dialogs.scheduling
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.DatePicker
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -15,6 +16,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.parcelize.Parcelize
 import org.dhis2.bindings.app
 import org.dhis2.commons.data.EventCreationType
 import org.dhis2.commons.dialogs.PeriodDialog
@@ -36,18 +38,24 @@ class SchedulingDialog : BottomSheetDialogFragment() {
         const val PROGRAM_STAGE_UID = "PROGRAM_STAGE_UID"
         const val EVENT_LABEL = "EVENT_LABEL"
 
+        private const val TAG_LAUNCH_MODE = "LAUNCH_MODE"
+
         fun newSchedule(
             enrollmentUid: String,
             programStagesUids: List<String>,
             showYesNoOptions: Boolean,
             eventCreationType: EventCreationType,
         ): SchedulingDialog {
+            val launchMode = LaunchMode.NewSchedule(
+                enrollmentUid = enrollmentUid,
+                programStagesUids = programStagesUids,
+                showYesNoOptions = showYesNoOptions,
+                eventCreationType = eventCreationType,
+            )
+
             return SchedulingDialog().apply {
-                this.launchMode = LaunchMode.NewSchedule(
-                    enrollmentUid = enrollmentUid,
-                    programStagesUids = programStagesUids,
-                    showYesNoOptions = showYesNoOptions,
-                    eventCreationType = eventCreationType,
+                arguments = bundleOf(
+                    TAG_LAUNCH_MODE to launchMode,
                 )
             }
         }
@@ -56,16 +64,22 @@ class SchedulingDialog : BottomSheetDialogFragment() {
             eventUid: String,
             showYesNoOptions: Boolean,
             eventCreationType: EventCreationType,
-        ) = SchedulingDialog().apply {
-            this.launchMode = LaunchMode.EnterEvent(
+        ): SchedulingDialog {
+            val launchMode = LaunchMode.EnterEvent(
                 eventUid = eventUid,
                 showYesNoOptions = showYesNoOptions,
                 eventCreationType = eventCreationType,
             )
+
+            return SchedulingDialog().apply {
+                arguments = bundleOf(
+                    TAG_LAUNCH_MODE to launchMode,
+                )
+            }
         }
     }
 
-    lateinit var launchMode: LaunchMode
+    private lateinit var launchMode: LaunchMode
 
     @Inject
     lateinit var factory: SchedulingViewModelFactory.Factory
@@ -77,6 +91,10 @@ class SchedulingDialog : BottomSheetDialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NORMAL, R.style.CustomBottomSheetDialogTheme)
+        val arguments = arguments
+        if (arguments != null) {
+            launchMode = LaunchMode.fromBundle(arguments)
+        }
     }
 
     override fun onAttach(context: Context) {
@@ -174,11 +192,24 @@ class SchedulingDialog : BottomSheetDialogFragment() {
             .show(requireActivity().supportFragmentManager, PeriodDialog::class.java.simpleName)
     }
 
-    sealed interface LaunchMode {
+    sealed interface LaunchMode : Parcelable {
+
+        companion object {
+
+            fun fromBundle(args: Bundle): LaunchMode {
+                return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    args.getParcelable(TAG_LAUNCH_MODE, LaunchMode::class.java)!!
+                } else {
+                    @Suppress("DEPRECATION")
+                    args.getParcelable(TAG_LAUNCH_MODE)!!
+                }
+            }
+        }
 
         val showYesNoOptions: Boolean
         val eventCreationType: EventCreationType
 
+        @Parcelize
         data class NewSchedule(
             val enrollmentUid: String,
             val programStagesUids: List<String>,
@@ -186,6 +217,7 @@ class SchedulingDialog : BottomSheetDialogFragment() {
             override val eventCreationType: EventCreationType,
         ) : LaunchMode
 
+        @Parcelize
         data class EnterEvent(
             val eventUid: String,
             override val showYesNoOptions: Boolean,

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialog.kt
@@ -7,6 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.DatePicker
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
@@ -21,8 +23,6 @@ import org.dhis2.commons.dialogs.calendarpicker.OnDatePickerListener
 import org.dhis2.form.R
 import org.dhis2.form.model.EventMode
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
-import org.hisp.dhis.android.core.enrollment.Enrollment
-import org.hisp.dhis.android.core.program.ProgramStage
 import java.util.Date
 import javax.inject.Inject
 
@@ -37,15 +37,15 @@ class SchedulingDialog : BottomSheetDialogFragment() {
         const val EVENT_LABEL = "EVENT_LABEL"
 
         fun newSchedule(
-            enrollment: Enrollment,
-            programStages: List<ProgramStage>,
+            enrollmentUid: String,
+            programStagesUids: List<String>,
             showYesNoOptions: Boolean,
             eventCreationType: EventCreationType,
         ): SchedulingDialog {
             return SchedulingDialog().apply {
                 this.launchMode = LaunchMode.NewSchedule(
-                    enrollment = enrollment,
-                    programStages = programStages,
+                    enrollmentUid = enrollmentUid,
+                    programStagesUids = programStagesUids,
                     showYesNoOptions = showYesNoOptions,
                     eventCreationType = eventCreationType,
                 )
@@ -133,8 +133,6 @@ class SchedulingDialog : BottomSheetDialogFragment() {
             setContent {
                 SchedulingDialogUi(
                     viewModel = viewModel,
-                    programStages = viewModel.programStages,
-                    orgUnitUid = viewModel.enrollment?.organisationUnit(),
                     launchMode = launchMode,
                     onDismiss = { dismiss() },
                 )
@@ -182,8 +180,8 @@ class SchedulingDialog : BottomSheetDialogFragment() {
         val eventCreationType: EventCreationType
 
         data class NewSchedule(
-            val enrollment: Enrollment,
-            val programStages: List<ProgramStage>,
+            val enrollmentUid: String,
+            val programStagesUids: List<String>,
             override val showYesNoOptions: Boolean,
             override val eventCreationType: EventCreationType,
         ) : LaunchMode

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialogUi.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialogUi.kt
@@ -5,10 +5,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.EventBusy
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -46,18 +47,19 @@ import org.hisp.dhis.mobile.ui.designsystem.component.RadioButtonData
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideStringResource
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
+import timber.log.Timber
 
 @Composable
 fun SchedulingDialogUi(
-    programStages: List<ProgramStage>,
     viewModel: SchedulingViewModel,
-    orgUnitUid: String?,
     launchMode: LaunchMode,
     onDismiss: () -> Unit,
 ) {
     val date by viewModel.eventDate.collectAsState()
     val catCombo by viewModel.eventCatCombo.collectAsState()
+    val programStages by viewModel.programStages.collectAsState()
     val selectedProgramStage by viewModel.programStage.collectAsState()
+    val enrollment by viewModel.enrollment.collectAsState()
 
     val yesNoOptions = InputYesNoFieldValues.entries.map {
         RadioButtonData(
@@ -116,7 +118,7 @@ fun SchedulingDialogUi(
                         selectedProgramStage = selectedProgramStage,
                         date = date,
                         catCombo = catCombo,
-                        orgUnitUid = orgUnitUid,
+                        orgUnitUid = enrollment?.organisationUnit(),
                         launchMode = launchMode,
                     )
                 }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialogUi.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingDialogUi.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.EventBusy
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -47,7 +46,6 @@ import org.hisp.dhis.mobile.ui.designsystem.component.RadioButtonData
 import org.hisp.dhis.mobile.ui.designsystem.resource.provideStringResource
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.TextColor
-import timber.log.Timber
 
 @Composable
 fun SchedulingDialogUi(

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingViewModelTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dialogs/scheduling/SchedulingViewModelTest.kt
@@ -3,30 +3,41 @@ package org.dhis2.usescases.teiDashboard.dialogs.scheduling
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.setMain
+import org.dhis2.commons.bindings.enrollment
+import org.dhis2.commons.bindings.programStage
 import org.dhis2.commons.data.EventCreationType
 import org.dhis2.commons.viewmodel.DispatcherProvider
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.enrollment.Enrollment
+import org.hisp.dhis.android.core.program.ProgramStage
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.spy
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SchedulingViewModelTest {
 
     private lateinit var schedulingViewModel: SchedulingViewModel
 
-    private val testingDispatcher = StandardTestDispatcher()
+    private val testingDispatcher = UnconfinedTestDispatcher()
+
+    private val enrollment = Enrollment.builder().uid("enrollment-uid").build()
+    private val programStage = ProgramStage.builder().uid("program-stage").build()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
         Dispatchers.setMain(testingDispatcher)
         schedulingViewModel = SchedulingViewModel(
-            d2 = mock(),
+            d2 = mock {
+                on { enrollment("enrollment-uid") } doReturn enrollment
+                on { programStage("program-stage") } doReturn programStage
+            },
             resourceManager = mock(),
             eventResourcesProvider = mock(),
             periodUtils = mock(),
@@ -45,8 +56,8 @@ class SchedulingViewModelTest {
                 }
             },
             launchMode = SchedulingDialog.LaunchMode.NewSchedule(
-                enrollment = Enrollment.builder().uid("enrollment").build(),
-                programStages = emptyList(),
+                enrollmentUid = "enrollment-uid",
+                programStagesUids = listOf("program-stage"),
                 showYesNoOptions = false,
                 eventCreationType = EventCreationType.SCHEDULE,
             ),


### PR DESCRIPTION
## Description

Since we were setting the variable for an instance, it's not getting restored after config change. Instead we are passing the data as a argument bundle, so that it can get restored after config change or process death.

We are using Gson to stringify the `LaunchMode` object and then convert it back to type when accessing the launch mode variable in `SchedulingDialog`. This is not a perfect solution, but given `Enrollnment` and `ProgramStage` or not `Parcelable` or `Serializable`, we cannot use Kotlin Parcelize or Serialization.


[jira issue](https://dhis2.atlassian.net/jira/software/c/projects/ANDROAPP/boards/113?selectedIssue=ANDROAPP-6511)
