### PR TITLE
chore: Update snapshots url in build.gradle.kts

### DIFF
--- a/aggregates/build.gradle.kts
+++ b/aggregates/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 repositories{
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
     mavenCentral()
     google()
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 apply(from = "${project.rootDir}/jacoco/jacoco.gradle.kts")
 
 repositories {
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
     mavenCentral()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.util.Locale
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
         google()
     }
     dependencies {
@@ -62,7 +62,7 @@ allprojects {
     }
 
     repositories {
-        maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
         google()
         mavenCentral()
         maven {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 apply(from = "${project.rootDir}/jacoco/jacoco.gradle.kts")
 
 repositories {
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 }
 
 android {

--- a/commonskmm/build.gradle.kts
+++ b/commonskmm/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 
 repositories{
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
     mavenCentral()
     google()
 }

--- a/dhis_android_analytics/build.gradle.kts
+++ b/dhis_android_analytics/build.gradle.kts
@@ -10,7 +10,7 @@ apply(from = "${project.rootDir}/jacoco/jacoco.gradle.kts")
 
 repositories {
     maven { url = uri("https://jitpack.io") }
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 }
 
 android {

--- a/form/build.gradle.kts
+++ b/form/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 apply(from = "${project.rootDir}/jacoco/jacoco.gradle.kts")
 
 repositories {
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 }
 
 android {

--- a/stock-usecase/build.gradle.kts
+++ b/stock-usecase/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 apply(from = "${project.rootDir}/jacoco/jacoco.gradle.kts")
 
 repositories {
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 }
 
 base {


### PR DESCRIPTION
## Description

As a consequence of the migration to a new publishing portal, the SNAPSHOT artifacts are now located in a different repository. This PR updates the url of the snapshot repository.

## Solution Description

Just update the url of the snapshot repository.
