### PR TITLE
chore: push commits via API in github actions

### DIFF
--- a/.github/workflows/release-generate-notes.yml
+++ b/.github/workflows/release-generate-notes.yml
@@ -27,14 +27,7 @@ jobs:
         working-directory: ./scripts
         run: python3 generateReleaseNotes.py
 
-      - name: setup git config
-        run: |
-          # setup the username and email.
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<android@dhis2.org>"
-
       - name: Commit changes
-        run: |
-          # Commit and push
-          git commit -am "Update release notes"
-          git push
+        uses: flex-development/gh-commit@1.0.0
+        with:
+          message: "Update release notes"

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -33,12 +33,6 @@ jobs:
       with:
         python-version: 3.12.1
 
-    - name: setup git config
-      run: |
-        # setup the username and email.
-        git config user.name "GitHub Actions Bot"
-        git config user.email "<android@dhis2.org>"
-
       # override vName with new version
     - name: Create release branch
       run: git checkout -b release/${{ inputs.release_version_name }}
@@ -46,11 +40,11 @@ jobs:
     - name: Run Python script to update release branch version
       run: python scripts/updateVersionName.py ${{ inputs.release_version_name }}
 
-    - name: Push
-      run: |
-        git add .
-        git commit -m "Update version to ${{ inputs.release_version_name }}"
-        git push origin release/${{ inputs.release_version_name }}
+    - name: Commit and Push Changes
+      uses: flex-development/gh-commit@1.0.0
+      with:
+        message: 'Update version to ${{ inputs.release_version_name }}'
+        ref: 'release/${{ inputs.release_version_name }}'
 
   update_version:
     # The type of runner that the job will run on
@@ -65,12 +59,6 @@ jobs:
         with:
           python-version: 3.12.1
 
-      - name: setup git config
-        run: |
-          # setup the username and email.
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<android@dhis2.org>"
-
       - name: Create release branch
         run: git checkout -b update_version_to${{ inputs.development_version_name }}
 
@@ -78,10 +66,10 @@ jobs:
         run: python scripts/updateVersionName.py ${{ inputs.development_version_name }}
 
       - name: Commit and Push Changes
-        run: |
-          git add .
-          git commit -m "Update version to ${{ inputs.development_version_name }}"
-          git push origin update_version_to${{ inputs.development_version_name }}
+        uses: flex-development/gh-commit@1.0.0
+        with:
+          message: 'Update version to ${{ inputs.development_version_name }}'
+          ref: 'update_version_to${{ inputs.development_version_name }}'
 
       - name: create pull request
         run: gh pr create -B develop -H update_version_to${{ inputs.development_version_name }} --title 'Merge update_version_to${{ inputs.development_version_name }} into develop' --body 'Created by Github action'


### PR DESCRIPTION
## Description
Change in github actions to push commits via Github API. It uses a third-party action for that.

[ANDROAPP-6643](https://dhis2.atlassian.net/browse/ANDROAPP-6643)

## Solution description
It uses a third-party action to commit in github actions.

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROAPP-6643]: https://dhis2.atlassian.net/browse/ANDROAPP-6643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ