### PR TITLE
Fix condition for Jenkinsfile cron job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 //Sets cron schedule just for PUSH job
-String cron_string = JOB_NAME == 'android-multibranch-PUSH' ? '0 0 * * *' : ''
+String cron_string = JOB_NAME.startsWith('android-multibranch-PUSH') ? '0 0 * * *' : ''
 
 pipeline {
     agent {


### PR DESCRIPTION
## Description
Modify the condition to check the Job name. The variable JOB_NAME contains the name of the folder (such as android-multibranch-PR) and the branch name, so the variable value is something as `android-multibranch-PR/develop`.

The change is to verify if JOB_NAME starts with the name of folder.