### PR TITLE
chore: Enable browserstack single runner for Form and Compose tests

### DIFF
--- a/scripts/browserstackJenkins.sh
+++ b/scripts/browserstackJenkins.sh
@@ -43,7 +43,7 @@ echo "build id running: $build_id"
 
 # Monitor build status
 build_status="running"
-sleep $build_time_average
+sleep $build_time_average_long
 echo "Monitoring build status started...."
 
 while [[ $build_status = "running" ]];

--- a/scripts/browserstackJenkinsCompose.sh
+++ b/scripts/browserstackJenkinsCompose.sh
@@ -13,8 +13,9 @@ json=$(jq -n \
                 --argjson devices ["$browserstack_device_list"] \
                 --arg video "$browserstack_video" \
                 --arg deviceLogs "$browserstack_deviceLogs" \
+                --arg singleRunnerInvocation "$browserstack_singleRunnerInvocation" \
                 --arg buildTag "$buildTag" \
-                '{devices: $devices, testSuite: $module_url, video: $video, deviceLogs: $deviceLogs, buildTag: $buildTag}')
+                '{devices: $devices, testSuite: $module_url, video: $video, deviceLogs: $deviceLogs, singleRunnerInvocation: $singleRunnerInvocation, buildTag: $buildTag}')
 
 test_execution_response="$(curl -X POST https://api-cloud.browserstack.com/app-automate/espresso/v2/module-build -d \ "$json" -H "Content-Type: application/json" -u "$BROWSERSTACK_USR:$BROWSERSTACK_PSW")"
 
@@ -24,7 +25,7 @@ echo "build id running: $build_id"
 
 # Monitor build status
 build_status="running"
-sleep $build_time_average
+sleep $build_time_average_short
 echo "Monitoring build status started...."
 
 while [[ $build_status = "running" ]];

--- a/scripts/browserstackJenkinsForm.sh
+++ b/scripts/browserstackJenkinsForm.sh
@@ -15,8 +15,9 @@ json=$(jq -n \
                 --argjson devices ["$browserstack_device_list"] \
                 --arg video "$browserstack_video" \
                 --arg deviceLogs "$browserstack_deviceLogs" \
+                --arg singleRunnerInvocation "$browserstack_singleRunnerInvocation" \
                 --arg buildTag "$buildTag" \
-                '{devices: $devices, testSuite: $module_url, video: $video, deviceLogs: $deviceLogs, buildTag: $buildTag}')
+                '{devices: $devices, testSuite: $module_url, video: $video, deviceLogs: $deviceLogs, singleRunnerInvocation: $singleRunnerInvocation, buildTag: $buildTag}')
 
 test_execution_response="$(curl -X POST https://api-cloud.browserstack.com/app-automate/espresso/v2/module-build -d \ "$json" -H "Content-Type: application/json" -u "$BROWSERSTACK_USR:$BROWSERSTACK_PSW")"
 
@@ -26,7 +27,7 @@ echo "build id running: $build_id"
 
 # Monitor build status
 build_status="running"
-sleep $build_time_average
+sleep $build_time_average_short
 echo "Monitoring build status started...."
 
 while [[ $build_status = "running" ]];

--- a/scripts/browserstackJenkinsLandscape.sh
+++ b/scripts/browserstackJenkinsLandscape.sh
@@ -44,7 +44,7 @@ echo "build id running: $build_id"
 
 # Monitor build status
 build_status="running"
-sleep $build_time_average
+sleep $build_time_average_long
 echo "Monitoring build status started...."
 
 while [[ $build_status = "running" ]];

--- a/scripts/config_jenkins.init
+++ b/scripts/config_jenkins.init
@@ -1,4 +1,5 @@
-build_time_average=660
+build_time_average_short=60
+build_time_average_long=660
 polling_interval=10
 browserstack_device_list="\"Samsung Galaxy S10-9.0\""
 browserstack_device_list_landscape="\"Samsung Galaxy Tab S6-9.0\""
@@ -8,6 +9,7 @@ browserstack_gps_location="40.730610,-73.935242"
 browserstack_language="en"
 browserstack_locale="en"
 browserstack_deviceLogs=true
+browserstack_singleRunnerInvocation=true
 browserstack_number_of_parallel_executions=2
 bitrise_max_parallel_builds=3
 browserstack_class="\"org.dhis2.usescases.UseCaseTestsSuite\",\"org.dhis2.usescases.FlowTestsSuite\""


### PR DESCRIPTION
## Description
This is a proof to know if enabling the singleRunner in Browserstack works and makes the CI faster.

## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
