### PR TITLE
feat: [ANDROAPP-7244] Add PIN domain and data layer (1/4)

### DIFF
--- a/login/src/androidMain/kotlin/org/dhis2/mobile/login/pin/data/SessionRepositoryImpl.kt
+++ b/login/src/androidMain/kotlin/org/dhis2/mobile/login/pin/data/SessionRepositoryImpl.kt
@@ -1,0 +1,84 @@
+package org.dhis2.mobile.login.pin.data
+
+import org.dhis2.mobile.commons.providers.PreferenceProvider
+import org.hisp.dhis.android.core.D2
+import timber.log.Timber
+
+/**
+ * Android implementation of SessionRepository using DHIS2 SDK.
+ * Handles PIN storage and session management using D2 dataStore and preferences.
+ */
+class SessionRepositoryImpl(
+    private val d2: D2,
+    private val preferenceProvider: PreferenceProvider,
+) : SessionRepository {
+    companion object {
+        private const val PIN_KEY = "pin"
+        private const val PREF_SESSION_LOCKED = "SessionLocked"
+    }
+
+    override suspend fun savePin(pin: String) {
+        try {
+            d2
+                .dataStoreModule()
+                .localDataStore()
+                .value(PIN_KEY)
+                .blockingSet(pin)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to save PIN")
+            throw e
+        }
+    }
+
+    override suspend fun getStoredPin(): String? =
+        try {
+            d2
+                .dataStoreModule()
+                .localDataStore()
+                .value(PIN_KEY)
+                .blockingGet()
+                ?.value()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to retrieve PIN")
+            null
+        }
+
+    override suspend fun deletePin() {
+        try {
+            d2
+                .dataStoreModule()
+                .localDataStore()
+                .value(PIN_KEY)
+                .blockingDeleteIfExist()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to delete PIN")
+            throw e
+        }
+    }
+
+    override suspend fun setSessionLocked(locked: Boolean) {
+        try {
+            preferenceProvider.setValue(PREF_SESSION_LOCKED, locked)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to set session locked state")
+            throw e
+        }
+    }
+
+    override suspend fun isSessionLocked(): Boolean =
+        try {
+            preferenceProvider.getBoolean(PREF_SESSION_LOCKED, false)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to get session locked state")
+            false
+        }
+
+    override suspend fun logout() {
+        try {
+            d2.userModule().blockingLogOut()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to logout")
+            throw e
+        }
+    }
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/data/SessionRepository.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/data/SessionRepository.kt
@@ -1,0 +1,41 @@
+package org.dhis2.mobile.login.pin.data
+
+/**
+ * Repository interface for managing PIN and session operations.
+ * Platform-specific implementations should use the DHIS2 SDK for data operations.
+ */
+interface SessionRepository {
+    /**
+     * Saves a PIN to secure storage.
+     * @param pin The PIN to save.
+     */
+    suspend fun savePin(pin: String)
+
+    /**
+     * Retrieves the stored PIN.
+     * @return The stored PIN, or null if no PIN is stored.
+     */
+    suspend fun getStoredPin(): String?
+
+    /**
+     * Deletes the stored PIN from secure storage.
+     */
+    suspend fun deletePin()
+
+    /**
+     * Marks the session as locked.
+     * @param locked True to lock the session, false to unlock it.
+     */
+    suspend fun setSessionLocked(locked: Boolean)
+
+    /**
+     * Checks if the session is currently locked.
+     * @return True if the session is locked, false otherwise.
+     */
+    suspend fun isSessionLocked(): Boolean
+
+    /**
+     * Logs out the current user and clears session data.
+     */
+    suspend fun logout()
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/model/PinResult.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/model/PinResult.kt
@@ -1,0 +1,29 @@
+package org.dhis2.mobile.login.pin.domain.model
+
+/**
+ * Represents the result of a PIN validation operation.
+ */
+sealed class PinResult {
+    /**
+     * PIN validation was successful.
+     */
+    data object Success : PinResult()
+
+    /**
+     * PIN validation failed.
+     * @param attemptsLeft Number of attempts remaining before forced logout.
+     */
+    data class Failed(
+        val attemptsLeft: Int,
+    ) : PinResult()
+
+    /**
+     * Too many failed attempts - user needs to recover PIN.
+     */
+    data object TooManyAttempts : PinResult()
+
+    /**
+     * No PIN is stored in the system.
+     */
+    data object NoPinStored : PinResult()
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/model/PinState.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/model/PinState.kt
@@ -1,0 +1,36 @@
+package org.dhis2.mobile.login.pin.domain.model
+
+/**
+ * Represents the different states of PIN operations in the UI.
+ */
+sealed class PinState {
+    /**
+     * Initial/Idle state - waiting for user interaction.
+     */
+    data object Idle : PinState()
+
+    /**
+     * PIN operation in progress.
+     */
+    data object Loading : PinState()
+
+    /**
+     * PIN validation or save was successful.
+     */
+    data object Success : PinState()
+
+    /**
+     * PIN validation failed with an error message.
+     * @param message The error message to display.
+     * @param remainingAttempts Number of remaining attempts before forced logout (null if not applicable).
+     */
+    data class Error(
+        val message: String,
+        val remainingAttempts: Int? = null,
+    ) : PinState()
+
+    /**
+     * Too many failed attempts - will trigger forgot PIN flow.
+     */
+    data object TooManyAttempts : PinState()
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ForgotPinUseCase.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ForgotPinUseCase.kt
@@ -1,0 +1,25 @@
+package org.dhis2.mobile.login.pin.domain.usecase
+
+import org.dhis2.mobile.login.pin.data.SessionRepository
+
+/**
+ * Use case for handling the "Forgot PIN" flow.
+ * This logs out the user and deletes the stored PIN.
+ */
+class ForgotPinUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    /**
+     * Executes the forgot PIN flow by logging out and clearing PIN data.
+     * @return Result indicating success or failure.
+     */
+    suspend operator fun invoke(): Result<Unit> =
+        try {
+            sessionRepository.deletePin()
+            sessionRepository.logout()
+            sessionRepository.setSessionLocked(false)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/GetIsSessionLockedUseCase.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/GetIsSessionLockedUseCase.kt
@@ -1,0 +1,9 @@
+package org.dhis2.mobile.login.pin.domain.usecase
+
+import org.dhis2.mobile.login.pin.data.SessionRepository
+
+class GetIsSessionLockedUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    suspend operator fun invoke() = sessionRepository.isSessionLocked()
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/SavePinUseCase.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/SavePinUseCase.kt
@@ -1,0 +1,25 @@
+package org.dhis2.mobile.login.pin.domain.usecase
+
+import org.dhis2.mobile.login.pin.data.SessionRepository
+
+/**
+ * Use case for saving a new PIN.
+ * This is typically used when setting up PIN protection for the first time.
+ */
+class SavePinUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    /**
+     * Saves the provided PIN and configures session settings.
+     * @param pin The PIN to save.
+     * @return Result indicating success or failure.
+     */
+    suspend operator fun invoke(pin: String): Result<Unit> =
+        try {
+            sessionRepository.savePin(pin)
+            sessionRepository.setSessionLocked(true)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+}

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ValidatePinUseCase.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ValidatePinUseCase.kt
@@ -1,0 +1,44 @@
+package org.dhis2.mobile.login.pin.domain.usecase
+
+import org.dhis2.mobile.login.pin.data.SessionRepository
+import org.dhis2.mobile.login.pin.domain.model.PinResult
+
+/**
+ * Use case for validating a PIN against the stored PIN.
+ * Tracks attempts and enforces a maximum number of failed attempts.
+ */
+class ValidatePinUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    companion object {
+        private const val MAX_ATTEMPTS = 3
+    }
+
+    /**
+     * Validates the provided PIN against the stored PIN.
+     * @param pin The PIN to validate.
+     * @param currentAttempts The current number of failed attempts.
+     * @return PinResult indicating the validation outcome.
+     */
+    suspend operator fun invoke(
+        pin: String,
+        currentAttempts: Int,
+    ): PinResult {
+        val storedPin = sessionRepository.getStoredPin()
+
+        if (storedPin == null) {
+            return PinResult.NoPinStored
+        }
+
+        return if (storedPin == pin) {
+            PinResult.Success
+        } else {
+            val attemptsLeft = MAX_ATTEMPTS - (currentAttempts + 1)
+            if (attemptsLeft <= 0) {
+                PinResult.TooManyAttempts
+            } else {
+                PinResult.Failed(attemptsLeft)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part 1/4 - Foundation layer for PIN-based session locking.

## Summary
Adds domain models, use cases, and repository implementation for PIN feature.

## What's Included
- **Domain Models**: PinResult, PinState sealed classes
- **Repository**: SessionRepository interface + Android implementation
- **Use Cases**: ValidatePinUseCase, SavePinUseCase, ForgotPinUseCase, GetIsSessionLockedUseCase

## Testing
✅ **Ktlint**: Passed  
✅ **Unit Tests**: 1208/1208 passed  
✅ **Build**: Successful (2m 50s)

## CI Compatibility
✅ **Size**: 293 lines (< 400)  
✅ **Independent**: No dependencies on other PRs

## Notes
- DI wiring will be added in PR3
- UI components in PR2

**Part 1/4** | Next: PR2 (UI components)