### PR TITLE
refactor: [ANDROAPP-7551] Create GetEnrollmentAnalyticsUseCase

### DIFF
--- a/app/src/main/java/org/dhis2/data/server/ServerModule.kt
+++ b/app/src/main/java/org/dhis2/data/server/ServerModule.kt
@@ -5,7 +5,9 @@ import android.content.ContextWrapper
 import dagger.Module
 import dagger.Provides
 import dhis2.org.analytics.charts.Charts
-import dhis2.org.analytics.charts.DhisAnalyticCharts
+import dhis2.org.analytics.charts.di.ChartsComponent
+import dhis2.org.analytics.charts.di.DaggerChartsComponent
+import dhis2.org.analytics.charts.domain.GetEnrollmentAnalyticsUseCase
 import okhttp3.Interceptor
 import org.dhis2.BuildConfig
 import org.dhis2.R
@@ -81,7 +83,20 @@ class ServerModule {
 
     @Provides
     @PerServer
-    fun provideCharts(serverComponent: ServerComponent): Charts = DhisAnalyticCharts.Provider.get(serverComponent)
+    fun provideChartsComponent(serverComponent: ServerComponent): ChartsComponent =
+        DaggerChartsComponent
+            .builder()
+            .dependencies(serverComponent)
+            .build()
+
+    @Provides
+    @PerServer
+    fun provideCharts(chartsComponent: ChartsComponent): Charts = chartsComponent.charts()
+
+    @Provides
+    @PerServer
+    fun provideGetEnrollmentAnalyticsUseCase(chartsComponent: ChartsComponent): GetEnrollmentAnalyticsUseCase =
+        chartsComponent.getEnrollmentAnalyticsUseCase()
 
     @Provides
     @PerServer

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/di/ChartsInjector.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/di/ChartsInjector.kt
@@ -8,6 +8,7 @@ import dhis2.org.analytics.charts.Charts
 import dhis2.org.analytics.charts.ChartsRepository
 import dhis2.org.analytics.charts.ChartsRepositoryImpl
 import dhis2.org.analytics.charts.DhisAnalyticCharts
+import dhis2.org.analytics.charts.domain.GetEnrollmentAnalyticsUseCase
 import dhis2.org.analytics.charts.data.AnalyticResources
 import dhis2.org.analytics.charts.mappers.AnalyticDataElementToDataElementData
 import dhis2.org.analytics.charts.mappers.AnalyticIndicatorToIndicatorData
@@ -36,6 +37,7 @@ import javax.inject.Singleton
 )
 interface ChartsComponent {
     fun charts(): Charts
+    fun getEnrollmentAnalyticsUseCase(): GetEnrollmentAnalyticsUseCase
 }
 
 @Module
@@ -138,4 +140,10 @@ class ChartsModule {
 
     @Provides
     internal fun bindStorageFeatureImpl(analyticsCharts: DhisAnalyticCharts): Charts = analyticsCharts
+
+    @Provides
+    internal fun provideGetEnrollmentAnalyticsUseCase(
+        chartsRepository: ChartsRepository,
+        dispatcherProvider: DispatcherProvider,
+    ): GetEnrollmentAnalyticsUseCase = GetEnrollmentAnalyticsUseCase(chartsRepository, dispatcherProvider)
 }

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/domain/GetEnrollmentAnalyticsUseCase.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/domain/GetEnrollmentAnalyticsUseCase.kt
@@ -9,10 +9,10 @@ class GetEnrollmentAnalyticsUseCase(
     private val chartsRepository: ChartsRepository,
     private val dispatchers: DispatcherProvider,
 ) {
-    suspend operator fun invoke(input: String): Result<List<Graph>> =
+    suspend operator fun invoke(enrollmentUid: String): Result<List<Graph>> =
         withContext(dispatchers.io()) {
             try {
-                Result.success(chartsRepository.getAnalyticsForEnrollment(input))
+                Result.success(chartsRepository.getAnalyticsForEnrollment(enrollmentUid))
             } catch (e: Exception) {
                 Result.failure(e)
             }

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/domain/GetEnrollmentAnalyticsUseCase.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/domain/GetEnrollmentAnalyticsUseCase.kt
@@ -1,0 +1,20 @@
+package dhis2.org.analytics.charts.domain
+
+import dhis2.org.analytics.charts.ChartsRepository
+import dhis2.org.analytics.charts.data.Graph
+import kotlinx.coroutines.withContext
+import org.dhis2.commons.viewmodel.DispatcherProvider
+
+class GetEnrollmentAnalyticsUseCase(
+    private val chartsRepository: ChartsRepository,
+    private val dispatchers: DispatcherProvider,
+) {
+    suspend operator fun invoke(input: String): Result<List<Graph>> =
+        withContext(dispatchers.io()) {
+            try {
+                Result.success(chartsRepository.getAnalyticsForEnrollment(input))
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+}

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/GroupAnalyticsFragment.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/GroupAnalyticsFragment.kt
@@ -8,6 +8,9 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.github.mikephil.charting.utils.Utils
 import dhis2.org.R
 import dhis2.org.analytics.charts.data.AnalyticGroup
@@ -18,6 +21,7 @@ import dhis2.org.analytics.charts.ui.di.AnalyticsFragmentModule
 import dhis2.org.analytics.charts.ui.dialog.SearchColumnDialog
 import dhis2.org.databinding.AnalyticsGroupBinding
 import dhis2.org.databinding.AnalyticsItemBinding
+import kotlinx.coroutines.launch
 import org.dhis2.commons.bindings.clipWithRoundedCorners
 import org.dhis2.commons.bindings.scrollToPosition
 import org.dhis2.commons.dialogs.AlertBottomDialog
@@ -220,47 +224,57 @@ class GroupAnalyticsFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        groupViewModel.chipItems.observe(viewLifecycleOwner) { chipResult ->
-            when {
-                chipResult.isSuccess -> {
-                    val chips = chipResult.getOrDefault(emptyList())
-                    if (chips.isEmpty() || chips.size < MIN_SIZE_TO_SHOW) {
-                        binding?.analyticChipGroup?.visibility = View.GONE
-                    } else {
-                        binding?.analyticChipGroup?.visibility = View.VISIBLE
-                        disableToolbarElevation?.invoke()
-                        addChips(chips)
-                    }
-                }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    groupViewModel.chipItems.collect { chipResult ->
+                        chipResult ?: return@collect
+                        when {
+                            chipResult.isSuccess -> {
+                                val chips = chipResult.getOrDefault(emptyList())
+                                if (chips.isEmpty() || chips.size < MIN_SIZE_TO_SHOW) {
+                                    binding?.analyticChipGroup?.visibility = View.GONE
+                                } else {
+                                    binding?.analyticChipGroup?.visibility = View.VISIBLE
+                                    disableToolbarElevation?.invoke()
+                                    addChips(chips)
+                                }
+                            }
 
-                chipResult.isFailure -> {
-                    binding?.progressLayout?.visibility = View.GONE
-                    binding?.emptyAnalytics?.apply {
-                        visibility = View.VISIBLE
-                        text = getString(R.string.visualization_groups_failure)
+                            chipResult.isFailure -> {
+                                binding?.progressLayout?.visibility = View.GONE
+                                binding?.emptyAnalytics?.apply {
+                                    visibility = View.VISIBLE
+                                    text = getString(R.string.visualization_groups_failure)
+                                }
+                            }
+                        }
+                        startPostponedEnterTransition()
                     }
                 }
-            }
-            startPostponedEnterTransition()
-        }
-        groupViewModel.analytics.observe(viewLifecycleOwner) { analytics ->
-            try {
-                when {
-                    analytics.isSuccess ->
-                        adapter.submitList(analytics.getOrDefault(emptyList())) {
-                            binding?.progressLayout?.visibility = View.GONE
-                        }
+                launch {
+                    groupViewModel.analytics.collect { analytics ->
+                        analytics ?: return@collect
+                        try {
+                            when {
+                                analytics.isSuccess ->
+                                    adapter.submitList(analytics.getOrDefault(emptyList())) {
+                                        binding?.progressLayout?.visibility = View.GONE
+                                    }
 
-                    analytics.isFailure -> {
-                        binding?.progressLayout?.visibility = View.GONE
-                        binding?.emptyAnalytics?.apply {
-                            visibility = View.VISIBLE
-                            text = getString(R.string.visualization_failure)
+                                analytics.isFailure -> {
+                                    binding?.progressLayout?.visibility = View.GONE
+                                    binding?.emptyAnalytics?.apply {
+                                        visibility = View.VISIBLE
+                                        text = getString(R.string.visualization_failure)
+                                    }
+                                }
+                            }
+                        } finally {
+                            AnalyticsCountingIdlingResource.decrement()
                         }
                     }
                 }
-            } finally {
-                AnalyticsCountingIdlingResource.decrement()
             }
         }
     }

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/GroupAnalyticsViewModel.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/GroupAnalyticsViewModel.kt
@@ -1,19 +1,20 @@
 package dhis2.org.analytics.charts.ui
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dhis2.org.analytics.charts.Charts
 import dhis2.org.analytics.charts.data.AnalyticGroup
+import dhis2.org.analytics.charts.domain.GetEnrollmentAnalyticsUseCase
 import dhis2.org.analytics.charts.idling.AnalyticsCountingIdlingResource
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.dhis2.commons.matomo.Actions
 import org.dhis2.commons.matomo.Categories
 import org.dhis2.commons.matomo.Labels
 import org.dhis2.commons.matomo.MatomoAnalyticsController
+import org.dhis2.commons.viewmodel.DispatcherProvider
 import org.hisp.dhis.android.core.common.RelativePeriod
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import timber.log.Timber
@@ -25,11 +26,13 @@ class GroupAnalyticsViewModel(
     private val uid: String?,
     private val charts: Charts,
     private val matomoAnalyticsController: MatomoAnalyticsController,
+    private val getEnrollmentAnalyticsUseCase: GetEnrollmentAnalyticsUseCase,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
-    private val _chipItems = MutableLiveData<Result<List<AnalyticGroup>>>()
-    val chipItems: LiveData<Result<List<AnalyticGroup>>> = _chipItems
-    private val _analytics = MutableLiveData<Result<List<AnalyticsModel>>>()
-    val analytics: LiveData<Result<List<AnalyticsModel>>> = _analytics
+    private val _chipItems = MutableStateFlow<Result<List<AnalyticGroup>>?>(null)
+    val chipItems: StateFlow<Result<List<AnalyticGroup>>?> = _chipItems.asStateFlow()
+    private val _analytics = MutableStateFlow<Result<List<AnalyticsModel>>?>(null)
+    val analytics: StateFlow<Result<List<AnalyticsModel>>?> = _analytics.asStateFlow()
     private var currentGroup: String? = null
 
     init {
@@ -44,18 +47,19 @@ class GroupAnalyticsViewModel(
     }
 
     private fun fetchAnalyticsGroup(onSuccess: () -> Unit) {
-        viewModelScope.launch {
-            val result =
-                async(context = Dispatchers.IO) {
-                    charts.getVisualizationGroups(uid).map {
-                        AnalyticGroup(it.id(), it.name())
-                    }
-                }
+        AnalyticsCountingIdlingResource.increment()
+        viewModelScope.launch(dispatchers.io()) {
             try {
-                _chipItems.value = Result.success(result.await())
+                val groups = charts.getVisualizationGroups(uid).map {
+                    AnalyticGroup(it.id(), it.name())
+                }
+                _chipItems.value = Result.success(groups)
                 onSuccess()
             } catch (e: Exception) {
                 _chipItems.value = Result.failure(e)
+            }
+            finally {
+                AnalyticsCountingIdlingResource.decrement()
             }
         }
     }
@@ -138,50 +142,55 @@ class GroupAnalyticsViewModel(
     fun fetchAnalytics(groupUid: String?) {
         AnalyticsCountingIdlingResource.increment()
         currentGroup = groupUid
-        viewModelScope.launch {
-            val result =
-                async(context = Dispatchers.IO) {
-                    when (mode) {
-                        AnalyticMode.ENROLLMENT ->
-                            uid?.let {
-                                charts
-                                    .geEnrollmentCharts(uid)
-                                    .map { ChartModel(it) }
-                            } ?: emptyList()
-
-                        AnalyticMode.TRACKER_PROGRAM ->
-                            uid?.let {
-                                charts
-                                    .getProgramVisualizations(groupUid, uid)
-                                    .map { ChartModel(it) }
-                            } ?: emptyList()
-
-                        AnalyticMode.EVENT_PROGRAM ->
-                            uid?.let {
-                                charts
-                                    .getProgramVisualizations(groupUid, uid)
-                                    .map { ChartModel(it) }
-                            } ?: emptyList()
-
-                        AnalyticMode.HOME ->
-                            charts
-                                .getHomeVisualizations(groupUid)
-                                .map { ChartModel(it) }
-
-                        AnalyticMode.DATASET ->
-                            uid?.let {
-                                charts
-                                    .getDataSetVisualizations(groupUid, uid)
-                                    .map { ChartModel(it) }
-                            } ?: emptyList()
+        when (mode) {
+            AnalyticMode.ENROLLMENT ->
+                viewModelScope.launch {
+                    uid?.let {
+                        getEnrollmentAnalyticsUseCase(uid)
+                            .onSuccess { graphs ->
+                                _analytics.value = Result.success(graphs.map { ChartModel(it) })
+                            }.onFailure { e ->
+                                Timber.e(e)
+                                _analytics.value = Result.failure(e)
+                            }
+                    } ?: run {
+                        _analytics.value = Result.success(emptyList())
                     }
                 }
-            try {
-                _analytics.value = Result.success(result.await())
-            } catch (e: Exception) {
-                Timber.e(e)
-                _analytics.value = Result.failure(e)
-            }
+
+            else ->
+                viewModelScope.launch(dispatchers.io()) {
+                    try {
+                        val result = when (mode) {
+                            AnalyticMode.TRACKER_PROGRAM ->
+                                uid?.let {
+                                    charts.getProgramVisualizations(groupUid, uid)
+                                        .map { ChartModel(it) }
+                                } ?: emptyList()
+
+                            AnalyticMode.EVENT_PROGRAM ->
+                                uid?.let {
+                                    charts.getProgramVisualizations(groupUid, uid)
+                                        .map { ChartModel(it) }
+                                } ?: emptyList()
+
+                            AnalyticMode.HOME ->
+                                charts.getHomeVisualizations(groupUid).map { ChartModel(it) }
+
+                            AnalyticMode.DATASET ->
+                                uid?.let {
+                                    charts.getDataSetVisualizations(groupUid, uid)
+                                        .map { ChartModel(it) }
+                                } ?: emptyList()
+
+                            AnalyticMode.ENROLLMENT -> emptyList()
+                        }
+                        _analytics.value = Result.success(result)
+                    } catch (e: Exception) {
+                        Timber.e(e)
+                        _analytics.value = Result.failure(e)
+                    }
+                }
         }
     }
 

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/GroupAnalyticsViewModelFactory.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/GroupAnalyticsViewModelFactory.kt
@@ -3,13 +3,17 @@ package dhis2.org.analytics.charts.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import dhis2.org.analytics.charts.Charts
+import dhis2.org.analytics.charts.domain.GetEnrollmentAnalyticsUseCase
 import org.dhis2.commons.matomo.MatomoAnalyticsController
+import org.dhis2.commons.viewmodel.DispatcherProvider
 
 class GroupAnalyticsViewModelFactory(
     private val mode: AnalyticMode,
     private val uid: String?,
     private val charts: Charts,
     private val matomoAnalyticsController: MatomoAnalyticsController,
+    private val getEnrollmentAnalyticsUseCase: GetEnrollmentAnalyticsUseCase,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T =
         GroupAnalyticsViewModel(
@@ -17,5 +21,7 @@ class GroupAnalyticsViewModelFactory(
             uid,
             charts,
             matomoAnalyticsController,
+            getEnrollmentAnalyticsUseCase,
+            dispatchers,
         ) as T
 }

--- a/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/di/AnalyticsFragmentInjector.kt
+++ b/dhis_android_analytics/src/main/java/dhis2/org/analytics/charts/ui/di/AnalyticsFragmentInjector.kt
@@ -4,10 +4,12 @@ import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
 import dhis2.org.analytics.charts.Charts
+import dhis2.org.analytics.charts.domain.GetEnrollmentAnalyticsUseCase
 import dhis2.org.analytics.charts.ui.AnalyticMode
 import dhis2.org.analytics.charts.ui.GroupAnalyticsFragment
 import dhis2.org.analytics.charts.ui.GroupAnalyticsViewModelFactory
 import org.dhis2.commons.matomo.MatomoAnalyticsController
+import org.dhis2.commons.viewmodel.DispatcherProvider
 
 @Subcomponent(modules = [AnalyticsFragmentModule::class])
 interface AnalyticsFragmentComponent {
@@ -23,5 +25,15 @@ class AnalyticsFragmentModule(
     fun provideViewModelFactory(
         charts: Charts,
         matomoAnalyticsController: MatomoAnalyticsController,
-    ): GroupAnalyticsViewModelFactory = GroupAnalyticsViewModelFactory(mode, uid, charts, matomoAnalyticsController)
+        getEnrollmentAnalyticsUseCase: GetEnrollmentAnalyticsUseCase,
+        dispatcherProvider: DispatcherProvider,
+    ): GroupAnalyticsViewModelFactory =
+        GroupAnalyticsViewModelFactory(
+            mode,
+            uid,
+            charts,
+            matomoAnalyticsController,
+            getEnrollmentAnalyticsUseCase,
+            dispatcherProvider,
+        )
 }

--- a/dhis_android_analytics/src/test/java/dhis2/org/analytics/charts/domain/GetEnrollmentAnalyticsUseCaseTest.kt
+++ b/dhis_android_analytics/src/test/java/dhis2/org/analytics/charts/domain/GetEnrollmentAnalyticsUseCaseTest.kt
@@ -1,0 +1,74 @@
+package dhis2.org.analytics.charts.domain
+
+import dhis2.org.analytics.charts.ChartsRepository
+import dhis2.org.analytics.charts.data.Graph
+import dhis2.org.analytics.charts.data.ChartType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.dhis2.commons.viewmodel.DispatcherProvider
+import org.hisp.dhis.android.core.period.PeriodType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetEnrollmentAnalyticsUseCaseTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val dispatcherProvider: DispatcherProvider = mock {
+        on { io() } doReturn testDispatcher
+        on { computation() } doReturn testDispatcher
+        on { ui() } doReturn testDispatcher
+    }
+
+    private val chartsRepository: ChartsRepository = mock()
+
+    private val useCase = GetEnrollmentAnalyticsUseCase(chartsRepository, dispatcherProvider)
+
+    @Test
+    fun `Should return success result with graph list when repository succeeds`() = runTest {
+        val expectedGraphs = listOf(
+            Graph(
+                title = "graph_1",
+                series = emptyList(),
+                periodToDisplayDefault = null,
+                eventPeriodType = PeriodType.Daily,
+                periodStep = 0L,
+                chartType = ChartType.LINE_CHART,
+            ),
+        )
+        whenever(chartsRepository.getAnalyticsForEnrollment("enrollmentUid")) doReturn expectedGraphs
+
+        val result = useCase("enrollmentUid")
+
+        assertTrue(result.isSuccess)
+        assertEquals(expectedGraphs, result.getOrNull())
+    }
+
+    @Test
+    fun `Should return failure result when repository throws exception`() = runTest {
+        val exception = RuntimeException("Repository error")
+        whenever(chartsRepository.getAnalyticsForEnrollment("enrollmentUid")) doThrow exception
+
+        val result = useCase("enrollmentUid")
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `Should execute on io dispatcher`() = runTest {
+        whenever(chartsRepository.getAnalyticsForEnrollment("enrollmentUid")) doReturn emptyList()
+
+        useCase("enrollmentUid")
+
+        // Verifying io() was called means the use case used the injected dispatcher
+        org.mockito.kotlin.verify(dispatcherProvider).io()
+    }
+}


### PR DESCRIPTION
- Introduce `GetEnrollmentAnalyticsUseCase` to handle enrollment analytics fetching logic.
- Migrated `GroupAnalyticsViewModel` to use `StateFlow` instead of `LiveData` for `chipItems` and `analytics`.
- Updated `GroupAnalyticsFragment` to collect flows within the `repeatOnLifecycle` block.