### PR TITLE
fix: update flag handling in SyncActivity to use drawable resource identifier and hide flag when not valid

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/sync/SyncActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/sync/SyncActivity.kt
@@ -2,6 +2,7 @@ package org.dhis2.usescases.sync
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View.GONE
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.work.WorkInfo
@@ -104,7 +105,8 @@ class SyncActivity :
 
     override fun setFlag(flagName: String?) {
         flagName?.takeIf { it.isNotBlank() }?.let {
-            binding.logoFlag.setImageResource(R.drawable.ic_flag)
+            val flagRes = resources.getIdentifier(flagName, "drawable", packageName)
+            binding.logoFlag.setImageResource(flagRes)
             animations.startFlagAnimation { value ->
                 binding.apply {
                     logoFlag.alpha = value
@@ -113,7 +115,7 @@ class SyncActivity :
             }
         } ?: run {
             // Hide flag if no valid name provided
-            binding.logoFlag.setImageDrawable(null)
+            binding.logoFlag.visibility = GONE
         }
     }
 


### PR DESCRIPTION
## Description

In syncActivity use the corresponding flag drawable name or hide the view if there is no flag configured