### PR TITLE
fix: [ANDROAPP-7550] maintain running status in syncStatusController if sync is still running

### DIFF
--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncStatusController.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncStatusController.kt
@@ -121,7 +121,16 @@ class SyncStatusController {
     }
 
     suspend fun restore() {
-        downloadStatus.emit(SyncStatusData())
+        if (downloadStatus.value.running == true) {
+            downloadStatus.emit(
+                SyncStatusData(
+                    isInitialSync = true,
+                    running = true,
+                ),
+            )
+        } else {
+            downloadStatus.emit(SyncStatusData())
+        }
     }
 
     suspend fun onNetworkUnavailable() {


### PR DESCRIPTION

## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7550).

Please provide a clear definition of the problem and explain your solution.