### PR TITLE
fix: [ANDROAPP-6977] Crash when loading dataset with empty category option combo

### DIFF
--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -429,7 +429,7 @@ internal class DataSetInstanceRepositoryImpl(
                             ?: dataElementCategoryComboUid(it.uid),
                     )
                 },
-            ).mapIndexed { index, noGroupingDataSetElements ->
+            ).mapIndexedNotNull { index, noGroupingDataSetElements ->
                 val mainCellElement = noGroupingDataSetElements.first()
                 val catComboUid = mainCellElement.categoryComboUid ?: dataElementCategoryComboUid(
                     mainCellElement.uid,
@@ -438,6 +438,8 @@ internal class DataSetInstanceRepositoryImpl(
                     .withCategories()
                     .uid(catComboUid)
                     .blockingGet()!!
+
+                if (catCombo.categories()?.isEmpty() == true) return@mapIndexedNotNull null
 
                 val catComboHasPivotedCategory =
                     catCombo.categories()?.any { it.uid() == pivotedCategoryUid } ?: false
@@ -481,9 +483,9 @@ internal class DataSetInstanceRepositoryImpl(
                 .byUid().`in`(catComboUids)
                 .withCategories()
                 .orderByDisplayName(RepositoryScope.OrderByDirection.ASC)
-                .blockingGet().map { catCombo ->
-
-                    val subGroups = catCombo.categories()?.mapNotNull { it.uid() } ?: emptyList()
+                .blockingGet().mapNotNull { catCombo ->
+                    if (catCombo.categories()?.isEmpty() == true) return@mapNotNull null
+                    val subGroups = catCombo.categories()?.mapNotNull { it.uid() } ?: return@mapNotNull null
                     val cellElements = dataSetElementsInSection.filter { dataSetElement ->
                         val catComboUid =
                             dataSetElement.categoryComboUid ?: dataElementCategoryComboUid(

--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -828,7 +828,7 @@ internal class DataSetInstanceRepositoryImpl(
             ?.compulsoryDataElementOperands()
             ?.find {
                 it.dataElement()?.uid() == dataElementUid &&
-                        it.categoryOptionCombo()?.uid() == categoryOptionComboUid
+                    it.categoryOptionCombo()?.uid() == categoryOptionComboUid
             } != null
         val dataElementValueType = dataElement?.valueType()?.toInputType()
         val inputType = requireNotNull(dataElementValueType).takeIf {

--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -39,7 +39,6 @@ import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.dataelement.DataElementOperand
 import org.hisp.dhis.android.core.dataset.DataSetEditableStatus
 import org.hisp.dhis.android.core.dataset.DataSetNonEditableReason
-import org.hisp.dhis.android.core.dataset.Section
 import org.hisp.dhis.android.core.dataset.SectionPivotMode
 import org.hisp.dhis.android.core.dataset.TabsDirection
 import org.hisp.dhis.android.core.maintenance.D2Error
@@ -181,7 +180,35 @@ internal class DataSetInstanceRepositoryImpl(
         dataSetUid: String,
     ) = d2.dataSetModule().sections()
         .byDataSetUid().eq(dataSetUid)
-        .blockingGet().map(Section::toDataSetSection)
+        .blockingGet().map { section ->
+            section.toDataSetSection(
+                misconfiguredRows(dataSetUid, section.uid()),
+            )
+        }
+
+    private fun misconfiguredRows(dataSetUid: String, sectionUid: String): List<String> {
+        val dataSetElements = d2.dataSetModule().dataSets()
+            .withDataSetElements()
+            .uid(dataSetUid)
+            .blockingGet()?.dataSetElements()?.associate {
+                it.dataElement().uid() to it.categoryCombo()?.uid()
+            } ?: emptyMap()
+
+        return d2.dataSetModule().sections().withDataElements()
+            .uid(sectionUid)
+            .blockingGet()?.dataElements()?.mapNotNull {
+                val catComboUid = dataSetElements[it.uid()] ?: it.categoryComboUid()
+                val emptyCategory = d2.categoryModule().categoryCombos().withCategories()
+                    .uid(catComboUid)
+                    .blockingGet()
+                    ?.categories().isNullOrEmpty()
+                if (emptyCategory) {
+                    it.displayFormName()
+                } else {
+                    null
+                }
+            } ?: emptyList()
+    }
 
     override suspend fun isComplete(
         dataSetUid: String,
@@ -485,7 +512,8 @@ internal class DataSetInstanceRepositoryImpl(
                 .orderByDisplayName(RepositoryScope.OrderByDirection.ASC)
                 .blockingGet().mapNotNull { catCombo ->
                     if (catCombo.categories()?.isEmpty() == true) return@mapNotNull null
-                    val subGroups = catCombo.categories()?.mapNotNull { it.uid() } ?: return@mapNotNull null
+                    val subGroups =
+                        catCombo.categories()?.mapNotNull { it.uid() } ?: return@mapNotNull null
                     val cellElements = dataSetElementsInSection.filter { dataSetElement ->
                         val catComboUid =
                             dataSetElement.categoryComboUid ?: dataElementCategoryComboUid(
@@ -800,7 +828,7 @@ internal class DataSetInstanceRepositoryImpl(
             ?.compulsoryDataElementOperands()
             ?.find {
                 it.dataElement()?.uid() == dataElementUid &&
-                    it.categoryOptionCombo()?.uid() == categoryOptionComboUid
+                        it.categoryOptionCombo()?.uid() == categoryOptionComboUid
             } != null
         val dataElementValueType = dataElement?.valueType()?.toInputType()
         val inputType = requireNotNull(dataElementValueType).takeIf {

--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/mappers/SectionToDataSetSection.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/mappers/SectionToDataSetSection.kt
@@ -3,9 +3,10 @@ package org.dhis2.mobile.aggregates.data.mappers
 import org.dhis2.mobile.aggregates.model.DataSetSection
 import org.hisp.dhis.android.core.dataset.Section
 
-internal fun Section.toDataSetSection() = DataSetSection(
+internal fun Section.toDataSetSection(misconfiguredRows: List<String>) = DataSetSection(
     uid = uid(),
     title = displayName()!!,
     topContent = displayOptions()?.beforeSectionText(),
     bottomContent = displayOptions()?.afterSectionText(),
+    misconfiguredRows = misconfiguredRows,
 )

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/model/DataSetSection.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/model/DataSetSection.kt
@@ -5,4 +5,5 @@ internal data class DataSetSection(
     val title: String,
     val topContent: String? = null,
     val bottomContent: String? = null,
+    val misconfiguredRows: List<String>,
 )

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/DataSetTableScreen.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/DataSetTableScreen.kt
@@ -252,9 +252,9 @@ fun DataSetInstanceScreen(
             (dataSetScreenState as? DataSetScreenState.Loaded)?.let { state ->
                 when {
                     state.modalDialog != null ->
-                        ValidationBottomSheet(dataSetUIState = (dataSetScreenState as? DataSetScreenState.Loaded)?.modalDialog!!)
+                    ValidationBottomSheet(dataSetUIState = (dataSetScreenState as? DataSetScreenState.Loaded)?.modalDialog!!)
 
-                    state.validationBar != null ->
+                state.validationBar != null ->
                         ValidationBar(uiState = (dataSetScreenState as? DataSetScreenState.Loaded)?.validationBar!!)
 
                     state.dataSetDetails.isCompleted or !state.dataSetDetails.edition.editable -> {
@@ -579,6 +579,21 @@ private fun DataSetSinglePane(
                                         emptySectionMessage
                                     }
                                     WarningInfoBar(message)
+                                }
+
+                                with(
+                                    dataSetSections.firstOrNull { it.uid == currentSection }?.misconfiguredRows,
+                                ) {
+                                    val message =
+                                        "Some fields couldn't be displayed due to a configuration issue: %s.\nPlease contact your administrator."
+                                    val info = when {
+                                        this != null && size > 4 -> "${joinToString(", ")} and ${size - 4} more"
+                                        this != null -> joinToString(", ")
+                                        else -> null
+                                    }
+                                    if (!this.isNullOrEmpty()) {
+                                        WarningInfoBar(message.format(info))
+                                    }
                                 }
 
                                 dataSetSections.firstOrNull { it.uid == currentSection }?.topContent?.let {

--- a/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/DataSetTableScreen.kt
+++ b/aggregates/src/commonMain/kotlin/org/dhis2/mobile/aggregates/ui/DataSetTableScreen.kt
@@ -252,9 +252,9 @@ fun DataSetInstanceScreen(
             (dataSetScreenState as? DataSetScreenState.Loaded)?.let { state ->
                 when {
                     state.modalDialog != null ->
-                    ValidationBottomSheet(dataSetUIState = (dataSetScreenState as? DataSetScreenState.Loaded)?.modalDialog!!)
+                        ValidationBottomSheet(dataSetUIState = (dataSetScreenState as? DataSetScreenState.Loaded)?.modalDialog!!)
 
-                state.validationBar != null ->
+                    state.validationBar != null ->
                         ValidationBar(uiState = (dataSetScreenState as? DataSetScreenState.Loaded)?.validationBar!!)
 
                     state.dataSetDetails.isCompleted or !state.dataSetDetails.edition.editable -> {

--- a/aggregates/src/commonTest/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModelTest.kt
+++ b/aggregates/src/commonTest/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModelTest.kt
@@ -177,7 +177,11 @@ internal class DataSetTableViewModelTest : KoinTest {
                     edition = DataSetEdition(editable = true, NonEditableReason.None),
                 ),
                 dataSetSections = listOf(
-                    DataSetSection(uid = "sectionUid", title = "sectionTitle"),
+                    DataSetSection(
+                        uid = "sectionUid",
+                        title = "sectionTitle",
+                        misconfiguredRows = emptyList()
+                    ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
                 initialSectionToLoad = 0,
@@ -761,7 +765,11 @@ internal class DataSetTableViewModelTest : KoinTest {
                     edition = DataSetEdition(editable = true, NonEditableReason.None),
                 ),
                 dataSetSections = listOf(
-                    DataSetSection(uid = "sectionUid", title = "sectionTitle"),
+                    DataSetSection(
+                        uid = "sectionUid",
+                        title = "sectionTitle",
+                        misconfiguredRows = emptyList()
+                    ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
                 initialSectionToLoad = 0,
@@ -773,7 +781,10 @@ internal class DataSetTableViewModelTest : KoinTest {
             assertTrue(awaitItem() is DataSetScreenState.Loading)
             with(awaitItem()) {
                 assertTrue(this is DataSetScreenState.Loaded)
-                assertEquals(TextAlignment.LEFT, (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment)
+                assertEquals(
+                    TextAlignment.LEFT,
+                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment
+                )
                 assertEquals("Title", this.dataSetDetails.customTitle.header)
                 assertEquals("Subtitle", this.dataSetDetails.customTitle.subHeader)
             }
@@ -799,7 +810,11 @@ internal class DataSetTableViewModelTest : KoinTest {
                     edition = DataSetEdition(editable = true, NonEditableReason.None),
                 ),
                 dataSetSections = listOf(
-                    DataSetSection(uid = "sectionUid", title = "sectionTitle"),
+                    DataSetSection(
+                        uid = "sectionUid",
+                        title = "sectionTitle",
+                        misconfiguredRows = emptyList()
+                    ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
                 initialSectionToLoad = 0,
@@ -811,7 +826,10 @@ internal class DataSetTableViewModelTest : KoinTest {
             assertTrue(awaitItem() is DataSetScreenState.Loading)
             with(awaitItem()) {
                 assertTrue(this is DataSetScreenState.Loaded)
-                assertEquals(TextAlignment.RIGHT, (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment)
+                assertEquals(
+                    TextAlignment.RIGHT,
+                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment
+                )
             }
         }
     }
@@ -835,7 +853,11 @@ internal class DataSetTableViewModelTest : KoinTest {
                     edition = DataSetEdition(editable = true, NonEditableReason.None),
                 ),
                 dataSetSections = listOf(
-                    DataSetSection(uid = "sectionUid", title = "sectionTitle"),
+                    DataSetSection(
+                        uid = "sectionUid",
+                        title = "sectionTitle",
+                        misconfiguredRows = emptyList()
+                    ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
                 initialSectionToLoad = 0,
@@ -847,7 +869,10 @@ internal class DataSetTableViewModelTest : KoinTest {
             assertTrue(awaitItem() is DataSetScreenState.Loading)
             with(awaitItem()) {
                 assertTrue(this is DataSetScreenState.Loaded)
-                assertEquals(TextAlignment.CENTER, (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment)
+                assertEquals(
+                    TextAlignment.CENTER,
+                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment
+                )
             }
         }
     }

--- a/aggregates/src/commonTest/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModelTest.kt
+++ b/aggregates/src/commonTest/kotlin/org/dhis2/mobile/aggregates/ui/viewModel/DataSetTableViewModelTest.kt
@@ -180,7 +180,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                     DataSetSection(
                         uid = "sectionUid",
                         title = "sectionTitle",
-                        misconfiguredRows = emptyList()
+                        misconfiguredRows = emptyList(),
                     ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
@@ -768,7 +768,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                     DataSetSection(
                         uid = "sectionUid",
                         title = "sectionTitle",
-                        misconfiguredRows = emptyList()
+                        misconfiguredRows = emptyList(),
                     ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
@@ -783,7 +783,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                 assertTrue(this is DataSetScreenState.Loaded)
                 assertEquals(
                     TextAlignment.LEFT,
-                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment
+                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment,
                 )
                 assertEquals("Title", this.dataSetDetails.customTitle.header)
                 assertEquals("Subtitle", this.dataSetDetails.customTitle.subHeader)
@@ -813,7 +813,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                     DataSetSection(
                         uid = "sectionUid",
                         title = "sectionTitle",
-                        misconfiguredRows = emptyList()
+                        misconfiguredRows = emptyList(),
                     ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
@@ -828,7 +828,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                 assertTrue(this is DataSetScreenState.Loaded)
                 assertEquals(
                     TextAlignment.RIGHT,
-                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment
+                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment,
                 )
             }
         }
@@ -856,7 +856,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                     DataSetSection(
                         uid = "sectionUid",
                         title = "sectionTitle",
-                        misconfiguredRows = emptyList()
+                        misconfiguredRows = emptyList(),
                     ),
                 ),
                 dataSetRenderingConfig = DataSetRenderingConfig(useVerticalTabs = true),
@@ -871,7 +871,7 @@ internal class DataSetTableViewModelTest : KoinTest {
                 assertTrue(this is DataSetScreenState.Loaded)
                 assertEquals(
                     TextAlignment.CENTER,
-                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment
+                    (this as DataSetScreenState.Loaded).dataSetDetails.customTitle.textAlignment,
                 )
             }
         }

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
@@ -46,12 +46,12 @@ class TeiDashboardTest : BaseTest() {
 
     override fun setUp() {
         super.setUp()
-        enableIntents()
         setupMockServer()
     }
 
     @Test
     fun shouldSuccessfullyCreateANoteWhenClickCreateNote() {
+        enableIntents()
         mockWebServerRobot.addResponse(
             method = ResponseController.GET,
             path = API_UNIQUE_ID_TRACKED_ENTITY_ATTRIBUTES_RESERVED_VALUES_PATH,
@@ -74,10 +74,12 @@ class TeiDashboardTest : BaseTest() {
             clickOnSaveButton()
             checkNewNoteWasCreated(NOTE_VALID)
         }
+
     }
 
     @Test
     fun shouldNotCreateANoteWhenClickClear() {
+        enableIntents()
         mockWebServerRobot.addResponse(
             method = ResponseController.GET,
             path = API_UNIQUE_ID_TRACKED_ENTITY_ATTRIBUTES_RESERVED_VALUES_PATH,
@@ -361,6 +363,7 @@ class TeiDashboardTest : BaseTest() {
 
     @Test
     fun shouldEnrollToOtherProgramWhenClickOnProgramEnrollments() {
+        enableIntents()
         mockWebServerRobot.addResponse(
             method = ResponseController.GET,
             path = API_UNIQUE_ID_TRACKED_ENTITY_ATTRIBUTES_RESERVED_VALUES_PATH,

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
@@ -46,6 +46,7 @@ class TeiDashboardTest : BaseTest() {
 
     override fun setUp() {
         super.setUp()
+        enableIntents()
         setupMockServer()
     }
 
@@ -385,6 +386,7 @@ class TeiDashboardTest : BaseTest() {
         }
 
         enrollmentRobot(composeTestRule) {
+            checkEnrollmentListIsLaunched()
             clickOnAProgramForEnrollment(composeTestRule, womanProgram)
             clickOnAcceptInDatePicker()
         }

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/TeiDashboardTest.kt
@@ -69,6 +69,7 @@ class TeiDashboardTest : BaseTest() {
 
         noteRobot {
             clickOnFabAddNewNote()
+            verifyNoteDetailActivityIsLaunched()
             typeNote(NOTE_VALID)
             clickOnSaveButton()
             checkNewNoteWasCreated(NOTE_VALID)
@@ -92,6 +93,7 @@ class TeiDashboardTest : BaseTest() {
 
         noteRobot {
             clickOnFabAddNewNote()
+            verifyNoteDetailActivityIsLaunched()
             typeNote(NOTE_INVALID)
             clickOnClearButton()
             clickYesOnAlertDialog()

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/EnrollmentRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/EnrollmentRobot.kt
@@ -13,6 +13,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -21,6 +23,7 @@ import org.dhis2.common.BaseRobot
 import org.dhis2.common.matchers.RecyclerviewMatchers.Companion.atPosition
 import org.dhis2.usescases.flow.teiFlow.entity.EnrollmentListUIModel
 import org.dhis2.usescases.teiDashboard.dashboardfragments.teidata.DashboardProgramViewHolder
+import org.dhis2.usescases.teiDashboard.teiProgramList.TeiProgramListActivity
 import org.dhis2.usescases.teiDashboard.teiProgramList.ui.PROGRAM_TO_ENROLL
 import org.hamcrest.CoreMatchers.allOf
 
@@ -39,6 +42,10 @@ class EnrollmentRobot(val composeTestRule: ComposeTestRule) : BaseRobot() {
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(PROGRAM_TO_ENROLL.format(program), useUnmergedTree = true)
             .performClick()
+    }
+
+    fun checkEnrollmentListIsLaunched() {
+        Intents.intended(allOf(hasComponent(TeiProgramListActivity::class.java.name)))
     }
 
     fun clickOnAcceptInDatePicker() {

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/NoteRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/NoteRobot.kt
@@ -1,11 +1,12 @@
 package org.dhis2.usescases.teidashboard.robot
 
-import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.TypeTextAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -15,6 +16,7 @@ import org.dhis2.common.BaseRobot
 import org.dhis2.common.matchers.RecyclerviewMatchers.Companion.atPosition
 import org.dhis2.common.matchers.RecyclerviewMatchers.Companion.isNotEmpty
 import org.dhis2.usescases.notes.NotesViewHolder
+import org.dhis2.usescases.notes.noteDetail.NoteDetailActivity
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
 
@@ -28,6 +30,10 @@ class NoteRobot : BaseRobot() {
 
     fun clickOnFabAddNewNote() {
         onView(withId(R.id.addNoteButton)).check(matches(isDisplayed())).perform(click())
+    }
+
+    fun verifyNoteDetailActivityIsLaunched() {
+        Intents.intended(allOf(hasComponent(NoteDetailActivity::class.java.name)))
     }
 
     fun clickOnNoteWithPosition(position: Int) {

--- a/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
@@ -122,6 +122,7 @@ class FormViewModel(
                     runDataIntegrityCheck()
                 }
             }
+            FormCountingIdlingResource.decrement()
         }
 
         loadData()

--- a/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FormViewModel.kt
@@ -38,6 +38,7 @@ import org.dhis2.form.model.StoreResult
 import org.dhis2.form.model.UiRenderType
 import org.dhis2.form.model.ValueStoreResult
 import org.dhis2.form.ui.event.RecyclerViewUiEvents
+import org.dhis2.form.ui.idling.FormCountingIdlingResource
 import org.dhis2.form.ui.intent.FormIntent
 import org.dhis2.mobile.commons.validation.validators.FieldMaskValidator
 import org.hisp.dhis.android.core.arch.helpers.Result
@@ -170,6 +171,8 @@ class FormViewModel(
                         handler.postDelayed({
                             processCalculatedItems(skipProgramRules = true)
                         }, 500L)
+                    } else {
+                        FormCountingIdlingResource.decrement()
                     }
                 }
 


### PR DESCRIPTION
## Description
Do not map category option combos with no categories attached

[ jira issue ](https://dhis2.atlassian.net/browse/ANDROAPP-6977

## Solution description
If this PR is a fix include a brief description on how the issue is solved.
## Covered unit test cases
Describe the tests that you ran to verify your changes.
## Where did you test this issue?
- [ ] Smartphone Emulator
- [ ] Tablet Emulator
- [ ] Smartphone
- [ ] Tablet
## Which Android versions did you test this issue?
- [ ] 4.4
- [ ] 5.X - 6.X
- [ ] 7.X
- [ ] 8.X
- [ ] 9.X - 10.X
- [ ] 11.X - 13.X
- [ ] Other
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
