### PR TITLE
fix: [ANDROAPP-6477] surround lateral menu navigation with async call

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt
@@ -1,5 +1,6 @@
 package org.dhis2.usescases.main
 
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
@@ -49,6 +50,10 @@ class MainRobot : BaseRobot() {
     }
 
     fun checkViewIsNotEmpty(composeTestRule: ComposeTestRule) {
+        composeTestRule.waitUntil() {
+            composeTestRule.onNodeWithTag(HOME_ITEMS)
+                .fetchSemanticsNode().config.getOrNull(HasPrograms) == true
+        }
         composeTestRule.onNodeWithTag(HOME_ITEMS).assert(
             SemanticsMatcher.expectValue(HasPrograms, true)
         )

--- a/app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt
@@ -31,6 +31,7 @@ class MainTest : BaseTest() {
     fun checkHomeScreenRecyclerviewHasElements() {
         startActivity()
         homeRobot {
+            composeTestRule.waitForIdle()
             checkViewIsNotEmpty(composeTestRule)
         }
     }

--- a/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import dispatch.core.dispatcherProvider
 import kotlinx.coroutines.launch
 import org.dhis2.BuildConfig
 import org.dhis2.R
@@ -93,13 +94,7 @@ class MainActivity :
 
     private var isPinLayoutVisible = false
 
-    private val mainNavigator = MainNavigator(
-        supportFragmentManager,
-        { /*no-op*/ },
-    ) { titleRes, _, showBottomNavigation ->
-        setTitle(getString(titleRes))
-        setBottomNavigationVisibility(showBottomNavigation)
-    }
+    private lateinit var mainNavigator: MainNavigator
 
     private val navigationLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { }
@@ -138,6 +133,14 @@ class MainActivity :
             )
             mainComponent.inject(this@MainActivity)
         } ?: navigateTo<LoginActivity>(true)
+        mainNavigator = MainNavigator(
+            dispatcherProvider = presenter.dispatcherProvider,
+            supportFragmentManager,
+            { /*no-op*/ },
+        ) { titleRes, _, showBottomNavigation ->
+            setTitle(getString(titleRes))
+            setBottomNavigationVisibility(showBottomNavigation)
+        }
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
 


### PR DESCRIPTION
This pull request includes several changes to improve the navigation and testing functionality in the `MainActivity` and related classes. The most important changes include adding a dispatcher provider to `MainNavigator`, refactoring the initialization of `MainNavigator` in `MainActivity`, and enhancing the `MainRobot` and `MainTest` classes for better test reliability.

### Navigation Improvements:

* [`app/src/main/java/org/dhis2/usescases/main/MainNavigator.kt`](diffhunk://#diff-adf15bf70d6b471a31f04a831e3074485656130a3ee59d37039d0cc36179e534R24): Added a dispatcher provider to `MainNavigator` and refactored the transaction handling to use coroutines for better performance and readability. [[1]](diffhunk://#diff-adf15bf70d6b471a31f04a831e3074485656130a3ee59d37039d0cc36179e534R24) [[2]](diffhunk://#diff-adf15bf70d6b471a31f04a831e3074485656130a3ee59d37039d0cc36179e534R140-R147) [[3]](diffhunk://#diff-adf15bf70d6b471a31f04a831e3074485656130a3ee59d37039d0cc36179e534L162-R161) [[4]](diffhunk://#diff-adf15bf70d6b471a31f04a831e3074485656130a3ee59d37039d0cc36179e534R170-R186)

### Activity Initialization:

* [`app/src/main/java/org/dhis2/usescases/main/MainActivity.kt`](diffhunk://#diff-d4aa7de9b5c76d8d0be1d2b52a2ae473d06986d0b88095495faa49e38cf27ed8L96-R97): Refactored the initialization of `MainNavigator` to use a dispatcher provider, improving the setup process and making it more flexible. [[1]](diffhunk://#diff-d4aa7de9b5c76d8d0be1d2b52a2ae473d06986d0b88095495faa49e38cf27ed8L96-R97) [[2]](diffhunk://#diff-d4aa7de9b5c76d8d0be1d2b52a2ae473d06986d0b88095495faa49e38cf27ed8R136-R143)

### Testing Enhancements:

* [`app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt`](diffhunk://#diff-e2e625880a83a63f66030285bda8ea91f54f49e9803bd7aeb93e528c3b15b2c9R53-R56): Added a wait condition to ensure the view is not empty before performing assertions, improving test reliability.
* [`app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt`](diffhunk://#diff-015d3df7d510f59ac57d83f45e08a5f38f6cd6c0d3da63cac2a7058c364f4276R34): Added a call to `waitForIdle` in the `checkHomeScreenRecyclerviewHasElements` method to ensure the UI is idle before running tests.
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
