### PR TITLE
fix: Do not show 'default' categoryOptionCombo label

### DIFF
--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -25,10 +25,12 @@ import org.dhis2.mobile.commons.validation.validators.FieldMaskValidator
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.category.CategoryOptionCombo
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.dataelement.DataElementOperand
 import org.hisp.dhis.android.core.dataset.DataSetEditableStatus
 import org.hisp.dhis.android.core.dataset.Section
@@ -665,10 +667,6 @@ internal class DataSetInstanceRepositoryImpl(
         val categoryOptionCombo = d2.categoryModule().categoryOptionCombos()
             .uid(categoryOptionComboUid)
             .blockingGet()
-        val isDefaultCategoryCombo = d2.categoryModule().categoryCombos()
-            .uid(categoryOptionCombo?.categoryCombo()?.uid())
-            .blockingGet()
-            ?.isDefault ?: false
         val isMandatory = d2.dataSetModule().dataSets().withCompulsoryDataElementOperands()
             .uid(dataSetUid)
             .blockingGet()
@@ -683,17 +681,8 @@ internal class DataSetInstanceRepositoryImpl(
         }
             ?: if (dataElementValueType is InputType.MultiText) InputType.MultiText else InputType.OptionSet
 
-        val categoryOptionComboSuffix =
-            if (isDefaultCategoryCombo) {
-                ""
-            } else {
-                " / ${categoryOptionCombo?.displayName()}"
-            }
-
-        val dataElementLabel = "${dataElement.displayFormName()}$categoryOptionComboSuffix"
-
         return DataElementInfo(
-            label = dataElementLabel,
+            label = getDataElementInfoLabel(dataElement, categoryOptionCombo),
             inputType = inputType,
             description = dataElement.displayDescription(),
             isRequired = isMandatory,
@@ -919,5 +908,23 @@ internal class DataSetInstanceRepositoryImpl(
             }
         }
         return dataToReview
+    }
+
+    private fun getDataElementInfoLabel(
+        dataElement: DataElement,
+        coc: CategoryOptionCombo?,
+    ): String {
+        val isDefaultCategoryCombo = d2.categoryModule().categoryCombos()
+            .uid(coc?.categoryCombo()?.uid())
+            .blockingGet()
+            ?.isDefault ?: false
+
+        val dataElementLabel = dataElement.run { displayFormName() ?: displayName() ?: uid() }
+
+        return if (isDefaultCategoryCombo) {
+            dataElementLabel
+        } else {
+            "$dataElementLabel / ${coc?.displayName()}"
+        }
     }
 }

--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -665,6 +665,10 @@ internal class DataSetInstanceRepositoryImpl(
         val categoryOptionCombo = d2.categoryModule().categoryOptionCombos()
             .uid(categoryOptionComboUid)
             .blockingGet()
+        val isDefaultCategoryCombo = d2.categoryModule().categoryCombos()
+            .uid(categoryOptionCombo?.categoryCombo()?.uid())
+            .blockingGet()
+            ?.isDefault ?: false
         val isMandatory = d2.dataSetModule().dataSets().withCompulsoryDataElementOperands()
             .uid(dataSetUid)
             .blockingGet()
@@ -679,8 +683,17 @@ internal class DataSetInstanceRepositoryImpl(
         }
             ?: if (dataElementValueType is InputType.MultiText) InputType.MultiText else InputType.OptionSet
 
+        val categoryOptionComboSuffix =
+            if (isDefaultCategoryCombo) {
+                ""
+            } else {
+                " / ${categoryOptionCombo?.displayName()}"
+            }
+
+        val dataElementLabel = "${dataElement.displayFormName()}$categoryOptionComboSuffix"
+
         return DataElementInfo(
-            label = "${dataElement.displayFormName()}/${categoryOptionCombo?.displayName()}",
+            label = dataElementLabel,
             inputType = inputType,
             description = dataElement.displayDescription(),
             isRequired = isMandatory,


### PR DESCRIPTION
## Description
This PR includes two fixes:
- Do not include 'default' categoryOptionCombo label ([ANDROAPP-6900](https://dhis2.atlassian.net/browse/ANDROAPP-6900))
- Add space between dataElement name and categoryOptionCombo label ([ANDROAPP-6908](https://dhis2.atlassian.net/browse/ANDROAPP-6908))

## Where did you test this issue?
- [X] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code


[ANDROAPP-6900]: https://dhis2.atlassian.net/browse/ANDROAPP-6900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROAPP-6908]: https://dhis2.atlassian.net/browse/ANDROAPP-6908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ