### PR TITLE
fix(security): disable cleartext HTTP traffic by default

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,11 +44,11 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:requestLegacyExternalStorage="false"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true"
         tools:replace="allowBackup,fullBackupContent"
         tools:targetApi="s">
         <uses-library

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!--
+    Example: to allow cleartext HTTP to a specific host (e.g. a local dev
+    DHIS2 instance), uncomment and edit the block below. Prefer overriding
+    this file in a debug-only manifest rather than permitting cleartext in
+    release builds.
+
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">play.dhis2.org</domain>
+    </domain-config>
+    -->
+</network-security-config>


### PR DESCRIPTION
## Summary
Replaces `android:usesCleartextTraffic="true"` in `AndroidManifest.xml` with a Network Security Config that blocks cleartext HTTP by default. Adds `app/src/main/res/xml/network_security_config.xml` with `cleartextTrafficPermitted="false"` and system trust anchors.

## Why
The app handles PHI/PII. The explicit `usesCleartextTraffic="true"` was overriding Android 9+'s secure default, exposing credentials and patient data to MITM attacks on any `http://` DHIS2 instance.

## Behavior change
- HTTPS: unchanged
- HTTP: blocked with `java.io.IOException: Cleartext HTTP traffic to <host> not permitted`
- Need HTTP for a specific host? Add a per-host `<domain-config cleartextTrafficPermitted="true">` — ideally via a `debug` manifest override, not globally.

## Test plan
- [ ] `dhis2Debug` against HTTPS server — login + sync work
- [ ] `dhis2Release`, `dhis2PlayServicesRelease`, `dhis2TrainingRelease` build and install
- [ ] HTTP instance is rejected (not transmitted in clear)
- [ ] CI passes — any regression was relying on cleartext