### PR TITLE
fix: remove invalid update-types from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,9 @@ updates:
       # Ignore development versions with + in the version number
       - dependency-name: "*"
         versions: ["*+*"]
-      # Ignore all pre-release versions using update-types
+      # Ignore common pre-release version patterns
       - dependency-name: "*"
-        update-types: ["version-update:semver-prerelease"]
+        versions: ["*-SNAPSHOT", "*-alpha*", "*-beta*", "*-rc*", "*-RC*", "*-M*"]
       # Ignore specific JetBrains Compose dev versions
       - dependency-name: "org.jetbrains.compose*"
         versions: ["*+dev*", "*-dev*", "*dev*", "*+*"]


### PR DESCRIPTION
## Summary
Fixes the Dependabot configuration validation error by removing the invalid `version-update:semver-prerelease` value.

## Problem
After merging the previous PR, Dependabot was showing this error:
```
The property '#/updates/0/ignore/1/update-types/0' value "version-update:semver-prerelease" did not match one of the following values: version-update:semver-major, version-update:semver-minor, version-update:semver-patch
```

## Solution
- ❌ Removed invalid `update-types: ["version-update:semver-prerelease"]`
- ✅ Replaced with specific version patterns: `[\*-SNAPSHOT\, \*-alpha*\, \*-beta*\, \*-rc*\, \*-RC*\, \*-M*\]`
- ✅ Maintains all existing functionality for ignoring development versions

## Testing
After merging, the Dependabot configuration should validate successfully and continue to ignore:
- Development versions with `+dev` suffix (e.g., `2.10.0+dev2995`)
- Pre-release versions (alpha, beta, RC, SNAPSHOT, etc.)
- JetBrains Compose development versions

## Validation
The configuration uses only valid `update-types` values and proper version pattern matching.