### PR TITLE
fix(security): encrypt user credentials SharedPreferences

### DIFF
--- a/app/src/androidTest/java/org/dhis2/common/preferences/PreferenceTestingImpl.kt
+++ b/app/src/androidTest/java/org/dhis2/common/preferences/PreferenceTestingImpl.kt
@@ -4,11 +4,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import org.dhis2.commons.prefs.PreferenceProviderImpl
 import org.dhis2.commons.Constants
+import org.dhis2.mobile.commons.providers.createSecureSharedPreferences
 
 class PreferenceTestingImpl(context: Context) : PreferenceProviderImpl(context) {
 
     private val sharedPreferences: SharedPreferences =
-        context.getSharedPreferences(Constants.SHARE_PREFS, Context.MODE_PRIVATE)
+        createSecureSharedPreferences(context, Constants.SHARE_PREFS)
 
     override fun setValue(key: String, value: Any?) {
         value?.let {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     api(libs.dhis2.expressionparser)
     api(libs.androidx.coreKtx)
     api(libs.androidx.appcompat)
+    implementation(libs.androidx.security.crypto)
     api(libs.androidx.fragmentKtx)
     api(libs.androidx.viewModelKtx)
     api(libs.androidx.recyclerView)

--- a/commons/src/main/java/org/dhis2/commons/prefs/PreferenceProviderImpl.kt
+++ b/commons/src/main/java/org/dhis2/commons/prefs/PreferenceProviderImpl.kt
@@ -15,6 +15,7 @@ import org.dhis2.mobile.commons.providers.SECURE_PASS
 import org.dhis2.mobile.commons.providers.SECURE_SERVER_URL
 import org.dhis2.mobile.commons.providers.SECURE_USER_NAME
 import org.dhis2.mobile.commons.providers.SHARE_PREFS
+import org.dhis2.mobile.commons.providers.createSecureSharedPreferences
 import org.hisp.dhis.android.core.arch.storage.internal.AndroidSecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.ChunkedSecureStore
 import timber.log.Timber
@@ -24,7 +25,7 @@ open class PreferenceProviderImpl(
     context: Context,
 ) : PreferenceProvider {
     private val sharedPreferences: SharedPreferences =
-        context.getSharedPreferences(SHARE_PREFS, Context.MODE_PRIVATE)
+        createSecureSharedPreferences(context, SHARE_PREFS)
 
     private val asc = AndroidSecureStore(context)
     private val css = ChunkedSecureStore(asc)

--- a/commonskmm/build.gradle.kts
+++ b/commonskmm/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
             implementation(libs.test.espresso.idlingresource)
             api(libs.analytics.timber)
             implementation(libs.androidx.browser)
+            implementation(libs.androidx.security.crypto)
             // Sentry
             api(libs.analytics.sentry)
         }

--- a/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/providers/EncryptedPreferences.kt
+++ b/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/providers/EncryptedPreferences.kt
@@ -1,0 +1,104 @@
+package org.dhis2.mobile.commons.providers
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import timber.log.Timber
+import java.io.File
+
+const val ENCRYPTED_SHARE_PREFS = "org.dhis2.enc"
+private const val MIGRATION_MARKER = "__enc_migrated_from_plain"
+
+/**
+ * Returns a SharedPreferences backed by AES-256-GCM encryption with keys
+ * anchored in the Android Keystore. On first use, any entries still sitting in
+ * the legacy plaintext prefs file are copied over and the plaintext file is
+ * cleared.
+ *
+ * On API < 23 the Keystore cannot back the master key, so we fall back to the
+ * plain SharedPreferences (same behaviour as before this change). API 21-22
+ * represents a negligible install base but still needs to not crash.
+ */
+fun createSecureSharedPreferences(
+    context: Context,
+    plainPrefsName: String,
+): SharedPreferences {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        return context.getSharedPreferences(plainPrefsName, Context.MODE_PRIVATE)
+    }
+
+    val encrypted = openEncryptedPrefs(context)
+    migrateFromPlainIfNeeded(context, encrypted, plainPrefsName)
+    return encrypted
+}
+
+private fun openEncryptedPrefs(context: Context): SharedPreferences {
+    val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+    return try {
+        buildEncryptedPrefs(context, masterKeyAlias)
+    } catch (e: Exception) {
+        // Master key or file is unreadable (keystore invalidated, backup-restored
+        // across devices, MAC mismatch). Wipe and recreate; any stored credentials
+        // are lost and the user must re-authenticate.
+        Timber.w(e, "Encrypted prefs unreadable; resetting")
+        deleteSharedPreferencesFiles(context, ENCRYPTED_SHARE_PREFS)
+        buildEncryptedPrefs(context, masterKeyAlias)
+    }
+}
+
+private fun buildEncryptedPrefs(
+    context: Context,
+    masterKeyAlias: String,
+): SharedPreferences = EncryptedSharedPreferences.create(
+    ENCRYPTED_SHARE_PREFS,
+    masterKeyAlias,
+    context,
+    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+)
+
+private fun migrateFromPlainIfNeeded(
+    context: Context,
+    encrypted: SharedPreferences,
+    plainPrefsName: String,
+) {
+    if (encrypted.getBoolean(MIGRATION_MARKER, false)) return
+
+    val plain = context.getSharedPreferences(plainPrefsName, Context.MODE_PRIVATE)
+    val entries = plain.all
+    encrypted.edit {
+        for ((key, value) in entries) {
+            when (value) {
+                is String -> putString(key, value)
+                is Boolean -> putBoolean(key, value)
+                is Int -> putInt(key, value)
+                is Long -> putLong(key, value)
+                is Float -> putFloat(key, value)
+                is Set<*> -> {
+                    if (value.all { it is String }) {
+                        @Suppress("UNCHECKED_CAST")
+                        putStringSet(key, value as Set<String>)
+                    }
+                }
+            }
+        }
+        putBoolean(MIGRATION_MARKER, true)
+    }
+    if (entries.isNotEmpty()) {
+        plain.edit { clear() }
+    }
+}
+
+private fun deleteSharedPreferencesFiles(context: Context, name: String) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        context.deleteSharedPreferences(name)
+        return
+    }
+    val dir = File(context.applicationInfo.dataDir, "shared_prefs")
+    File(dir, "$name.xml").delete()
+    File(dir, "$name.xml.bak").delete()
+}

--- a/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/providers/PreferenceProviderImpl.kt
+++ b/commonskmm/src/androidMain/kotlin/org/dhis2/mobile/commons/providers/PreferenceProviderImpl.kt
@@ -16,7 +16,7 @@ internal class PreferenceProviderImpl(
     context: Context,
 ) : PreferenceProvider {
     private val sharedPreferences: SharedPreferences =
-        context.getSharedPreferences(SHARE_PREFS, Context.MODE_PRIVATE)
+        createSecureSharedPreferences(context, SHARE_PREFS)
 
     private val asc = AndroidSecureStore(context)
     private val css = ChunkedSecureStore(asc)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ ktlint = "13.1.0"
 sonarqube = "7.0.0.6105"
 browser = "1.9.0"
 biometric = "1.1.0"
+securityCrypto = "1.0.0"
 coil = "3.3.0"
 cyclonedx = "2.1.0"
 
@@ -140,6 +141,7 @@ androidx-material3-window = { group = "androidx.compose.material3", name = "mate
 compose-material3-window = { group = "org.jetbrains.compose.material3", name = "material3-window-size-class", version.ref = "material3WindowSizeCompose" }
 androidx-material3-adaptative-android = { group = "androidx.compose.material3.adaptive", name = "adaptive-android", version.ref = "material3AdaptiveAndroid" }
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 kotlin-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxserialization" }
 google-guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }


### PR DESCRIPTION
## Summary
Migrates `PreferenceProviderImpl` from plaintext `SharedPreferences` to `EncryptedSharedPreferences` so user data (server URL, username, biometric wrappers, cached JSON) is no longer readable via `adb run-as`, device backup, or rooted access.

- **Crypto:** `AES256_SIV` keys, `AES256_GCM` values, master key in Android Keystore.
- **New helper:** `EncryptedPreferences.kt` in `commonskmm` — single codepath shared by both `PreferenceProviderImpl`s (Dagger in `commons`, Koin in `commonskmm`) and `PreferenceTestingImpl`.
- **Migration:** on first open, entries in the legacy `org.dhis2` file are copied into `org.dhis2.enc` and the legacy file is cleared. A boolean marker prevents re-running.
- **Fallbacks:** below API 23, uses plaintext (Keystore unavailable). On API 23+, any master-key/MAC failure (e.g. Keystore wiped, cross-device restore) deletes and recreates the file and prompts re-auth instead of crashing.

Both `PreferenceProviderImpl` copies had to be migrated together — both were registered as active singletons writing to the same file, so migrating only one would leave a half-encrypted store.

## Test plan
- [ ] Fresh install: `org.dhis2.enc` is created and its contents are binary.
- [ ] Upgrade from prior build: user stays signed in, legacy `org.dhis2.xml` is empty.
- [ ] Sign-in / sign-out still work.
- [ ] Clear Keystore credentials → app recovers and re-prompts auth (no crash).
- [ ] API 21/22: plaintext fallback works.
- [ ] Androidtest suite passes.