### PR TITLE
fix: [ANDROAPP-6513] Return default color if parsing fails

### DIFF
--- a/ui-components/src/main/java/org/dhis2/ui/MetadataIcon.kt
+++ b/ui-components/src/main/java/org/dhis2/ui/MetadataIcon.kt
@@ -99,7 +99,11 @@ fun MetadataIconPreview(
     MetadataIcon(metadataIconData = metadataIconData)
 }
 
-fun String.toColor() = Color(android.graphics.Color.parseColor(this))
+fun String.toColor() = try {
+    Color(android.graphics.Color.parseColor(this))
+} catch (e: Exception) {
+    Color.Unspecified
+}
 
 class MetadataIconDataParamProvider : PreviewParameterProvider<MetadataIconData> {
     override val values: Sequence<MetadataIconData>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
