### PR TITLE
ci: Exclude pull requests from con job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 //Sets cron schedule just for PUSH job
-String con_string = JOB_NAME == 'android-multibranch-PUSH' ? '0 0 * * *' : ''
+String cron_string = JOB_NAME == 'android-multibranch-PUSH' ? '0 0 * * *' : ''
 
 pipeline {
     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+//Sets cron schedule just for PUSH job
+String con_string = JOB_NAME == 'android-multibranch-PUSH' ? '0 0 * * *' : ''
+
 pipeline {
     agent {
         label "ec2-android"
     }
 
     triggers {
-        cron('0 0 * * *')
+        cron(cron_string)
     }
 
     options {


### PR DESCRIPTION

Every night long live branches runs the ci, exclude opened pull requests