### PR TITLE
chore: [ANDROAPP-7156] replace use of _id with Primary Keys

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/development/ConflictGenerator.kt
+++ b/app/src/main/java/org/dhis2/usescases/development/ConflictGenerator.kt
@@ -114,10 +114,10 @@ class ConflictGenerator(private val d2: D2) {
                         DataValueTableInfo.TABLE_INFO.name(),
                         cv,
                         "dataElement = ${dataValue?.dataElement()} AND " +
-                        "period = ${dataValue?.period()} AND " +
-                        "orgUnit = ${dataValue?.organisationUnit()} AND " +
-                        "categoryOptionCombo = ${dataValue?.categoryOptionCombo()} AND " +
-                        "attributeOptionCombo = ${dataValue?.attributeOptionCombo()}",
+                            "period = ${dataValue?.period()} AND " +
+                            "orgUnit = ${dataValue?.organisationUnit()} AND " +
+                            "categoryOptionCombo = ${dataValue?.categoryOptionCombo()} AND " +
+                            "attributeOptionCombo = ${dataValue?.attributeOptionCombo()}",
                         emptyArray(),
                     )
                 }
@@ -342,10 +342,10 @@ class ConflictGenerator(private val d2: D2) {
                 DataValueTableInfo.TABLE_INFO.name(),
                 updatedDataValueCV,
                 "dataElement = ${attributeValue.dataElement()} AND " +
-                        "period = ${attributeValue.period()} AND " +
-                        "orgUnit = ${attributeValue.organisationUnit()} AND " +
-                        "categoryOptionCombo = ${attributeValue.categoryOptionCombo()} AND " +
-                        "attributeOptionCombo = ${attributeValue.attributeOptionCombo()}",
+                    "period = ${attributeValue.period()} AND " +
+                    "orgUnit = ${attributeValue.organisationUnit()} AND " +
+                    "categoryOptionCombo = ${attributeValue.categoryOptionCombo()} AND " +
+                    "attributeOptionCombo = ${attributeValue.attributeOptionCombo()}",
                 emptyArray(),
             )
         } catch (e: Exception) {
@@ -375,10 +375,10 @@ class ConflictGenerator(private val d2: D2) {
                 DataValueTableInfo.TABLE_INFO.name(),
                 updatedDataValueCV,
                 "dataElement = ${attributeValue.dataElement()} AND " +
-                        "period = ${attributeValue.period()} AND " +
-                        "orgUnit = ${attributeValue.organisationUnit()} AND " +
-                        "categoryOptionCombo = ${attributeValue.categoryOptionCombo()} AND " +
-                        "attributeOptionCombo = ${attributeValue.attributeOptionCombo()}",
+                    "period = ${attributeValue.period()} AND " +
+                    "orgUnit = ${attributeValue.organisationUnit()} AND " +
+                    "categoryOptionCombo = ${attributeValue.categoryOptionCombo()} AND " +
+                    "attributeOptionCombo = ${attributeValue.attributeOptionCombo()}",
                 emptyArray(),
             )
         } catch (e: Exception) {

--- a/app/src/main/java/org/dhis2/usescases/development/ConflictGenerator.kt
+++ b/app/src/main/java/org/dhis2/usescases/development/ConflictGenerator.kt
@@ -113,7 +113,11 @@ class ConflictGenerator(private val d2: D2) {
                     d2.databaseAdapter().update(
                         DataValueTableInfo.TABLE_INFO.name(),
                         cv,
-                        "_id = ${dataValue?.id()}",
+                        "dataElement = ${dataValue?.dataElement()} AND " +
+                        "period = ${dataValue?.period()} AND " +
+                        "orgUnit = ${dataValue?.organisationUnit()} AND " +
+                        "categoryOptionCombo = ${dataValue?.categoryOptionCombo()} AND " +
+                        "attributeOptionCombo = ${dataValue?.attributeOptionCombo()}",
                         emptyArray(),
                     )
                 }
@@ -337,7 +341,11 @@ class ConflictGenerator(private val d2: D2) {
             d2.databaseAdapter().update(
                 DataValueTableInfo.TABLE_INFO.name(),
                 updatedDataValueCV,
-                "_id = ${attributeValue.id()}",
+                "dataElement = ${attributeValue.dataElement()} AND " +
+                        "period = ${attributeValue.period()} AND " +
+                        "orgUnit = ${attributeValue.organisationUnit()} AND " +
+                        "categoryOptionCombo = ${attributeValue.categoryOptionCombo()} AND " +
+                        "attributeOptionCombo = ${attributeValue.attributeOptionCombo()}",
                 emptyArray(),
             )
         } catch (e: Exception) {
@@ -366,7 +374,11 @@ class ConflictGenerator(private val d2: D2) {
             d2.databaseAdapter().update(
                 DataValueTableInfo.TABLE_INFO.name(),
                 updatedDataValueCV,
-                "_id = ${attributeValue.id()}",
+                "dataElement = ${attributeValue.dataElement()} AND " +
+                        "period = ${attributeValue.period()} AND " +
+                        "orgUnit = ${attributeValue.organisationUnit()} AND " +
+                        "categoryOptionCombo = ${attributeValue.categoryOptionCombo()} AND " +
+                        "attributeOptionCombo = ${attributeValue.attributeOptionCombo()}",
                 emptyArray(),
             )
         } catch (e: Exception) {

--- a/app/src/test/java/org/dhis2/data/filter/FilterRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/data/filter/FilterRepositoryTest.kt
@@ -524,7 +524,7 @@ class FilterRepositoryTest {
         filterType: String,
         show: Boolean = true,
     ): FilterSetting {
-        return FilterSetting.builder().filter(show).filterType(filterType).id(25)
+        return FilterSetting.builder().filter(show).filterType(filterType)
             .scope(scope).sort(show).build()
     }
 

--- a/app/src/test/java/org/dhis2/usescases/about/AboutPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/about/AboutPresenterTest.kt
@@ -39,7 +39,6 @@ class AboutPresenterTest {
     fun `Should print user credentials in view`() {
         val user = User.builder()
             .uid(UUID.randomUUID().toString())
-            .id(6654654)
             .username("demo@demo.es")
             .build()
         whenever(userRepository.credentials()) doReturn Flowable.just(user)

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/DashboardRepositoryImplTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/DashboardRepositoryImplTest.kt
@@ -294,17 +294,14 @@ class DashboardRepositoryImplTest {
             teiAttributesProvider.getValuesFromTrackedEntityTypeAttributes(teType, teiUid),
         ) doReturn arrayListOf(
             TrackedEntityAttributeValue.builder()
-                .id(1)
                 .value("attrValue1")
                 .trackedEntityAttribute("attr1")
                 .build(),
             TrackedEntityAttributeValue.builder()
-                .id(2)
                 .value("attrValue2")
                 .trackedEntityAttribute("attr2")
                 .build(),
             TrackedEntityAttributeValue.builder()
-                .id(3)
                 .value("attrValue4")
                 .trackedEntityAttribute("attr4")
                 .build(),
@@ -365,17 +362,14 @@ class DashboardRepositoryImplTest {
             teiAttributesProvider.getValuesFromProgramTrackedEntityAttributes(teType, teiUid),
         ) doReturn arrayListOf(
             TrackedEntityAttributeValue.builder()
-                .id(1)
                 .value("attrValue1")
                 .trackedEntityAttribute("attr1")
                 .build(),
             TrackedEntityAttributeValue.builder()
-                .id(2)
                 .value("attrValue2")
                 .trackedEntityAttribute("attr2")
                 .build(),
             TrackedEntityAttributeValue.builder()
-                .id(3)
                 .value("attrValue3")
                 .trackedEntityAttribute("attr3")
                 .build(),

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/TeiAttributesProviderTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/TeiAttributesProviderTest.kt
@@ -243,21 +243,18 @@ class TeiAttributesProviderTest {
     private fun trackedEntityTypeAttributes(): List<TrackedEntityTypeAttribute> {
         return arrayListOf(
             TrackedEntityTypeAttribute.builder()
-                .id(1)
                 .displayInList(true)
                 .searchable(true)
                 .trackedEntityType(ObjectWithUid.create("teType"))
                 .trackedEntityAttribute(ObjectWithUid.create("attr1"))
                 .build(),
             TrackedEntityTypeAttribute.builder()
-                .id(2)
                 .displayInList(true)
                 .searchable(true)
                 .trackedEntityType(ObjectWithUid.create("teType"))
                 .trackedEntityAttribute(ObjectWithUid.create("attr2"))
                 .build(),
             TrackedEntityTypeAttribute.builder()
-                .id(4)
                 .searchable(true)
                 .displayInList(true)
                 .trackedEntityType(ObjectWithUid.create("teType"))
@@ -269,17 +266,14 @@ class TeiAttributesProviderTest {
     private fun trackedEntityAttributeValues(): List<TrackedEntityAttributeValue> {
         return arrayListOf(
             TrackedEntityAttributeValue.builder()
-                .id(1)
                 .value("attrValue1")
                 .trackedEntityAttribute("attr1")
                 .build(),
             TrackedEntityAttributeValue.builder()
-                .id(2)
                 .value("attrValue2")
                 .trackedEntityAttribute("attr2")
                 .build(),
             TrackedEntityAttributeValue.builder()
-                .id(3)
                 .value("attrValue3")
                 .trackedEntityAttribute("attr3")
                 .build(),

--- a/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/DataElementFactory.kt
+++ b/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/DataElementFactory.kt
@@ -6,7 +6,6 @@ object DataElementFactory {
 
     fun create(uid: String, name: String): DataElement {
         return DataElement.builder()
-            .id(55)
             .uid(uid)
             .name(name)
             .displayName(name).build()

--- a/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/DestinationFactory.kt
+++ b/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/DestinationFactory.kt
@@ -13,7 +13,6 @@ object DestinationFactory {
         val name = faker.address().streetName()
 
         return Option.builder()
-            .id(id)
             .uid(uidGenerator.generate())
             .name(name)
             .displayName(name).build()

--- a/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/FacilityFactory.kt
+++ b/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/FacilityFactory.kt
@@ -13,7 +13,6 @@ object FacilityFactory {
         val name = faker.address().streetName()
 
         return OrganisationUnit.builder()
-            .id(id)
             .uid(uidGenerator.generate())
             .name(name)
             .displayName(name).build()

--- a/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/GroupAnalyticsFactory.kt
+++ b/stock-usecase/src/test/java/org/dhis2/android/rtsm/data/GroupAnalyticsFactory.kt
@@ -34,7 +34,6 @@ object VisualizationsFactory {
         val name = faker.address().streetName()
 
         return AnalyticsDhisVisualization.builder()
-            .id(id)
             .name(name)
             .uid(uidGenerator.generate())
             .type(AnalyticsDhisVisualizationType.VISUALIZATION)


### PR DESCRIPTION
## Description

Remove uses of CoreObject _id  coming from SDK database objects
the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7156).

## Solution Description

In the context of upgrading the database to a KMP solution, the explicit index columns “_id” have been removed from the SDK. There are three usages of this column in the App that need to be addressed right after the corresponding PR from the SDK has been merged to avoid blocking the App ci pipelines.
## Title Format
