### PR TITLE
refactor: [ANDROAPP-7253] Adapt AndroidCustomIntentContext to new model

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImplKt.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImplKt.kt
@@ -414,9 +414,8 @@ class SearchRepositoryImplKt(
                             }
                         val customIntentModel =
                             customIntentRepository.getCustomIntent(
-                                programUid = programUid,
                                 triggerUid = attribute.uid(),
-                                programStageUid = null,
+                                orgunitUid = null,
                                 actionType = CustomIntentActionTypeModel.SEARCH,
                             )
                         createField(

--- a/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepositoryImpl.kt
+++ b/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepositoryImpl.kt
@@ -18,10 +18,9 @@ class CustomIntentRepositoryImpl(
 
     override fun getCustomIntent(
         triggerUid: String?,
-        programUid: String?,
-        programStageUid: String?,
+        orgunitUid: String?,
         actionType: CustomIntentActionTypeModel,
-    ): CustomIntentModel? = getCustomIntentFromUid(triggerUid, CustomIntentContext(programUid, programStageUid), actionType)
+    ): CustomIntentModel? = getCustomIntentFromUid(triggerUid, CustomIntentContext(orgunitUid = orgunitUid), actionType)
 
     private fun getCustomIntentActionType(actionType: CustomIntentActionTypeModel): CustomIntentType =
         when (actionType) {

--- a/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepository.kt
+++ b/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepository.kt
@@ -6,8 +6,7 @@ import org.dhis2.mobile.commons.model.CustomIntentModel
 interface CustomIntentRepository {
     fun getCustomIntent(
         triggerUid: String?,
-        programUid: String?,
-        programStageUid: String?,
+        orgunitUid: String?,
         actionType: CustomIntentActionTypeModel,
     ): CustomIntentModel?
 }

--- a/form/src/main/java/org/dhis2/form/data/EnrollmentRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EnrollmentRepository.kt
@@ -171,11 +171,17 @@ class EnrollmentRepository(
                     programTrackedEntityAttribute.trackedEntityAttribute()?.uid(),
                 ),
             )
+
+        val enrollmentOrgUnitUid =
+            conf
+                .enrollment()
+                ?.organisationUnit()
+        val ownerOrgUnitUid = conf.ownerOrgUnit()
+
         val attributeCustomIntent =
             customIntentRepository.getCustomIntent(
                 programTrackedEntityAttribute.trackedEntityAttribute()?.uid(),
-                programUid,
-                null,
+                enrollmentOrgUnitUid,
                 CustomIntentActionTypeModel.DATA_ENTRY,
             )
 
@@ -183,12 +189,6 @@ class EnrollmentRepository(
         var mandatory = programTrackedEntityAttribute.mandatory() ?: false
         val optionSet = attribute.optionSet()?.uid()
         val generated = attribute.generated() ?: false
-
-        val enrollmentOrgUnitUid =
-            conf
-                .enrollment()
-                ?.organisationUnit()
-        val ownerOrgUnitUid = conf.ownerOrgUnit()
 
         var dataValue: String? =
             attribute

--- a/form/src/main/java/org/dhis2/form/data/EventRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EventRepository.kt
@@ -624,8 +624,7 @@ class EventRepository(
         val customIntent =
             customIntentRepository.getCustomIntent(
                 uid,
-                programUid,
-                programStage?.uid(),
+                event?.organisationUnit(),
                 CustomIntentActionTypeModel.DATA_ENTRY,
             )
         val displayName = de?.displayName() ?: ""


### PR DESCRIPTION
## Description

Jira issue [ANDROAPP-7253](https://dhis2.atlassian.net/browse/ANDROAPP-7253).

This PR adapts the app to use the new AndroidCustomIntentContext. The only variable provided is the `orgunitid`. This variable refers to:
- the enrollment orgunit if the intent is called for a TrackedEntityAttribute.
- the event orgunit if the intent is called for a TrackedEntityDataValue.
- null if the intent is called in search (we would have to check this use case with Simprints).

This PR just adapts the context to the new model, but this logic might be modified with the the jira [ANDROAPP-7178](https://dhis2.atlassian.net/browse/ANDROAPP-7178). This jira ticket is about ensuring that the orgunit passed as parameter is always up-to-date with the one selected in the form.

[ANDROAPP-7253]: https://dhis2.atlassian.net/browse/ANDROAPP-7253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROAPP-7178]: https://dhis2.atlassian.net/browse/ANDROAPP-7178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ