### PR TITLE
fix: [ANDROAPP-6567] LocationComponent crash if accessed before activation

### DIFF
--- a/dhis2_android_maps/src/main/java/org/dhis2/maps/managers/MapManager.kt
+++ b/dhis2_android_maps/src/main/java/org/dhis2/maps/managers/MapManager.kt
@@ -318,7 +318,14 @@ abstract class MapManager(
 
     private fun updateLocationState() {
         map?.apply {
-            val currentLocation = locationComponent.lastKnownLocation?.let { LatLng(it) }
+            locationComponent.isLocationComponentActivated
+            val currentLocation = with(locationComponent) {
+                if (isLocationComponentActivated) {
+                    lastKnownLocation?.let { LatLng(it) }
+                } else {
+                    null
+                }
+            }
             val mapCenter = cameraPosition.target
             val locationState = when {
                 !locationProvider.hasLocationEnabled() ||


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
