### PR TITLE
fix: [ANDROAPP-7177] Display overdue events in TEI list correctly

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -438,13 +438,13 @@ public class SearchRepositoryImpl implements SearchRepository {
 
         List<Event> filteredScheduled = new ArrayList<>();
         for (Event event : scheduledList) {
-            if (dateUtils.isEventDueDateOverdue(event.dueDate())) {
+            if (Boolean.TRUE.equals(dateUtils.isEventDueDateOverdue(event.dueDate()))) {
                 filteredScheduled.add(event);
             }
         }
 
         for (Event event : overdueList) {
-            if (dateUtils.isEventDueDateOverdue(event.dueDate())) {
+            if (Boolean.TRUE.equals(dateUtils.isEventDueDateOverdue(event.dueDate()))) {
                 filteredScheduled.add(event);
             }
         }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -1,10 +1,8 @@
 package org.dhis2.usescases.searchTrackEntity;
 
 import android.database.sqlite.SQLiteConstraintException;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import org.dhis2.R;
 import org.dhis2.bindings.ExtensionsKt;
 import org.dhis2.bindings.ValueExtensionsKt;

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEModule.java
@@ -156,7 +156,8 @@ public class SearchTEModule {
                                       NetworkUtils networkUtils,
                                       SearchTEIRepository searchTEIRepository,
                                       ThemeManager themeManager,
-                                      MetadataIconProvider metadataIconProvider) {
+                                      MetadataIconProvider metadataIconProvider,
+                                      DateUtils dateUtils) {
         ProfilePictureProvider profilePictureProvider = new ProfilePictureProvider(d2);
         return new SearchRepositoryImpl(teiType,
                 initialProgram,
@@ -171,7 +172,8 @@ public class SearchTEModule {
                 searchTEIRepository,
                 themeManager,
                 metadataIconProvider,
-                profilePictureProvider);
+                profilePictureProvider,
+                dateUtils);
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TeiDataRepositoryImpl.kt
@@ -18,7 +18,6 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventCollectionRepository
-import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.program.Program
@@ -261,7 +260,7 @@ class TeiDataRepositoryImpl(
                                 ),
                         ),
                     )
-                    checkEventStatus(eventList)
+                    eventList
                         .take(
                             if (showAllEvents) eventList.size else maxEventToShow,
                         ).forEachIndexed { index, event ->
@@ -355,7 +354,7 @@ class TeiDataRepositoryImpl(
             .isFalse
             .get()
             .map { eventList ->
-                checkEventStatus(eventList)
+                eventList
                     .take(
                         if (showAllEvents) eventList.size else maxEventToShow,
                     ).forEachIndexed { _, event ->
@@ -464,26 +463,6 @@ class TeiDataRepositoryImpl(
                 .blockingGet()
         }
     }
-
-    private fun checkEventStatus(events: List<Event>): List<Event> =
-        events.mapNotNull { event ->
-            if (event.status() == EventStatus.SCHEDULE &&
-                dateUtils.isEventDueDateOverdue(event.dueDate())
-            ) {
-                d2
-                    .eventModule()
-                    .events()
-                    .uid(event.uid())
-                    .setStatus(EventStatus.OVERDUE)
-                d2
-                    .eventModule()
-                    .events()
-                    .uid(event.uid())
-                    .blockingGet()
-            } else {
-                event
-            }
-        }
 
     private fun getEventValues(
         eventUid: String,

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
@@ -189,7 +189,7 @@ class SearchRepositoryTest {
         val events =
             listOf(
                 createEvent("eventUid", EventStatus.OVERDUE, overdueDate.time),
-                createEvent("eventUid", EventStatus.SCHEDULE, Date()),
+                createEvent("eventUid", EventStatus.SCHEDULE, overdueDate.time),
             )
 
         mockedSdkCalls(searchItem, tei, enrollmentsInProgram, allEnrollments, events)
@@ -221,7 +221,7 @@ class SearchRepositoryTest {
             )
         val events =
             listOf(
-                createEvent("eventUid", EventStatus.SCHEDULE, Date()),
+                createEvent("eventUid", EventStatus.SCHEDULE, overdueDate.time),
             )
 
         mockedSdkCalls(searchItem, tei, enrollmentsInProgram, allEnrollments, events)

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
@@ -98,6 +98,7 @@ class SearchRepositoryTest {
     private val searchTEIRepository: SearchTEIRepository = mock()
     private val themeManager: ThemeManager = mock()
     private val profilePictureProvider: ProfilePictureProvider = mock()
+    private val dateUtils: DateUtils = DateUtils()
 
     @Before
     fun setUp() {
@@ -144,6 +145,7 @@ class SearchRepositoryTest {
                 themeManager,
                 metadataIconProvider,
                 profilePictureProvider,
+                dateUtils,
             )
     }
 
@@ -171,7 +173,7 @@ class SearchRepositoryTest {
         val sorting = SortingItem.create(Filters.ENROLLMENT_DATE)
         val tei = TrackedEntitySearchItemHelper.toTrackedEntityInstance(searchItem)
 
-        val overdueDate = DateUtils.getInstance().getCalendarByDate(Date())
+        val overdueDate = dateUtils.getCalendarByDate(Date())
         overdueDate.add(Calendar.DATE, -2)
 
         val enrollmentsInProgram =
@@ -198,13 +200,13 @@ class SearchRepositoryTest {
     }
 
     @Test
-    fun shouldTransformToSearchTeiModelWithOutOverdueEvents() {
+    fun shouldTransformToSearchTeiModelWithOverdueScheduledEvents() {
         val searchItem = getTrackedEntitySearchItem("header")
         val program = Program.builder().uid("programUid").build()
         val sorting = SortingItem.create(Filters.ENROLLMENT_DATE)
         val tei = TrackedEntitySearchItemHelper.toTrackedEntityInstance(searchItem)
 
-        val overdueDate = DateUtils.getInstance().getCalendarByDate(Date())
+        val overdueDate = dateUtils.getCalendarByDate(Date())
         overdueDate.add(Calendar.DATE, -2)
 
         val enrollmentsInProgram =
@@ -220,6 +222,38 @@ class SearchRepositoryTest {
         val events =
             listOf(
                 createEvent("eventUid", EventStatus.SCHEDULE, Date()),
+            )
+
+        mockedSdkCalls(searchItem, tei, enrollmentsInProgram, allEnrollments, events)
+
+        val result = searchRepositoryJava.transform(searchItem, program, true, sorting)
+
+        assertTrue(result.isHasOverdue)
+    }
+
+    @Test
+    fun shouldTransformToSearchTeiModelWithOutOverdueEvents() {
+        val searchItem = getTrackedEntitySearchItem("header")
+        val program = Program.builder().uid("programUid").build()
+        val sorting = SortingItem.create(Filters.ENROLLMENT_DATE)
+        val tei = TrackedEntitySearchItemHelper.toTrackedEntityInstance(searchItem)
+
+        val overdueDate = dateUtils.getCalendarByDate(Date())
+        overdueDate.add(Calendar.DATE, 2)
+
+        val enrollmentsInProgram =
+            listOf(
+                createEnrollment("enrollmentUid", "orgUnit", program.uid()),
+                createEnrollment("enrollmentUid_2", "orgUnit", program.uid()),
+            )
+        val allEnrollments =
+            listOf(
+                createEnrollment("enrollmentUid_3", "orgUnit", "uid"),
+                createEnrollment("enrollmentUid_4", "orgUnit_2", "uid"),
+            )
+        val events =
+            listOf(
+                createEvent("eventUid", EventStatus.SCHEDULE, overdueDate.time),
             )
 
         mockedSdkCalls(searchItem, tei, enrollmentsInProgram, allEnrollments, events)
@@ -354,7 +388,11 @@ class SearchRepositoryTest {
         whenever(
             eventCollectionRepository.blockingGet(),
         ) doReturn eventsToReturn.filter { it.status() == EventStatus.OVERDUE }
-
+        whenever(enumEventFilterConnector.eq(EventStatus.SCHEDULE)).thenReturn(eventCollectionRepository)
+        whenever(eventCollectionRepository.byStatus().eq(EventStatus.SCHEDULE)).thenReturn(eventCollectionRepository)
+        whenever(eventCollectionRepository.byProgramUid().eq(any())).thenReturn(eventCollectionRepository)
+        whenever(eventCollectionRepository.orderByDueDate(RepositoryScope.OrderByDirection.DESC)).thenReturn(eventCollectionRepository)
+        whenever(eventCollectionRepository.blockingGet()).thenReturn(eventsToReturn.filter { it.status() == EventStatus.SCHEDULE })
         // mock orgUnitName(orgUnitUid)
         whenever(d2.organisationUnitModule().organisationUnits()) doReturn orgUnitCollectionRepository
         whenever(


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/jira/software/c/projects/ANDROAPP/boards/113?selectedIssue=ANDROAPP-7177).

Please provide a clear definition of the problem and explain your solution.

Remove SDK call that sets overdue scheduled events status to overdue, fixing the incorrect pending sync status displayed in tei list after entering and exiting a TEI.

Check for overdue scheduled events in TEI list to properly display TEIs with overdue events.

Update current Unit tests and add one for new functionality.