### PR TITLE
fix: Adapt test to change in CustomIntentContext

### DIFF
--- a/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepositoryImpl.kt
+++ b/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/customintents/CustomIntentRepositoryImpl.kt
@@ -26,7 +26,7 @@ class CustomIntentRepositoryImpl(
         triggerUid: String,
         actionType: CustomIntentActionTypeModel,
     ): Boolean {
-        val customIntent = getCustomIntentFromUid(triggerUid, CustomIntentContext(null, null), actionType)
+        val customIntent = getCustomIntentFromUid(triggerUid, CustomIntentContext(null), actionType)
         return customIntent != null &&
             (
                 customIntent.customIntentResponse.size > 1 ||


### PR DESCRIPTION
## Description

The adaptation to the new CustomIntentContext left a test using the old constructor. Now that the SDK has been updated, this is failing.