### PR TITLE
fix [ANDROAPP-7234] Allow to search using comma

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -27,6 +27,8 @@ import org.dhis2.data.sorting.SearchSortingValueSetter;
 import org.dhis2.metadata.usecases.FileResourceConfiguration;
 import org.dhis2.metadata.usecases.ProgramConfiguration;
 import org.dhis2.metadata.usecases.TrackedEntityInstanceConfiguration;
+import org.dhis2.mobile.commons.customintents.CustomIntentRepository;
+import org.dhis2.mobile.commons.model.CustomIntentActionTypeModel;
 import org.dhis2.mobile.commons.providers.FieldErrorMessageProvider;
 import org.dhis2.mobile.commons.reporting.CrashReportController;
 import org.dhis2.tracker.data.ProfilePictureProvider;
@@ -122,6 +124,7 @@ public class SearchRepositoryImpl implements SearchRepository {
 
     private final MetadataIconProvider metadataIconProvider;
     private final ProfilePictureProvider profilePictureProvider;
+    private CustomIntentRepository customIntentRepository;
 
     SearchRepositoryImpl(String teiType,
                          @Nullable String initialProgram,
@@ -137,7 +140,8 @@ public class SearchRepositoryImpl implements SearchRepository {
                          ThemeManager themeManager,
                          MetadataIconProvider metadataIconProvider,
                          ProfilePictureProvider profilePictureProvider,
-                         DateUtils dateUtils
+                         DateUtils dateUtils,
+                         CustomIntentRepository customIntentRepository
     ) {
         this.teiType = teiType;
         this.d2 = d2;
@@ -160,6 +164,7 @@ public class SearchRepositoryImpl implements SearchRepository {
                 resources);
         this.metadataIconProvider = metadataIconProvider;
         this.profilePictureProvider = profilePictureProvider;
+        this.customIntentRepository = customIntentRepository;
     }
 
 
@@ -227,6 +232,11 @@ public class SearchRepositoryImpl implements SearchRepository {
                 boolean isUnique = attribute.unique();
                 boolean isOptionSet = (attribute.optionSet() != null);
                 assert dataValues != null;
+                if(!customIntentRepository.attributeHasCustomIntentAndReturnsAListOfValues(dataId, CustomIntentActionTypeModel.SEARCH)) {
+                    if (dataValues != null && dataValues.size() > 1) {
+                        dataValues = Collections.singletonList(String.join(",", dataValues));
+                    }
+                }
 
                 trackedEntityInstanceQuery = getTrackedEntityQuery(dataId, dataValues, isUnique, isOptionSet);
             }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -232,12 +232,9 @@ public class SearchRepositoryImpl implements SearchRepository {
                 boolean isUnique = attribute.unique();
                 boolean isOptionSet = (attribute.optionSet() != null);
                 assert dataValues != null;
-                if(!customIntentRepository.attributeHasCustomIntentAndReturnsAListOfValues(dataId, CustomIntentActionTypeModel.SEARCH)) {
-                    if (dataValues != null && dataValues.size() > 1) {
-                        dataValues = Collections.singletonList(String.join(",", dataValues));
-                    }
+                if(!customIntentRepository.attributeHasCustomIntentAndReturnsAListOfValues(dataId, CustomIntentActionTypeModel.SEARCH) && dataValues.size() > 1) {
+                    dataValues = Collections.singletonList(String.join(",", dataValues));
                 }
-
                 trackedEntityInstanceQuery = getTrackedEntityQuery(dataId, dataValues, isUnique, isOptionSet);
             }
         }

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryImpl.java
@@ -233,6 +233,8 @@ public class SearchRepositoryImpl implements SearchRepository {
                 boolean isOptionSet = (attribute.optionSet() != null);
                 assert dataValues != null;
                 if(!customIntentRepository.attributeHasCustomIntentAndReturnsAListOfValues(dataId, CustomIntentActionTypeModel.SEARCH) && dataValues.size() > 1) {
+                    //Only search with a list of values when the attribute is linked to a custom intent
+                    //that returns a list of values, otherwise the comma was one of the search characters
                     dataValues = Collections.singletonList(String.join(",", dataValues));
                 }
                 trackedEntityInstanceQuery = getTrackedEntityQuery(dataId, dataValues, isUnique, isOptionSet);

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEModule.java
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/SearchTEModule.java
@@ -157,7 +157,8 @@ public class SearchTEModule {
                                       SearchTEIRepository searchTEIRepository,
                                       ThemeManager themeManager,
                                       MetadataIconProvider metadataIconProvider,
-                                      DateUtils dateUtils) {
+                                      DateUtils dateUtils,
+                                      CustomIntentRepository customIntentRepository) {
         ProfilePictureProvider profilePictureProvider = new ProfilePictureProvider(d2);
         return new SearchRepositoryImpl(teiType,
                 initialProgram,
@@ -173,7 +174,8 @@ public class SearchTEModule {
                 themeManager,
                 metadataIconProvider,
                 profilePictureProvider,
-                dateUtils);
+                dateUtils,
+                customIntentRepository);
     }
 
     @Provides

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
@@ -146,6 +146,7 @@ class SearchRepositoryTest {
                 metadataIconProvider,
                 profilePictureProvider,
                 dateUtils,
+                customIntentRepository,
             )
     }
 

--- a/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepositoryImpl.kt
+++ b/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepositoryImpl.kt
@@ -22,6 +22,18 @@ class CustomIntentRepositoryImpl(
         actionType: CustomIntentActionTypeModel,
     ): CustomIntentModel? = getCustomIntentFromUid(triggerUid, CustomIntentContext(orgunitUid = orgunitUid), actionType)
 
+    override fun attributeHasCustomIntentAndReturnsAListOfValues(
+        triggerUid: String,
+        actionType: CustomIntentActionTypeModel,
+    ): Boolean {
+        val customIntent = getCustomIntentFromUid(triggerUid, CustomIntentContext(null, null), actionType)
+        return customIntent != null &&
+            (
+                customIntent.customIntentResponse.size > 1 ||
+                    customIntent.customIntentResponse.any { it.extraType == CustomIntentResponseExtraType.LIST_OF_OBJECTS }
+            )
+    }
+
     private fun getCustomIntentActionType(actionType: CustomIntentActionTypeModel): CustomIntentType =
         when (actionType) {
             CustomIntentActionTypeModel.DATA_ENTRY -> CustomIntentType.DATA_ENTRY

--- a/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepository.kt
+++ b/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepository.kt
@@ -9,4 +9,9 @@ interface CustomIntentRepository {
         orgunitUid: String?,
         actionType: CustomIntentActionTypeModel,
     ): CustomIntentModel?
+
+    fun attributeHasCustomIntentAndReturnsAListOfValues(
+        triggerUid: String,
+        actionType: CustomIntentActionTypeModel,
+    ): Boolean
 }

--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/CustomIntentProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/CustomIntentProvider.kt
@@ -187,13 +187,18 @@ private fun extractObjectValue(
     intent: Intent,
     objectCache: Map<String, JsonObject?>,
 ): List<String>? {
-    val jsonString = intent.getStringExtra(extra.name) ?: return null
-    val jsonObject = objectCache[jsonString] ?: getComplexObject(jsonString) ?: return null
+    try {
+        val jsonString = intent.getStringExtra(extra.name) ?: return null
+        val jsonObject = objectCache[jsonString] ?: getComplexObject(jsonString) ?: return null
 
-    return if (jsonObject.has(extra.key)) {
-        listOf(jsonObject[extra.key].asString)
-    } else {
-        null
+        return if (jsonObject.has(extra.key)) {
+            listOf(jsonObject[extra.key].asString)
+        } else {
+            null
+        }
+    } catch (e: Exception) {
+        Timber.d(e)
+        return null
     }
 }
 
@@ -202,13 +207,18 @@ private fun extractListValues(
     intent: Intent,
     listCache: Map<String, List<JsonObject>?>,
 ): List<String>? {
-    val jsonString = intent.getStringExtra(extra.name) ?: return null
-    val objectsList = listCache[jsonString] ?: getListOfObjects(jsonString) ?: return null
+    try {
+        val jsonString = intent.getStringExtra(extra.name) ?: return null
+        val objectsList = listCache[jsonString] ?: getListOfObjects(jsonString) ?: return null
 
-    return objectsList
-        .filter { it.has(extra.key) }
-        .map { it[extra.key].asString }
-        .takeIf { it.isNotEmpty() }
+        return objectsList
+            .filter { it.has(extra.key) }
+            .map { it[extra.key].asString }
+            .takeIf { it.isNotEmpty() }
+    } catch (e: Exception) {
+        Timber.d(e)
+        return null
+    }
 }
 
 fun getComplexObject(jsonString: String): JsonObject? =


### PR DESCRIPTION
## Description

 [JIRA issue](https://dhis2.atlassian.net/jira/software/c/projects/ANDROAPP/boards/113?selectedIssue=ANDROAPP-7234).

Please provide a clear definition of the problem and explain your solution.

With the new custom intent implementation in the Search TEI section, we could not search teiAttributes with a value with a comma in it, in order to adapt this, a new method has been added to the custom intent repository that checks whether that TEI attribute is linked to a custom intent that can return a list of values and then will search by it, if not, it will search with the plain text that was introduced in the search field