### PR TITLE
fix: [ANDROAPP-6426] hide transfer quickAction when is not available

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
@@ -307,7 +307,10 @@ class TEIDataFragment : FragmentGlobalAbstract(), TEIDataContracts.View {
                         presenter.onAddNewEventOptionSelected(it, null)
                     },
                     quickActions = (dashboardModel as? DashboardEnrollmentModel)?.let {
-                        quickActionsMapper.map(it) { quickActionType ->
+                        quickActionsMapper.map(
+                            it,
+                            dashboardViewModel.checkIfTeiCanBeTransferred(),
+                        ) { quickActionType ->
                             onQuickAction(quickActionType)
                         }
                     } ?: emptyList(),

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/ui/mapper/QuickActionsMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/ui/mapper/QuickActionsMapperTest.kt
@@ -47,7 +47,7 @@ class QuickActionsMapperTest {
                 QuickActionType.MORE_ENROLLMENTS.name,
             ),
         )
-        val quickActions = mapper.map(dashboardEnrollmentModel) {}
+        val quickActions = mapper.map(dashboardEnrollmentModel, true) {}
         assert(quickActions.size == 5)
     }
 
@@ -57,7 +57,7 @@ class QuickActionsMapperTest {
             status = EnrollmentStatus.ACTIVE,
             quickActions = listOf(QuickActionType.MORE_ENROLLMENTS.name),
         )
-        val quickActions = mapper.map(dashboardEnrollmentModel) {}
+        val quickActions = mapper.map(dashboardEnrollmentModel, true) {}
         assert(quickActions.first().label == "More enrollments")
     }
 
@@ -68,7 +68,7 @@ class QuickActionsMapperTest {
             followup = true,
             quickActions = listOf(QuickActionType.MARK_FOLLOW_UP.name),
         )
-        val quickActions = mapper.map(dashboardEnrollmentModel) {}
+        val quickActions = mapper.map(dashboardEnrollmentModel, true) {}
         assert(quickActions.isEmpty())
     }
 
@@ -81,8 +81,21 @@ class QuickActionsMapperTest {
                 QuickActionType.CANCEL_ENROLLMENT.name,
             ),
         )
-        val quickActions = mapper.map(dashboardEnrollmentModel) {}
+        val quickActions = mapper.map(dashboardEnrollmentModel, true) {}
         assert(quickActions.map { it.label } == listOf("Re-open enrollment", "Deactivate enrollment"))
+    }
+
+    @Test
+    fun shouldNotMapTransferActionIfNotAvailable() {
+        val dashboardEnrollmentModel = fakeEnrollmentModel(
+            status = EnrollmentStatus.COMPLETED,
+            quickActions = listOf(
+                QuickActionType.TRANSFER.name,
+                QuickActionType.CANCEL_ENROLLMENT.name,
+            ),
+        )
+        val quickActions = mapper.map(dashboardEnrollmentModel, false) {}
+        assert(quickActions.map { it.label } == listOf("Deactivate enrollment"))
     }
 
     private fun fakeEnrollmentModel(


### PR DESCRIPTION
## Description
Please include a summary of the change and include the related jira issue if it exists.

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
