### PR TITLE
Enable support to login with two factor code

### DIFF
--- a/app/src/main/java/org/dhis2/data/server/OpenIdSession.kt
+++ b/app/src/main/java/org/dhis2/data/server/OpenIdSession.kt
@@ -25,6 +25,7 @@ class OpenIdSession(
     enum class LogOutReason {
         OPEN_ID,
         DISABLED_ACCOUNT,
+        UNAUTHORIZED,
     }
 
     fun setSessionCallback(
@@ -44,6 +45,8 @@ class OpenIdSession(
                 d2.userModule().accountManager().accountDeletionObservable()
                     .filter { it == AccountDeletionReason.ACCOUNT_DISABLED }
                     .map { LogOutReason.DISABLED_ACCOUNT },
+                d2.userModule().accountManager().logOutObservable()
+                    .map { LogOutReason.UNAUTHORIZED },
             ).defaultSubscribe(
                 schedulerProvider,
                 { sessionCallback(it) },

--- a/app/src/main/java/org/dhis2/data/server/UserManager.java
+++ b/app/src/main/java/org/dhis2/data/server/UserManager.java
@@ -18,7 +18,7 @@ import kotlin.Pair;
 public interface UserManager {
 
     @NonNull
-    Observable<User> logIn(@NonNull String username, @NonNull String password, @NonNull String serverUrl);
+    Observable<User> logIn(@NonNull String username, @NonNull String password, @NonNull String serverUrl, String twoFactorCode);
 
     @NonNull
     Observable<IntentWithRequestCode> logIn(@NonNull OpenIDConnectConfig config);

--- a/app/src/main/java/org/dhis2/data/server/UserManagerImpl.java
+++ b/app/src/main/java/org/dhis2/data/server/UserManagerImpl.java
@@ -27,8 +27,8 @@ public class UserManagerImpl implements UserManager {
 
     @NonNull
     @Override
-    public Observable<User> logIn(@NonNull String username, @NonNull String password, @NonNull String serverUrl) {
-        return Observable.defer(() -> d2.userModule().logIn(username, password, serverUrl).toObservable());
+    public Observable<User> logIn(@NonNull String username, @NonNull String password, @NonNull String serverUrl, String twoFactorCode) {
+        return Observable.defer(() -> d2.userModule().logIn(username, password, serverUrl, twoFactorCode).toObservable());
     }
 
     @NonNull

--- a/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
@@ -154,7 +154,7 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
                         EXTRA_ACCOUNT_DISABLED,
                         true,
                     )
-
+                    OpenIdSession.LogOutReason.UNAUTHORIZED ->  putBoolean(EXTRA_SESSION_EXPIRED, true)
                     null -> {
                         // Nothing to do in this case
                     }
@@ -224,6 +224,8 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
 
         presenter.isDataComplete.observe(this) { this.setLoginVisibility(it) }
 
+        presenter.twoFactorCodeVisible.observe(this) { this.setTwoFactorCodeVisibility(it) }
+
         presenter.isTestingEnvironment.observe(
             this,
         ) { testingEnvironment ->
@@ -262,6 +264,7 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
         binding.clearPassButton.setOnClickListener { binding.userPassEdit.text = null }
         binding.clearUserNameButton.setOnClickListener { binding.userNameEdit.text = null }
         binding.clearUrl.setOnClickListener { binding.serverUrlEdit.text = null }
+        binding.clearTwoFactoButton.setOnClickListener { binding.userTwoFactorCodeEdit.text = null }
 
         presenter.loginProgressVisible.observe(this) { show ->
             showLoginProgress(show, getString(R.string.authenticating))
@@ -302,6 +305,14 @@ class LoginActivity : ActivityGlobalAbstract(), LoginContracts.View {
                     }
                 }
             }
+        }
+    }
+
+    fun setTwoFactorCodeVisibility(isVisible: Boolean) {
+        if (isVisible){
+            binding.twoFactoContainer.visibility = View.VISIBLE
+        } else {
+            binding.twoFactoContainer.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/org/dhis2/usescases/login/LoginViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginViewModel.kt
@@ -67,6 +67,7 @@ class LoginViewModel(
     val serverUrl = MutableLiveData<String>()
     val userName = MutableLiveData<String>()
     val password = MutableLiveData<String>()
+    val twoFactorCode = MutableLiveData<String>()
     val isDataComplete = MutableLiveData<Boolean>()
     val isTestingEnvironment = MutableLiveData<Trio<String, String, String>>()
     var testingCredentials: MutableMap<String, TestingCredential>? = null
@@ -81,6 +82,9 @@ class LoginViewModel(
 
     private val _displayMoreActions = MutableLiveData<Boolean>(true)
     val displayMoreActions: LiveData<Boolean> = _displayMoreActions
+
+    private val _twoFactorCodeVisible = MutableLiveData(false)
+    val twoFactorCodeVisible: LiveData<Boolean> = _twoFactorCodeVisible
 
     init {
         this.userManager?.let {
@@ -202,6 +206,7 @@ class LoginViewModel(
                         userName.value!!.trim { it <= ' ' },
                         password.value!!,
                         serverUrl.value!!,
+                        twoFactorCode.value,
                     )
                         .map {
                             run {
@@ -345,7 +350,11 @@ class LoginViewModel(
             userManager?.d2?.userModule()?.blockingLogOut()
             logIn()
         } else {
-            view.renderError(throwable)
+            if (throwable is D2Error && throwable.errorCode() == D2ErrorCode.INCORRECT_TWO_FACTOR_CODE && _twoFactorCodeVisible.value == false) {
+                _twoFactorCodeVisible.postValue(true)
+            } else {
+                view.renderError(throwable)
+            }
         }
     }
 
@@ -459,6 +468,13 @@ class LoginViewModel(
     fun onPassChanged(password: CharSequence, start: Int, before: Int, count: Int) {
         if (password.toString() != this.password.value) {
             this.password.value = password.toString()
+            checkData()
+        }
+    }
+
+    fun onTwoFactorCodeChanged(twoFactorCode: CharSequence, start: Int, before: Int, count: Int) {
+        if (password.toString() != this.password.value) {
+            this.twoFactorCode.value = twoFactorCode.toString()
             checkData()
         }
     }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -211,6 +211,61 @@
                     </com.google.android.material.textfield.TextInputLayout>
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/twoFactoContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/passContainer"
+                    android:visibility="gone">
+
+
+                    <ImageView
+                        android:id="@+id/twoFactorCodeIcon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintBottom_toBottomOf="@id/user_two_factor"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/user_two_factor"
+                        app:srcCompat="@drawable/ic_i_block" />
+
+                    <ImageButton
+                        android:id="@+id/clearTwoFactoButton"
+                        style="@style/ActionIconNoPadding"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@android:color/transparent"
+                        app:layout_constraintBottom_toBottomOf="@id/user_two_factor"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/user_two_factor"
+                        app:srcCompat="@drawable/ic_close" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/user_two_factor"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_centerInParent="true"
+                        android:layout_marginStart="12dp"
+                        android:layout_marginEnd="12dp"
+                        android:hint="@string/two_factor_code_hint"
+                        android:textColorHint="@color/text_black_808"
+                        android:theme="@style/loginInputText"
+                        app:layout_constraintEnd_toStartOf="@id/clearTwoFactoButton"
+                        app:layout_constraintStart_toEndOf="@id/twoFactorCodeIcon"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/user_two_factor_code_edit"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:imeOptions="actionDone"
+                            android:inputType="text"
+                            android:onTextChanged="@{presenter::onTwoFactorCodeChanged}"
+                            android:textColor="@color/text_black_333"
+                            android:textSize="17sp" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
                 <TextView
                     android:id="@+id/account_recovery"
                     android:layout_width="wrap_content"
@@ -223,7 +278,7 @@
                     android:textSize="@dimen/textSize_12"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/passContainer" />
+                    app:layout_constraintTop_toBottomOf="@id/twoFactoContainer" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -993,4 +993,5 @@
     <string name="successfully_transferred">Successfully transferred</string>
     <string name="event_cancelled">%1$s cancelled</string>
     <string name="due_date_updated">Due date updated</string>
+    <string name="two_factor_code_hint">Two factor code</string>
 </resources>

--- a/app/src/test/java/org/dhis2/usescases/login/LoginViewModelTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/login/LoginViewModelTest.kt
@@ -45,6 +45,7 @@ import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -191,7 +192,7 @@ class LoginViewModelTest {
     fun `Should log in successfully and show fabric dialog when  user has not been asked before`() {
         val mockedUser: User = mock()
         whenever(view.initLogin()) doReturn userManager
-        whenever(userManager.logIn(any(), any(), any())) doReturn Observable.just(mockedUser)
+        whenever(userManager.logIn(any(), any(), any(), eq(null))) doReturn Observable.just(mockedUser)
         instantiateLoginViewModelWithNullUserManager()
         loginViewModel.onServerChanged(serverUrl = "serverUrl", 0, 0, 0)
         loginViewModel.onUserChanged(userName = "username", 0, 0, 0)

--- a/commons/src/main/java/org/dhis2/commons/resources/D2ErrorUtils.kt
+++ b/commons/src/main/java/org/dhis2/commons/resources/D2ErrorUtils.kt
@@ -154,6 +154,7 @@ class D2ErrorUtils(
 
             D2ErrorCode.DATABASE_IMPORT_FAILED -> "Database import failed"
             D2ErrorCode.DATABASE_IMPORT_INVALID_FILE -> "Invalid file"
+            D2ErrorCode.INCORRECT_TWO_FACTOR_CODE -> context.getString(R.string.incorrect_two_factor_code)
         }
     }
 

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -308,4 +308,5 @@
     <string name="sync_retry">Retry sync</string>
     <string name="syncing">Synchronizing...</string>
     <string name="remove">Remove</string>
+    <string name="incorrect_two_factor_code">Incorrect two factor code</string>
 </resources>


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

No Jira issue for this. Just an external contribution from EyeSeeTea.

## Solution description
This PR enables the use of 2FA in servers above v41. It depends on [this PR SDK side](https://github.com/dhis2/dhis2-android-sdk/pull/2311).

When a user activates 2FA the app will detect the failure produced by a login attempt on a 2FA-enabled user and will add a field asking for 2FA code to that user. 

The 2FA requires the cookie to be present after that login. So when the login expires (this is e.g. when its been a while since the user didn't login) the sync attemps will fail. It is important to note that, effectively, this means that when a user activates its 2FA, the user needs to be trained in the different from a sync perspective, as the app will only sync its metadata/data after a login is done. It's then important that the user knows that without a login, the data that was not synced won't be synced to the server before the next login.


## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [x] Smartphone Emulator
- [ ] Tablet Emulator
- [x] Smartphone
- [x] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [x] 9.X - 10.X
- [x] 11.X - 13.X
- [x] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
