### PR TITLE
chore: [ANDROAPP-7466] add new MetadataSyncPeriod item 6h

### DIFF
--- a/app/src/main/java/org/dhis2/bindings/SettingExtensions.kt
+++ b/app/src/main/java/org/dhis2/bindings/SettingExtensions.kt
@@ -15,6 +15,7 @@ const val MANUAL = 0
 fun MetadataSyncPeriod.toSeconds(): Int =
     when (this) {
         MetadataSyncPeriod.EVERY_HOUR -> EVERY_HOUR
+        MetadataSyncPeriod.EVERY_6_HOURS -> EVERY_6_HOUR
         MetadataSyncPeriod.EVERY_12_HOURS -> EVERY_12_HOUR
         MetadataSyncPeriod.EVERY_24_HOURS -> EVERY_24_HOUR
         MetadataSyncPeriod.EVERY_7_DAYS -> EVERY_7_DAYS

--- a/app/src/test/java/org/dhis2/bindings/SettingsExtensionsTest.kt
+++ b/app/src/test/java/org/dhis2/bindings/SettingsExtensionsTest.kt
@@ -8,6 +8,7 @@ class SettingsExtensionsTest {
     private val metadataSyncingPeriods =
         arrayListOf(
             EVERY_HOUR,
+            EVERY_6_HOUR,
             EVERY_12_HOUR,
             EVERY_24_HOUR,
             EVERY_7_DAYS,


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7466).

A new 6H period has been added to the MetadataSyncPeriod enum in the sdk, the app needs to adapt to the extension as well.