### PR TITLE
fix: [ANDROAPP-6902] Inject UIActionHandler instead of passing the context as parameter

### DIFF
--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/di/AggregateModule.android.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/di/AggregateModule.android.kt
@@ -4,8 +4,6 @@ import org.dhis2.mobile.aggregates.data.DataSetInstanceRepository
 import org.dhis2.mobile.aggregates.data.DataSetInstanceRepositoryImpl
 import org.dhis2.mobile.aggregates.data.OptionRepository
 import org.dhis2.mobile.aggregates.data.OptionRepositoryImpl
-import org.dhis2.mobile.aggregates.ui.UIActionHandler
-import org.dhis2.mobile.aggregates.ui.UIActionHandlerImpl
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -13,5 +11,4 @@ actual val platformModule: Module
     get() = module {
         single<DataSetInstanceRepository> { DataSetInstanceRepositoryImpl(get(), get()) }
         single<OptionRepository> { OptionRepositoryImpl(get()) }
-        single<UIActionHandler> { params -> UIActionHandlerImpl(params.get(), params.get()) }
     }

--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/ui/UiActionHandlerImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/ui/UiActionHandlerImpl.kt
@@ -18,10 +18,10 @@ import org.dhis2.maps.views.MapSelectorActivity.Companion.PROGRAM_UID
 import org.dhis2.maps.views.MapSelectorActivity.Companion.SCOPE
 import org.dhis2.mobile.aggregates.R
 
-internal class UIActionHandlerImpl(
+class UiActionHandlerImpl(
     private val context: FragmentActivity,
     private val dataSetUid: String,
-) : UIActionHandler {
+) : UiActionHandler {
     private var callback: ((String?) -> Unit)? = null
 
     private val mapLauncher =

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/di/AggregateModule.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/di/AggregateModule.kt
@@ -11,6 +11,7 @@ import org.dhis2.mobile.aggregates.domain.GetDataValueData
 import org.dhis2.mobile.aggregates.domain.GetDataValueInput
 import org.dhis2.mobile.aggregates.domain.RunValidationRules
 import org.dhis2.mobile.aggregates.domain.SetDataValue
+import org.dhis2.mobile.aggregates.ui.UiActionHandler
 import org.dhis2.mobile.aggregates.ui.dispatcher.Dispatcher
 import org.dhis2.mobile.aggregates.ui.provider.DataSetModalDialogProvider
 import org.dhis2.mobile.aggregates.ui.provider.ResourceManager
@@ -151,7 +152,7 @@ internal val featureModule = module {
         val attrOptionComboUid = params.get<String>()
         val openErrorLocation = params.getOrNull<Boolean>() ?: false
         val onClose = params.get<() -> Unit>()
-        val context = params.get<Any>()
+        val uiActionHandler = params.get<UiActionHandler>()
 
         DataSetTableViewModel(
             onClose = onClose,
@@ -194,9 +195,7 @@ internal val featureModule = module {
             runValidationRules = get {
                 parametersOf(dataSetUid, periodId, orgUnitUid, attrOptionComboUid)
             },
-            uiActionHandler = get {
-                parametersOf(context, dataSetUid)
-            },
+            uiActionHandler = uiActionHandler,
             inputDataUiStateMapper = get(),
             fieldErrorMessageProvider = get(),
         )

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/DataSetTableScreen.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/DataSetTableScreen.kt
@@ -105,7 +105,7 @@ fun DataSetInstanceScreen(
     snackbarHostState: SnackbarHostState,
     onBackClicked: () -> Unit,
     onSyncClicked: (onUpdateData: () -> Unit) -> Unit,
-    activity: Any,
+    uiActionHandler: UiActionHandler,
 ) {
     val dataSetTableViewModel: DataSetTableViewModel =
         koinViewModel<DataSetTableViewModel>(parameters = {
@@ -116,7 +116,7 @@ fun DataSetInstanceScreen(
                 parameters.attributeOptionComboUid,
                 parameters.openErrorLocation,
                 onBackClicked,
-                activity,
+                uiActionHandler,
             )
         })
     val dataSetScreenState by dataSetTableViewModel.dataSetScreenState.collectAsState()

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/UiActionHandler.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/UiActionHandler.kt
@@ -1,6 +1,6 @@
 package org.dhis2.mobile.aggregates.ui
 
-internal interface UIActionHandler {
+interface UiActionHandler {
     fun onCaptureCoordinates(
         fieldUid: String,
         locationType: String,

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModel.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModel.kt
@@ -38,7 +38,7 @@ import org.dhis2.mobile.aggregates.model.Violation
 import org.dhis2.mobile.aggregates.model.mapper.toTableModel
 import org.dhis2.mobile.aggregates.model.mapper.updateValue
 import org.dhis2.mobile.aggregates.model.mapper.withTotalsRow
-import org.dhis2.mobile.aggregates.ui.UIActionHandler
+import org.dhis2.mobile.aggregates.ui.UiActionHandler
 import org.dhis2.mobile.aggregates.ui.constants.NO_SECTION_UID
 import org.dhis2.mobile.aggregates.ui.dispatcher.Dispatcher
 import org.dhis2.mobile.aggregates.ui.inputs.CellIdGenerator
@@ -74,7 +74,7 @@ internal class DataSetTableViewModel(
     private val datasetModalDialogProvider: DataSetModalDialogProvider,
     private val completeDataSet: CompleteDataSet,
     private val runValidationRules: RunValidationRules,
-    private val uiActionHandler: UIActionHandler,
+    private val uiActionHandler: UiActionHandler,
     private val inputDataUiStateMapper: InputDataUiStateMapper,
     private val fieldErrorMessageProvider: FieldErrorMessageProvider,
 ) : ViewModel() {

--- a/aggregates/src/commonTest/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModelTest.kt
+++ b/aggregates/src/commonTest/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModelTest.kt
@@ -47,7 +47,7 @@ import org.dhis2.mobile.aggregates.model.ValidationRulesConfiguration.MANDATORY
 import org.dhis2.mobile.aggregates.model.ValidationRulesConfiguration.NONE
 import org.dhis2.mobile.aggregates.model.ValidationRulesConfiguration.OPTIONAL
 import org.dhis2.mobile.aggregates.model.ValidationRulesResult
-import org.dhis2.mobile.aggregates.ui.UIActionHandler
+import org.dhis2.mobile.aggregates.ui.UiActionHandler
 import org.dhis2.mobile.aggregates.ui.dispatcher.Dispatcher
 import org.dhis2.mobile.aggregates.ui.inputs.CellIdGenerator
 import org.dhis2.mobile.aggregates.ui.inputs.TableId
@@ -104,7 +104,7 @@ internal class DataSetTableViewModelTest : KoinTest {
     private lateinit var dataSetModalDialogProvider: DataSetModalDialogProvider
     private lateinit var completeDataSet: CompleteDataSet
     private lateinit var runValidationRules: RunValidationRules
-    private lateinit var uiActionHandler: UIActionHandler
+    private lateinit var uiActionHandler: UiActionHandler
     private lateinit var inputDataUiStateMapper: InputDataUiStateMapper
 
     private val onCloseCallback: () -> Unit = mock()
@@ -141,7 +141,7 @@ internal class DataSetTableViewModelTest : KoinTest {
         dataSetModalDialogProvider = declareMock<DataSetModalDialogProvider>()
         completeDataSet = declareMock<CompleteDataSet>()
         runValidationRules = declareMock<RunValidationRules>()
-        uiActionHandler = declareMock<UIActionHandler>()
+        uiActionHandler = declareMock<UiActionHandler>()
         inputDataUiStateMapper = declareMock<InputDataUiStateMapper>()
 
         whenever(dispatcher.io).thenReturn { testDispatcher }

--- a/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetInstanceActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/datasets/dataSetTable/DataSetInstanceActivity.kt
@@ -18,6 +18,7 @@ import org.dhis2.commons.sync.SyncContext
 import org.dhis2.mobile.aggregates.di.mappers.toDataSetInstanceParameters
 import org.dhis2.mobile.aggregates.model.DataSetInstanceParameters
 import org.dhis2.mobile.aggregates.ui.DataSetInstanceScreen
+import org.dhis2.mobile.aggregates.ui.UiActionHandlerImpl
 import org.dhis2.mobile.aggregates.ui.constants.INTENT_EXTRA_ATTRIBUTE_OPTION_COMBO_UID
 import org.dhis2.mobile.aggregates.ui.constants.INTENT_EXTRA_DATA_SET_UID
 import org.dhis2.mobile.aggregates.ui.constants.INTENT_EXTRA_ORGANISATION_UNIT_UID
@@ -35,6 +36,11 @@ class DataSetInstanceActivity : ActivityGlobalAbstract() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 //        enableEdgeToEdge()
+
+        val uiActionHandler = UiActionHandlerImpl(
+            context = this,
+            dataSetUid = intent.getStringExtra(INTENT_EXTRA_DATA_SET_UID) ?: "",
+        )
 
         setContent {
             TableTheme {
@@ -58,7 +64,7 @@ class DataSetInstanceActivity : ActivityGlobalAbstract() {
                             onUpdateData = onUpdateData,
                         )
                     },
-                    activity = activity,
+                    uiActionHandler = uiActionHandler,
                 )
             }
             supportFragmentManager


### PR DESCRIPTION
## Description
Inject UiActionHandler in DataSetInstanceScreen instead of passing the context

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-6902)
