### PR TITLE
fix: [ANDROAPP-7145] Correct snackBar no access to org unit message

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
@@ -545,7 +545,7 @@ class TEIDataFragment :
         Snackbar
             .make(
                 binding.root,
-                getString(R.string.at_enroll_org_unit).format(enrollmentOrgUnit),
+                getString(R.string.at_enroll_org_unit).format(enrollmentOrgUnit) + "\n" + getString(R.string.no_access_to_it),
                 Snackbar.LENGTH_SHORT,
             ).show()
     }


### PR DESCRIPTION
## Description

 [JIRA issue](https://dhis2.atlassian.net/jira/software/c/projects/ANDROAPP/boards/113?selectedIssue=ANDROAPP-7145).

No access snackbar was showing an incomplete message, these changes address this issue.