### PR TITLE
fix: [ANDROAPP-7295] fix null pointer with null flag name crash

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/sync/SyncActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/sync/SyncActivity.kt
@@ -103,14 +103,17 @@ class SyncActivity :
     }
 
     override fun setFlag(flagName: String?) {
-        binding.logoFlag.setImageResource(
-            resources.getIdentifier(flagName, "drawable", packageName),
-        )
-        animations.startFlagAnimation { value: Float? ->
-            binding.apply {
-                logoFlag.alpha = value!!
-                dhisLogo.alpha = 0f
+        flagName?.takeIf { it.isNotBlank() }?.let {
+            binding.logoFlag.setImageResource(R.drawable.ic_flag)
+            animations.startFlagAnimation { value ->
+                binding.apply {
+                    logoFlag.alpha = value
+                    dhisLogo.alpha = 0f
+                }
             }
+        } ?: run {
+            // Hide flag if no valid name provided
+            binding.logoFlag.setImageDrawable(null)
         }
     }
 


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7295).

Please provide a clear definition of the problem and explain your solution.

Occasional crash occurring on initial logging when the flag has not yet been fetched. refactored code to not set the flag if the value is null and removed deprecated methods