### PR TITLE
fix: [ANDROAPP-6962] Incorrect separator used in inputDialog for parent-child columns

### DIFF
--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -831,6 +831,7 @@ internal class DataSetInstanceRepositoryImpl(
             .uid(dataElementUid)
             .blockingGet()
         val categoryOptionCombo = d2.categoryModule().categoryOptionCombos()
+            .withCategoryOptions()
             .uid(categoryOptionComboUid)
             .blockingGet()
         val isMandatory = d2.dataSetModule().dataSets().withCompulsoryDataElementOperands()
@@ -839,7 +840,7 @@ internal class DataSetInstanceRepositoryImpl(
             ?.compulsoryDataElementOperands()
             ?.find {
                 it.dataElement()?.uid() == dataElementUid &&
-                    it.categoryOptionCombo()?.uid() == categoryOptionComboUid
+                        it.categoryOptionCombo()?.uid() == categoryOptionComboUid
             } != null
         val dataElementValueType = dataElement?.valueType()?.toInputType()
         val inputType = requireNotNull(dataElementValueType).takeIf {
@@ -1122,14 +1123,19 @@ internal class DataSetInstanceRepositoryImpl(
         val isDefaultCategoryCombo = d2.categoryModule().categoryCombos()
             .uid(coc?.categoryCombo()?.uid())
             .blockingGet()
-            ?.isDefault ?: false
+            ?.isDefault == true
+
+        val categoryOptionNames = coc?.categoryOptions()?.mapNotNull {
+            it.displayName() ?: d2.categoryModule().categories().uid(it.uid()).blockingGet()
+                ?.displayName()
+        } ?: emptyList()
 
         val dataElementLabel = dataElement.run { displayFormName() ?: displayName() ?: uid() }
 
         return if (isDefaultCategoryCombo) {
             dataElementLabel
         } else {
-            "$dataElementLabel / ${coc?.displayName()}"
+            (listOf(dataElementLabel) + categoryOptionNames).joinToString(" / ")
         }
     }
 }

--- a/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
+++ b/aggregates/src/androidMain/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImpl.kt
@@ -840,7 +840,7 @@ internal class DataSetInstanceRepositoryImpl(
             ?.compulsoryDataElementOperands()
             ?.find {
                 it.dataElement()?.uid() == dataElementUid &&
-                        it.categoryOptionCombo()?.uid() == categoryOptionComboUid
+                    it.categoryOptionCombo()?.uid() == categoryOptionComboUid
             } != null
         val dataElementValueType = dataElement?.valueType()?.toInputType()
         val inputType = requireNotNull(dataElementValueType).takeIf {

--- a/aggregates/src/androidUnitTest/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImplTest.kt
+++ b/aggregates/src/androidUnitTest/kotlin/org/dhis2/mobile/aggregates/data/DataSetInstanceRepositoryImplTest.kt
@@ -1,0 +1,135 @@
+package org.dhis2.mobile.aggregates.data
+
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.category.CategoryCombo
+import org.hisp.dhis.android.core.category.CategoryOption
+import org.hisp.dhis.android.core.category.CategoryOptionCombo
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.dataelement.DataElement
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DataSetInstanceRepositoryImplTest {
+
+    private val d2: D2 = Mockito.mock(D2::class.java, Mockito.RETURNS_DEEP_STUBS)
+
+    private val repository = DataSetInstanceRepositoryImpl(
+        d2 = d2,
+        periodLabelProvider = mock(),
+        fileController = mock(),
+    )
+
+    @Test
+    fun shouldProvideCorrectDataElementInfoLabel() = runTest {
+        val mockedDataElement: DataElement = mock {
+            on { displayFormName() } doReturn "DataElement Label"
+            on { valueType() } doReturn ValueType.TEXT
+            on { optionSet() } doReturn null
+            on { displayDescription() } doReturn null
+        }
+
+        val mockedCategoryOptions = listOf<CategoryOption>(
+            mock {
+                on { displayName() } doReturn "CatOpt1"
+            },
+            mock {
+                on { displayName() } doReturn "CatOpt2"
+            },
+        )
+
+        val mockedCategoryOptionCombo: CategoryOptionCombo = mock {
+            on { categoryCombo() } doReturn ObjectWithUid.create("catComboUid")
+            on { categoryOptions() } doReturn mockedCategoryOptions
+        }
+        whenever(
+            d2.dataElementModule().dataElements()
+                .uid(any())
+                .blockingGet(),
+        ) doReturn mockedDataElement
+
+        whenever(
+            d2.categoryModule().categoryOptionCombos()
+                .withCategoryOptions()
+                .uid(any())
+                .blockingGet(),
+        ) doReturn mockedCategoryOptionCombo
+
+        whenever(
+            d2.dataSetModule().dataSets().withCompulsoryDataElementOperands()
+                .uid(any())
+                .blockingGet(),
+        ) doReturn null
+
+        val mockedCategoryCombo: CategoryCombo = mock {
+            on { isDefault } doReturn false
+        }
+        whenever(
+            d2.categoryModule().categoryCombos()
+                .uid(any())
+                .blockingGet(),
+        )doReturn mockedCategoryCombo
+
+        val result = repository.dataElementInfo("dataSetUid", "dataElementUid", "catOptComboUid")
+
+        assertEquals("DataElement Label / CatOpt1 / CatOpt2", result.label)
+    }
+
+    @Test
+    fun shouldProvideCorrectDataElementInfoLabelForDefaultCatCombo() = runTest {
+        val mockedDataElement: DataElement = mock {
+            on { displayFormName() } doReturn "DataElement Label"
+            on { valueType() } doReturn ValueType.TEXT
+            on { optionSet() } doReturn null
+            on { displayDescription() } doReturn null
+        }
+
+        val mockedCategoryOptions = listOf<CategoryOption>(
+            mock {
+                on { displayName() } doReturn "default"
+            },
+        )
+
+        val mockedCategoryOptionCombo: CategoryOptionCombo = mock {
+            on { categoryCombo() } doReturn ObjectWithUid.create("catComboUid")
+            on { categoryOptions() } doReturn mockedCategoryOptions
+        }
+        whenever(
+            d2.dataElementModule().dataElements()
+                .uid(any())
+                .blockingGet(),
+        ) doReturn mockedDataElement
+
+        whenever(
+            d2.categoryModule().categoryOptionCombos()
+                .withCategoryOptions()
+                .uid(any())
+                .blockingGet(),
+        ) doReturn mockedCategoryOptionCombo
+
+        whenever(
+            d2.dataSetModule().dataSets().withCompulsoryDataElementOperands()
+                .uid(any())
+                .blockingGet(),
+        ) doReturn null
+
+        val mockedCategoryCombo: CategoryCombo = mock {
+            on { isDefault } doReturn true
+        }
+        whenever(
+            d2.categoryModule().categoryCombos()
+                .uid(any())
+                .blockingGet(),
+        )doReturn mockedCategoryCombo
+
+        val result = repository.dataElementInfo("dataSetUid", "dataElementUid", "catOptComboUid")
+
+        assertEquals("DataElement Label", result.label)
+    }
+}


### PR DESCRIPTION
## Description

Summarize the change and link
the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-6962).

## Solution Description

Briefly describe how the issue is resolved.

## Title Format

`<type>: [JIRA-ISSUE] Description`

- `<type>` Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g., `fix`, `feat`).
- Add the **JIRA issue number** in `[ANDROAPP-XXXX]`.
- Include a brief description.
- Append `[skip ci]` to skip CI if needed.
- Append `[skip size]` to skip PR size limitation.