### PR TITLE
fix: add wildcard ignore "-" for all dependencies in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     commit-message:
       prefix: "deps"
     ignore:
+      - dependency-name: "*"
+        versions: ["*+*"]
       - dependency-name: "com.squareup.okhttp3:*"
       - dependency-name: "org.hisp.dhis.mobile:designsystem"
         update-types:


### PR DESCRIPTION
## Description

ignore "*-*" versions updates.
These version should denote build metadata. For stability, it is generally recommended to use the official release version without the build metadata 