### PR TITLE
fix: [ANDROAPP-7202] remove scrollableContent from ListCardProvider

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/ui/ListCardProvider.kt
+++ b/commons/src/main/java/org/dhis2/commons/ui/ListCardProvider.kt
@@ -49,7 +49,6 @@ fun ListCardProvider(
                             ),
                         expandLabelText = card.expandLabelText,
                         shrinkLabelText = card.shrinkLabelText,
-                        scrollableContent = true,
                     ),
                 loading = false,
                 expandable = false,


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7202).

Remove scrollable content to avoid crash when expanding card