### PR TITLE
fix: [ANDROAPP-7293] add minimum size to pin bottom sheet content

### DIFF
--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/ui/components/PinBottomSheet.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/ui/components/PinBottomSheet.kt
@@ -161,6 +161,7 @@ fun PinBottomSheet(
                 showBottomSectionDivider = false,
                 headerTextAlignment = TextAlign.Center,
                 animateHeaderOnKeyboardAppearance = false,
+                scrollableContainerMinHeight = Spacing.Spacing40,
                 contentPadding =
                     PaddingValues(
                         horizontal = Spacing.Spacing24,


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7293).

Please provide a clear definition of the problem and explain your solution.

In landscape with the keyboard expanded the InputSegmentedShell was being hidden, the property ScrolableCOntainer Min height has been set to 40 dp to ensure this does not happen