### PR TITLE
feat: [ANDROAPP-7164] Evaluate custom intent request parameters

### DIFF
--- a/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/model/CustomIntentModel.kt
+++ b/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/model/CustomIntentModel.kt
@@ -10,7 +10,7 @@ data class CustomIntentModel(
 
 data class CustomIntentRequestArgumentModel(
     val key: String,
-    val value: String,
+    val value: Any,
 )
 
 data class CustomIntentResponseDataModel(

--- a/form/src/main/java/org/dhis2/form/data/DataEntryBaseRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/DataEntryBaseRepository.kt
@@ -84,7 +84,7 @@ abstract class DataEntryBaseRepository(
     }
 
     private fun getFilteredCustomIntents(uid: String?): List<CustomIntent?> {
-        return conf.customIntents().filter { customIntent ->
+        return conf.customIntents.filter { customIntent ->
             customIntent?.trigger()?.attributes()?.any { it.uid() == uid } == true ||
                 customIntent?.trigger()?.dataElements()?.any { it.uid() == uid } == true
         }

--- a/form/src/main/java/org/dhis2/form/data/DataEntryBaseRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/DataEntryBaseRepository.kt
@@ -5,7 +5,6 @@ package org.dhis2.form.data
 import androidx.compose.ui.graphics.Color
 import androidx.paging.PagingData
 import androidx.paging.map
-import io.ktor.http.parameters
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -100,7 +99,7 @@ abstract class DataEntryBaseRepository(
                 param.value?.let { value ->
                     CustomIntentRequestArgumentModel(
                         key = param.key,
-                        value = value
+                        value = value,
                     )
                 }
             }

--- a/form/src/main/java/org/dhis2/form/data/EnrollmentRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EnrollmentRepository.kt
@@ -29,6 +29,7 @@ import org.hisp.dhis.android.core.imports.ImportStatus
 import org.hisp.dhis.android.core.program.ProgramSection
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
 import org.hisp.dhis.android.core.program.SectionRenderingType
+import org.hisp.dhis.android.core.settings.CustomIntentContext
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 import org.hisp.dhis.mobile.ui.designsystem.component.SelectableDates
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
@@ -168,8 +169,11 @@ class EnrollmentRepository(
                 programTrackedEntityAttribute.trackedEntityAttribute()?.uid(),
             ),
         )
-        val attributeCustomIntent =
-            getCustomIntentFromUid(programTrackedEntityAttribute.trackedEntityAttribute()?.uid())
+        val customIntentContext = CustomIntentContext(programUid, null)
+        val attributeCustomIntent = getCustomIntentFromUid(
+            uid = programTrackedEntityAttribute.trackedEntityAttribute()?.uid(),
+            context = customIntentContext,
+        )
 
         val valueType = attribute.valueType()
         var mandatory = programTrackedEntityAttribute.mandatory() ?: false

--- a/form/src/main/java/org/dhis2/form/data/EventRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EventRepository.kt
@@ -49,6 +49,7 @@ import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.ProgramStageDataElement
 import org.hisp.dhis.android.core.program.ProgramStageSection
 import org.hisp.dhis.android.core.program.SectionRenderingType
+import org.hisp.dhis.android.core.settings.CustomIntentContext
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 
 class EventRepository(
@@ -545,7 +546,8 @@ class EventRepository(
             programStageDataElement.dataElement()!!.uid(),
         ).blockingGet()
         val uid = de?.uid() ?: ""
-        val customIntent = getCustomIntentFromUid(uid)
+        val customIntentContext = CustomIntentContext(programUid, programStage?.uid())
+        val customIntent = getCustomIntentFromUid(uid, customIntentContext)
         val displayName = de?.displayName() ?: ""
         val valueType = de?.valueType()
         val mandatory = programStageDataElement.compulsory() ?: false

--- a/form/src/main/java/org/dhis2/form/data/metadata/FormBaseConfiguration.kt
+++ b/form/src/main/java/org/dhis2/form/data/metadata/FormBaseConfiguration.kt
@@ -2,6 +2,7 @@ package org.dhis2.form.data.metadata
 
 import androidx.paging.PagingData
 import androidx.paging.filter
+import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -15,6 +16,7 @@ import org.hisp.dhis.android.core.option.Option
 import org.hisp.dhis.android.core.settings.CustomIntent
 import org.hisp.dhis.android.core.settings.CustomIntentActionType
 import org.hisp.dhis.android.core.settings.CustomIntentAttribute
+import org.hisp.dhis.android.core.settings.CustomIntentContext
 import org.hisp.dhis.android.core.settings.CustomIntentDataElement
 import org.hisp.dhis.android.core.settings.CustomIntentRequest
 import org.hisp.dhis.android.core.settings.CustomIntentRequestArgument
@@ -75,9 +77,9 @@ open class FormBaseConfiguration(
                 .request(
                     CustomIntentRequest.builder().arguments(
                         listOf(
-                            CustomIntentRequestArgument.builder().key("projectId").value("testDhisProjectId").build(),
-                            CustomIntentRequestArgument.builder().key("moduleId").value("testDhisModuleId").build(),
-                            CustomIntentRequestArgument.builder().key("userId").value("testDhisUserId").build(),
+                            CustomIntentRequestArgument.builder().key("projectId").value("'testDhisProjectId'").build(),
+                            CustomIntentRequestArgument.builder().key("moduleId").value("'testDhisModuleId'").build(),
+                            CustomIntentRequestArgument.builder().key("userId").value("'testDhisUserId'").build(),
                         ),
                     ).build(),
                 )
@@ -118,9 +120,9 @@ open class FormBaseConfiguration(
                 .request(
                     CustomIntentRequest.builder().arguments(
                         listOf(
-                            CustomIntentRequestArgument.builder().key("projectId").value("testDhisProjectId").build(),
-                            CustomIntentRequestArgument.builder().key("moduleId").value("testDhisModuleId").build(),
-                            CustomIntentRequestArgument.builder().key("userId").value("testDhisUserId").build(),
+                            CustomIntentRequestArgument.builder().key("projectId").value("'testDhisProjectId'").build(),
+                            CustomIntentRequestArgument.builder().key("moduleId").value("'testDhisModuleId'").build(),
+                            CustomIntentRequestArgument.builder().key("userId").value("'testDhisUserId'").build(),
                         ),
                     ).build(),
                 )
@@ -141,6 +143,14 @@ open class FormBaseConfiguration(
                         .build(),
                 ).build(),
         )
+    }
+
+    fun evaluateCustomIntentRequestParams(
+        customIntent: CustomIntent,
+        context: CustomIntentContext
+    ): Map<String, Any?> {
+        return d2.settingModule().customIntentService()
+            .blockingEvaluateRequestParams(customIntent, context)
     }
 
     fun disableCollapsableSectionsInProgram(programUid: String) =

--- a/form/src/main/java/org/dhis2/form/data/metadata/FormBaseConfiguration.kt
+++ b/form/src/main/java/org/dhis2/form/data/metadata/FormBaseConfiguration.kt
@@ -35,7 +35,7 @@ open class FormBaseConfiguration(
         .byUid().`in`(optionGroupUids)
         .blockingGet()
 
-    fun customIntents(): List<CustomIntent?> = if (featureConfig.isFeatureEnable(Feature.CUSTOM_INTENTS)) {
+    val customIntents: List<CustomIntent?> = if (featureConfig.isFeatureEnable(Feature.CUSTOM_INTENTS)) {
         getMockedCustomIntents()
     } else {
         d2.settingModule().customIntents()

--- a/form/src/main/java/org/dhis2/form/data/metadata/FormBaseConfiguration.kt
+++ b/form/src/main/java/org/dhis2/form/data/metadata/FormBaseConfiguration.kt
@@ -2,7 +2,6 @@ package org.dhis2.form.data.metadata
 
 import androidx.paging.PagingData
 import androidx.paging.filter
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -147,7 +146,7 @@ open class FormBaseConfiguration(
 
     fun evaluateCustomIntentRequestParams(
         customIntent: CustomIntent,
-        context: CustomIntentContext
+        context: CustomIntentContext,
     ): Map<String, Any?> {
         return d2.settingModule().customIntentService()
             .blockingEvaluateRequestParams(customIntent, context)

--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/CustomIntentProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/CustomIntentProvider.kt
@@ -112,7 +112,15 @@ fun ProvideCustomIntentInput(
 fun mapIntentData(customIntent: CustomIntentModel): Intent {
     return Intent(customIntent.packageName).apply {
         customIntent.customIntentRequest.forEach { argument ->
-            putExtra(argument.key, argument.value)
+            when (val value = argument.value) {
+                is String -> putExtra(argument.key, value)
+                is Int -> putExtra(argument.key, value)
+                is Double -> putExtra(argument.key, value)
+                is Long -> putExtra(argument.key, value)
+                is Short -> putExtra(argument.key, value)
+                is Boolean -> putExtra(argument.key, value)
+                else -> putExtra(argument.key, value.toString())
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This is a draft PR for [ANDROAPP-7164](https://dhis2.atlassian.net/browse/ANDROAPP-7164) just to discuss about the proposed solution. This PR shouldn't be merged as it is.

## Solution Description

It uses the DHIS2 Android SDK to evaluate the custom intent request parameters. The purpose of this evaluation is to be able to use variables and different value types in the parameters.

The parameters are evaluated when the form is built, which means that they are not re-evaluated when the form is been filled in. This might be a problem for certain variables: for example, if we add the variable `V{org_unit_id}` and the orgunit changes after the form is built, the parameter will still have the value from the previous orgunit. 

Ideally, this evaluation should be done right before launching the intent. Do you think it would be possible?


[ANDROAPP-7164]: https://dhis2.atlassian.net/browse/ANDROAPP-7164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ