### PR TITLE
fix: [ANDROAPP-6579] set dropdownmenu max width to 70% of screen size

### DIFF
--- a/app/src/main/java/org/dhis2/utils/customviews/MoreMenuView.kt
+++ b/app/src/main/java/org/dhis2/utils/customviews/MoreMenuView.kt
@@ -8,9 +8,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import org.hisp.dhis.mobile.ui.designsystem.component.IconButton
 import org.hisp.dhis.mobile.ui.designsystem.component.menu.DropDownMenu
 import org.hisp.dhis.mobile.ui.designsystem.component.menu.MenuItemData
+import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 
 @Composable
@@ -32,16 +34,17 @@ fun <T> MoreOptionsWithDropDownMenuButton(
     ) {
         onMenuToggle(!expanded)
     }
-
     DropDownMenu(
         modifier = Modifier.widthIn(max = 0.7.dw),
         items = dropDownMenuItems,
         expanded = expanded,
+        offset = DpOffset(x = -Spacing.Spacing16, y = Spacing.Spacing0),
         onDismissRequest = { onMenuToggle(false) },
-    ) { itemId ->
-        onMenuToggle(false)
-        onItemClick(itemId)
-    }
+        onItemClick = { itemId ->
+            onMenuToggle(false)
+            onItemClick(itemId)
+        },
+    )
 }
 
 inline val Double.dw: Dp

--- a/app/src/main/java/org/dhis2/utils/customviews/MoreMenuView.kt
+++ b/app/src/main/java/org/dhis2/utils/customviews/MoreMenuView.kt
@@ -1,10 +1,13 @@
 package org.dhis2.utils.customviews
 
+import android.content.res.Resources
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import org.hisp.dhis.mobile.ui.designsystem.component.IconButton
 import org.hisp.dhis.mobile.ui.designsystem.component.menu.DropDownMenu
 import org.hisp.dhis.mobile.ui.designsystem.component.menu.MenuItemData
@@ -31,6 +34,7 @@ fun <T> MoreOptionsWithDropDownMenuButton(
     }
 
     DropDownMenu(
+        modifier = Modifier.widthIn(max = 0.7.dw),
         items = dropDownMenuItems,
         expanded = expanded,
         onDismissRequest = { onMenuToggle(false) },
@@ -39,3 +43,8 @@ fun <T> MoreOptionsWithDropDownMenuButton(
         onItemClick(itemId)
     }
 }
+
+inline val Double.dw: Dp
+    get() = Resources.getSystem().displayMetrics.let {
+        Dp(value = ((this * it.widthPixels) / it.density).toFloat())
+    }


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
