### PR TITLE
fix: [ANDROAPP-64659] Implement no periods available functionality

### DIFF
--- a/app/src/main/java/org/dhis2/data/dhislogic/EnrollmentEventGenerator.kt
+++ b/app/src/main/java/org/dhis2/data/dhislogic/EnrollmentEventGenerator.kt
@@ -1,12 +1,13 @@
 package org.dhis2.data.dhislogic
 
 import org.dhis2.commons.Constants
-import org.dhis2.utils.DateUtils
+import org.dhis2.commons.date.DateUtils
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.program.ProgramStage
 import timber.log.Timber
 import java.util.Calendar
+import java.util.Date
 
 class EnrollmentEventGenerator(
     private val generatorRepository: EnrollmentEventGeneratorRepository,
@@ -121,10 +122,11 @@ class EnrollmentEventGenerator(
             calendar.set(Calendar.SECOND, 0)
             calendar.set(Calendar.MILLISECOND, 0)
             var eventDate = calendar.time
-
+            val currentDate = DateUtils.getInstance().getStartOfDay(Date())
             periodType?.let { eventDate = generatorRepository.periodStartingDate(it, eventDate) }
-
-            generatorRepository.setEventDate(eventUid, eventDate)
+            if (eventDate.before(currentDate) || eventDate == currentDate) {
+                generatorRepository.setEventDate(eventUid, eventDate)
+            }
         } catch (d2Error: D2Error) {
             Timber.e(d2Error)
         }

--- a/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt
@@ -172,10 +172,11 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
     }
 
     override fun openEvent(eventUid: String) {
-        if (presenter.isEventScheduleOrSkipped(eventUid)) {
+        val suggestedEventDateIsNotFutureDate = presenter.suggestedReportDateIsNotFutureDate(eventUid)
+        if (presenter.isEventScheduleOrSkipped(eventUid) && suggestedEventDateIsNotFutureDate) {
             val scheduleEventIntent = ScheduledEventActivity.getIntent(this, eventUid)
             openEventForResult.launch(scheduleEventIntent)
-        } else {
+        } else if (suggestedEventDateIsNotFutureDate) {
             val eventCreationIntent = Intent(abstracContext, EventCaptureActivity::class.java)
             eventCreationIntent.putExtras(
                 EventCaptureActivity.getActivityBundle(
@@ -185,6 +186,8 @@ class EnrollmentActivity : ActivityGlobalAbstract(), EnrollmentView {
                 ),
             )
             startActivityForResult(eventCreationIntent, RQ_EVENT)
+        } else {
+            openDashboard(presenter.getEnrollment()?.uid()!!)
         }
     }
 

--- a/form/src/main/java/org/dhis2/form/data/EventRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EventRepository.kt
@@ -43,7 +43,6 @@ import org.hisp.dhis.android.core.program.ProgramStageDataElement
 import org.hisp.dhis.android.core.program.ProgramStageSection
 import org.hisp.dhis.android.core.program.SectionRenderingType
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
-import java.util.Calendar.DAY_OF_YEAR
 import java.util.Date
 
 class EventRepository(
@@ -477,12 +476,7 @@ class EventRepository(
                 ?: getEnrollmentDate(enrollmentUid)
         }
         val calendar = DateUtils.getInstance().getCalendarByDate(minEventDate)
-        if (stageLastDate == null) {
-            val minDaysFromStart = getMinDaysFromStartByProgramStage(programStage)
-            calendar.add(DAY_OF_YEAR, minDaysFromStart)
-        } else {
-            calendar.add(DAY_OF_YEAR, programStage?.standardInterval() ?: 0)
-        }
+
         return dateUtils.getNextPeriod(programStage?.periodType(), calendar.time ?: event?.eventDate(), 1)
     }
 
@@ -499,7 +493,7 @@ class EventRepository(
             d2.eventModule().events().byEnrollmentUid().eq(enrollmentUid).byProgramStageUid()
                 .eq(programStageUid)
                 .byDeleted().isFalse
-                .orderByDueDate(RepositoryScope.OrderByDirection.DESC).blockingGet()
+                .orderByDueDate(RepositoryScope.OrderByDirection.DESC).blockingGet().filter { it.uid() != eventUid }
 
         var activeDate: Date? = null
         var scheduleDate: Date? = null
@@ -514,10 +508,6 @@ class EventRepository(
             activeDate.before(scheduleDate) -> scheduleDate
             else -> activeDate
         }
-    }
-
-    private fun getMinDaysFromStartByProgramStage(programStage: ProgramStage?): Int {
-        return programStage?.minDaysFromStart() ?: 0
     }
 
     private fun getEnrollmentDate(uid: String?): Date? {

--- a/form/src/main/java/org/dhis2/form/data/EventRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EventRepository.kt
@@ -477,7 +477,7 @@ class EventRepository(
         }
         val calendar = DateUtils.getInstance().getCalendarByDate(minEventDate)
 
-        return dateUtils.getNextPeriod(programStage?.periodType(), calendar.time ?: event?.eventDate(), 1)
+        return dateUtils.getNextPeriod(programStage?.periodType(), calendar.time ?: event?.eventDate(), if (stageLastDate == null) 0 else 1)
     }
 
     private fun getStageLastDate(): Date? {

--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/PeriodSelectorProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/PeriodSelectorProvider.kt
@@ -7,6 +7,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import org.dhis2.commons.date.DateUtils
+import org.dhis2.form.R
 import org.dhis2.form.extensions.inputState
 import org.dhis2.form.extensions.legend
 import org.dhis2.form.extensions.supportingText
@@ -14,7 +17,10 @@ import org.dhis2.form.model.FieldUiModel
 import org.dhis2.form.ui.event.RecyclerViewUiEvents
 import org.hisp.dhis.mobile.ui.designsystem.component.DropdownInputField
 import org.hisp.dhis.mobile.ui.designsystem.component.DropdownItem
+import org.hisp.dhis.mobile.ui.designsystem.component.InputDropDown
+import org.hisp.dhis.mobile.ui.designsystem.component.InputShellState
 import org.hisp.dhis.mobile.ui.designsystem.component.InputStyle
+import java.util.Date
 
 @Composable
 fun ProvidePeriodSelector(
@@ -24,38 +30,74 @@ fun ProvidePeriodSelector(
     focusRequester: FocusRequester,
     uiEventHandler: (RecyclerViewUiEvents) -> Unit,
 ) {
-    var selectedItem by remember(fieldUiModel.displayName) {
-        mutableStateOf(
-            fieldUiModel.displayName,
+    val currentDate = DateUtils.getInstance().getStartOfDay(Date())
+    if ((fieldUiModel.periodSelector?.minDate?.after(currentDate) == true)) {
+        ProvideEmptyPeriodSelector(
+            modifier = modifier,
+            name = fieldUiModel.label,
+            inputStyle = inputStyle,
+        )
+    } else {
+        var selectedItem by remember(fieldUiModel.displayName) {
+            mutableStateOf(
+                fieldUiModel.displayName,
+            )
+        }
+
+        DropdownInputField(
+            modifier = modifier,
+            title = fieldUiModel.label,
+            state = fieldUiModel.inputState(),
+            inputStyle = inputStyle,
+            legendData = fieldUiModel.legend(),
+            supportingTextData = fieldUiModel.supportingText(),
+            isRequiredField = fieldUiModel.mandatory,
+            selectedItem = DropdownItem(selectedItem ?: ""),
+            onResetButtonClicked = {
+                selectedItem = null
+                fieldUiModel.onClear()
+            },
+            onDropdownIconClick = {
+                uiEventHandler(
+                    RecyclerViewUiEvents.SelectPeriod(
+                        uid = fieldUiModel.uid,
+                        title = fieldUiModel.label,
+                        periodType = fieldUiModel.periodSelector!!.type,
+                        minDate = fieldUiModel.periodSelector!!.minDate,
+                        maxDate = fieldUiModel.periodSelector!!.maxDate,
+                    ),
+                )
+            },
+            onFocusChanged = {},
+            focusRequester = focusRequester,
+            expanded = false,
         )
     }
+}
 
-    DropdownInputField(
+@Composable
+fun ProvideEmptyPeriodSelector(
+    modifier: Modifier = Modifier,
+    name: String,
+    inputStyle: InputStyle,
+) {
+    var selectedItem by remember {
+        mutableStateOf("")
+    }
+
+    InputDropDown(
         modifier = modifier,
-        title = fieldUiModel.label,
-        state = fieldUiModel.inputState(),
+        title = name,
+        state = InputShellState.UNFOCUSED,
         inputStyle = inputStyle,
-        legendData = fieldUiModel.legend(),
-        supportingTextData = fieldUiModel.supportingText(),
-        isRequiredField = fieldUiModel.mandatory,
-        selectedItem = DropdownItem(selectedItem ?: ""),
+        selectedItem = DropdownItem(selectedItem),
         onResetButtonClicked = {
-            selectedItem = null
-            fieldUiModel.onClear()
+            selectedItem = ""
         },
-        onDropdownIconClick = {
-            uiEventHandler(
-                RecyclerViewUiEvents.SelectPeriod(
-                    uid = fieldUiModel.uid,
-                    title = fieldUiModel.label,
-                    periodType = fieldUiModel.periodSelector!!.type,
-                    minDate = fieldUiModel.periodSelector!!.minDate,
-                    maxDate = fieldUiModel.periodSelector!!.maxDate,
-                ),
-            )
+        onItemSelected = { newSelectedDropdownItem ->
+            selectedItem = newSelectedDropdownItem.label
         },
-        onFocusChanged = {},
-        focusRequester = focusRequester,
-        expanded = false,
+        dropdownItems = listOf(DropdownItem(stringResource(id = R.string.no_periods))),
+        isRequiredField = false,
     )
 }

--- a/form/src/main/res/values/strings.xml
+++ b/form/src/main/res/values/strings.xml
@@ -118,4 +118,6 @@
     <string name="no_options">No options available</string>
     <string name="cat_combo">Cat combo</string>
     <string name="storage_permission_denied">Storage permission is not granted.\nYou need to enable it to use this feature.</string>
+    <string name="no_periods">No periods available</string>
+
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 sdk = "34"
 minSdk = "21"
 vCode = "136"
-vName = "3.1.1-DEV"
+vName = "3.1.0"
 gradle = "8.6.1"
 kotlin = '2.0.20'
 hilt = '2.47'

--- a/tracker/src/main/kotlin/org/dhis2/tracker/events/CreateEventUseCaseRepository.kt
+++ b/tracker/src/main/kotlin/org/dhis2/tracker/events/CreateEventUseCaseRepository.kt
@@ -45,8 +45,12 @@ class CreateEventUseCaseRepository(
         } else {
             currentDate
         }
-        val eventRepository = d2.eventModule().events().uid(eventUid)
-        eventRepository.setEventDate(eventDate)
+
+        if(eventDate.before(currentDate) || eventDate == currentDate) {
+            val eventRepository = d2.eventModule().events().uid(eventUid)
+            eventRepository.setEventDate(eventDate)
+        }
+
     }
 
     private fun getStageLastDate(enrollmentUid: String?, programStageUid: String?): Date? {


### PR DESCRIPTION
This pull request includes several changes to the `EnrollmentEventGenerator`, `EnrollmentActivity`, `EnrollmentPresenterImpl`, `EventRepository`, `PeriodSelectorProvider`, and other related files. The main goal of these changes is to improve date handling and ensure that event dates are not set in the future. Additionally, a new string resource was added, and the version name was updated.

Improvements to date handling:

* [`app/src/main/java/org/dhis2/data/dhislogic/EnrollmentEventGenerator.kt`](diffhunk://#diff-76f4dad9e89337f7fe553e250e9210af2404529dfc701468a1f7711a1fa10da7L124-R129): Modified the event date generation logic to ensure that the event date is not set in the future.
* [`app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentActivity.kt`](diffhunk://#diff-9c4f4422db15e6fab9bab51f1cf55dcc3518e53ff9e2858203f30eb9b42a871cL175-R179): Added a check to ensure that the suggested event date is not in the future before opening the event. [[1]](diffhunk://#diff-9c4f4422db15e6fab9bab51f1cf55dcc3518e53ff9e2858203f30eb9b42a871cL175-R179) [[2]](diffhunk://#diff-9c4f4422db15e6fab9bab51f1cf55dcc3518e53ff9e2858203f30eb9b42a871cR189-R190)
* [`app/src/main/java/org/dhis2/usescases/enrollment/EnrollmentPresenterImpl.kt`](diffhunk://#diff-c43b0b6dd56a6835d0d5a8699379f9fbd2a2ad2c5aad3c480ee856804a7fc906R244-R261): Introduced a new method `suggestedReportDateIsNotFutureDate` to validate that the suggested report date is not in the future.
* [`form/src/main/java/org/dhis2/form/data/EventRepository.kt`](diffhunk://#diff-3060a8482d0e112865267580aa42db9208cedf16f1f9e026d1a18d4e4fd146baL480-R479): Updated the logic to filter out events with future dates and removed unnecessary methods. [[1]](diffhunk://#diff-3060a8482d0e112865267580aa42db9208cedf16f1f9e026d1a18d4e4fd146baL480-R479) [[2]](diffhunk://#diff-3060a8482d0e112865267580aa42db9208cedf16f1f9e026d1a18d4e4fd146baL502-R496)

UI and resource updates:

* [`form/src/main/java/org/dhis2/form/ui/provider/inputfield/PeriodSelectorProvider.kt`](diffhunk://#diff-aee18344a15cd086a5e6fcfa10bd2392ab304027f46c9190595aa0e1fd5db6a3R33-R40): Added a new period selector to handle cases where no valid periods are available. [[1]](diffhunk://#diff-aee18344a15cd086a5e6fcfa10bd2392ab304027f46c9190595aa0e1fd5db6a3R33-R40) [[2]](diffhunk://#diff-aee18344a15cd086a5e6fcfa10bd2392ab304027f46c9190595aa0e1fd5db6a3R76-R103)
* [`form/src/main/res/values/strings.xml`](diffhunk://#diff-ef42a1bf0a700e9aca056e6203e76c98594cbe52e7f7bf8bb4611521a4d2bf17R121-R122): Added a new string resource for "No periods available".

Version update:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL5-R5): Updated the version name from "3.1.1-DEV" to "3.1.0".
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
