### PR TITLE
fix(dependabot): add additional dependencies to ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,9 @@ updates:
     commit-message:
       prefix: "deps"
     ignore:
-      - dependency-name: "com.squareup.okhttp3:*"      
+      - dependency-name: "com.squareup.okhttp3:*"
+      - dependency-name: "org.hisp.dhis.mobile:designsystem:*"
+      - dependency-name: "org.hisp.dhis:android-core:*"
     groups:
       gradle-updates:
         patterns:


### PR DESCRIPTION
## Description

Ignore DHIS2 Android SDK and DHIS2 Mobile Design system updates, these will be handled manually by us.