### PR TITLE
fix: [ANDROAPP-6361] add file resource download to granular sync

### DIFF
--- a/app/src/main/java/org/dhis2/data/service/SyncPresenter.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenter.java
@@ -23,7 +23,7 @@ interface SyncPresenter {
 
     SyncResult checkSyncStatus();
 
-    Observable<TrackerD2Progress> syncGranularEvent(String eventUid);
+    Observable<D2Progress> syncGranularEvent(String eventUid);
 
     ListenableWorker.Result blockSyncGranularProgram(String programUid);
 
@@ -35,7 +35,7 @@ interface SyncPresenter {
 
     Observable<D2Progress> syncGranularProgram(String uid);
 
-    Observable<TrackerD2Progress> syncGranularTEI(String uid);
+    Observable<D2Progress> syncGranularTEI(String uid);
 
     Observable<D2Progress> syncGranularDataSet(String uid);
 

--- a/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
@@ -413,11 +413,6 @@ class SyncPresenterImpl(
                     d2.trackedEntityModule().trackedEntityInstanceDownloader()
                         .byProgramUid(uid)
                         .download()
-//                        .flatMap {
-//                            d2.fileResourceModule().fileResourceDownloader()
-//                                .byProgramUid().eq(uid)
-//                                .download()
-//                        }
                 } else {
                     Completable.fromObservable(
                         d2.eventModule().events().byProgramUid().eq(uid).upload(),

--- a/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
@@ -7,6 +7,8 @@ import androidx.work.ListenableWorker
 import io.reactivex.Completable
 import io.reactivex.Observable
 import org.dhis2.bindings.toSeconds
+import org.dhis2.commons.bindings.enrollment
+import org.dhis2.commons.bindings.program
 import org.dhis2.commons.prefs.Preference.Companion.DATA
 import org.dhis2.commons.prefs.Preference.Companion.EVENT_MAX
 import org.dhis2.commons.prefs.Preference.Companion.EVENT_MAX_DEFAULT
@@ -36,7 +38,6 @@ import org.hisp.dhis.android.core.settings.GeneralSettings
 import org.hisp.dhis.android.core.settings.LimitScope
 import org.hisp.dhis.android.core.settings.ProgramSettings
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
-import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import timber.log.Timber
 import java.util.Calendar
 import kotlin.math.ceil
@@ -297,19 +298,10 @@ class SyncPresenterImpl(
     }
 
     override fun syncGranularEvent(eventUid: String): Observable<D2Progress> {
-        Completable.fromObservable(d2.eventModule().events().byUid().eq(eventUid).upload())
-            .blockingAwait()
-        return d2.eventModule().eventDownloader()
-            .byUid().eq(eventUid)
-            .download()
-            .map {
-                it as D2Progress
-            }
-            .mergeWith(
-                d2.fileResourceModule().fileResourceDownloader()
-                    .byEventUid().eq(eventUid)
-                    .download(),
-            )
+        Completable.fromObservable(syncRepository.uploadEvent(eventUid)).blockingAwait()
+        return syncRepository.downLoadEvent(eventUid)
+            .map { it as D2Progress }
+            .mergeWith(syncRepository.downloadEventFiles(eventUid))
     }
 
     override fun blockSyncGranularProgram(programUid: String): ListenableWorker.Result {
@@ -406,58 +398,35 @@ class SyncPresenterImpl(
     }
 
     override fun syncGranularProgram(uid: String): Observable<D2Progress> {
-        val program = d2.programModule().programs().uid(uid).blockingGet()
-
-        return when (program?.programType()) {
-            null -> Observable.empty<TrackerD2Progress>()
+        return when (d2.program(uid)?.programType()) {
+            null -> null
             ProgramType.WITH_REGISTRATION -> {
-                Completable.fromObservable(
-                    d2.trackedEntityModule().trackedEntityInstances().byProgramUids(listOf(uid))
-                        .upload(),
-                ).blockingAwait()
-
-                d2.trackedEntityModule().trackedEntityInstanceDownloader()
-                    .byProgramUid(uid)
-                    .download()
+                Completable.fromObservable(syncRepository.uploadTrackerProgram(uid)).blockingAwait()
+                syncRepository.downloadTrackerProgram(uid)
             }
 
             ProgramType.WITHOUT_REGISTRATION -> {
-                Completable.fromObservable(
-                    d2.eventModule().events().byProgramUid().eq(uid).upload(),
-                ).blockingAwait()
-                d2.eventModule().eventDownloader()
-                    .byProgramUid(uid)
-                    .download()
+                Completable.fromObservable(syncRepository.uploadEventProgram(uid)).blockingAwait()
+                syncRepository.downloadEventProgram(uid)
             }
         }
-            .map {
-                it as D2Progress
-            }
-            .mergeWith(
-                d2.fileResourceModule().fileResourceDownloader()
-                    .byProgramUid().eq(uid)
-                    .download(),
-            )
+            ?.map { it as D2Progress }
+            ?.mergeWith(syncRepository.downloadProgramFiles(uid))
+            ?: Observable.empty()
     }
 
     override fun syncGranularTEI(uid: String): Observable<D2Progress> {
-        val enrollment = d2.enrollmentModule().enrollments().uid(uid).blockingGet()
+        val enrollment = d2.enrollment(uid)
+        val teiUid = enrollment?.trackedEntityInstance() ?: return Observable.empty()
+        val programUid = enrollment.program()
         Completable.fromObservable(
-            d2.trackedEntityModule().trackedEntityInstances()
-                .byUid().eq(enrollment?.trackedEntityInstance())
-                .byProgramUids(enrollment?.program()?.let { listOf(it) } ?: emptyList())
-                .upload(),
+            syncRepository.uploadTei(teiUid, programUid),
         ).blockingAwait()
-        return d2.trackedEntityModule().trackedEntityInstanceDownloader()
-            .byUid().eq(enrollment?.trackedEntityInstance())
-            .byProgramUid(enrollment?.program() ?: "")
-            .download()
-            .flatMap {
-                d2.fileResourceModule().fileResourceDownloader()
-                    .byTrackedEntityUid().eq(enrollment?.trackedEntityInstance())
-                    .byProgramUid().eq(enrollment?.program() ?: "")
-                    .download()
-            }
+        return syncRepository.downloadTei(teiUid, programUid)
+            .map { it as D2Progress }
+            .mergeWith(
+                syncRepository.downloadTeiFiles(teiUid, programUid),
+            )
     }
 
     override fun syncGranularDataSet(uid: String): Observable<D2Progress> {

--- a/app/src/main/java/org/dhis2/data/service/SyncRepository.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncRepository.kt
@@ -1,11 +1,25 @@
 package org.dhis2.data.service
 
+import io.reactivex.Observable
+import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 
 interface SyncRepository {
     fun getTeiByNotInStates(uid: String, states: List<State>): List<TrackedEntityInstance>
     fun getTeiByInStates(uid: String, states: List<State>): List<TrackedEntityInstance>
     fun getEventsFromEnrollmentByNotInSyncState(uid: String, states: List<State>): List<Event>
+    fun uploadEvent(eventUid: String): Observable<D2Progress>
+    fun downLoadEvent(eventUid: String): Observable<out D2Progress>
+    fun downloadEventFiles(eventUid: String): Observable<D2Progress>
+    fun uploadTrackerProgram(programUid: String): Observable<D2Progress>
+    fun downloadTrackerProgram(programUid: String): Observable<TrackerD2Progress>
+    fun uploadEventProgram(programUid: String): Observable<D2Progress>
+    fun downloadEventProgram(programUid: String): Observable<TrackerD2Progress>
+    fun downloadProgramFiles(programUid: String): Observable<D2Progress>
+    fun uploadTei(teiUid: String, programUid: String?): Observable<D2Progress>
+    fun downloadTei(teiUid: String, programUid: String?): Observable<TrackerD2Progress>
+    fun downloadTeiFiles(teiUid: String, programUid: String?): Observable<D2Progress>
 }

--- a/app/src/main/java/org/dhis2/data/service/SyncRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package org.dhis2.data.service
 
+import io.reactivex.Observable
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
@@ -33,4 +35,58 @@ class SyncRepositoryImpl(private val d2: D2) : SyncRepository {
             .byAggregatedSyncState().notIn(State.SYNCED)
             .blockingGet()
     }
+
+    override fun uploadEvent(eventUid: String) =
+        d2.eventModule().events().byUid().eq(eventUid).upload()
+
+    override fun downLoadEvent(eventUid: String): Observable<out D2Progress> =
+        d2.eventModule().eventDownloader()
+            .byUid().eq(eventUid)
+            .download()
+
+    override fun downloadEventFiles(eventUid: String) =
+        d2.fileResourceModule().fileResourceDownloader()
+            .byEventUid().eq(eventUid)
+            .download()
+
+    override fun uploadTrackerProgram(programUid: String) =
+        d2.trackedEntityModule().trackedEntityInstances()
+            .byProgramUids(listOf(programUid))
+            .upload()
+
+    override fun downloadTrackerProgram(programUid: String) =
+        d2.trackedEntityModule().trackedEntityInstanceDownloader()
+            .byProgramUid(programUid)
+            .download()
+
+    override fun uploadEventProgram(programUid: String) =
+        d2.eventModule().events().byProgramUid().eq(programUid).upload()
+
+    override fun downloadEventProgram(programUid: String) =
+        d2.eventModule().eventDownloader()
+            .byProgramUid(programUid)
+            .download()
+
+    override fun downloadProgramFiles(programUid: String) =
+        d2.fileResourceModule().fileResourceDownloader()
+            .byProgramUid().eq(programUid)
+            .download()
+
+    override fun uploadTei(teiUid: String, programUid: String?) =
+        d2.trackedEntityModule().trackedEntityInstances()
+            .byUid().eq(teiUid)
+            .byProgramUids(programUid?.let { listOf(it) } ?: emptyList())
+            .upload()
+
+    override fun downloadTei(teiUid: String, programUid: String?) =
+        d2.trackedEntityModule().trackedEntityInstanceDownloader()
+            .byUid().eq(teiUid)
+            .byProgramUid(programUid ?: "")
+            .download()
+
+    override fun downloadTeiFiles(teiUid: String, programUid: String?) =
+        d2.fileResourceModule().fileResourceDownloader()
+            .byTrackedEntityUid().eq(teiUid)
+            .byProgramUid().eq(programUid ?: "")
+            .download()
 }


### PR DESCRIPTION
## Description
File resources could only be downloaded when syncing from the home page, that lead to issues when trying to sync entities; the file resources were not being downloaded but the entity remained as unsynced.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-6361

## Solution description
Added granular sync for file resources when syncing programs (w/ and w/o enrollment ), events and teis.

## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
