### PR TITLE
fix(security): redact auth headers from OkHttp logging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -276,6 +276,7 @@ dependencies {
     implementation(libs.github.fancyshowcase)
     implementation(libs.lottie)
     implementation(libs.network.okhttp)
+    implementation(libs.network.okhttp.logging)
     implementation(libs.analytics.matomo)
     implementation(libs.analytics.rxlint)
     implementation(libs.analytics.customactivityoncrash)

--- a/app/src/main/java/org/dhis2/data/server/ServerModule.kt
+++ b/app/src/main/java/org/dhis2/data/server/ServerModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import dhis2.org.analytics.charts.Charts
 import dhis2.org.analytics.charts.DhisAnalyticCharts
 import okhttp3.Interceptor
+import okhttp3.logging.HttpLoggingInterceptor
 import org.dhis2.BuildConfig
 import org.dhis2.R
 import org.dhis2.bindings.app
@@ -181,6 +182,7 @@ class ServerModule {
                     AnalyticsHelper(context.app().appComponent().matomoController()),
                 ),
             )
+            interceptors.add(redactingLoggingInterceptor())
             return D2Configuration
                 .builder()
                 .appName(BuildConfig.APPLICATION_ID)
@@ -192,6 +194,19 @@ class ServerModule {
                 .context(context)
                 .build()
         }
+
+        private fun redactingLoggingInterceptor(): HttpLoggingInterceptor =
+            HttpLoggingInterceptor().apply {
+                level = if (BuildConfig.DEBUG) {
+                    HttpLoggingInterceptor.Level.BASIC
+                } else {
+                    HttpLoggingInterceptor.Level.NONE
+                }
+                redactHeader("Authorization")
+                redactHeader("Cookie")
+                redactHeader("Set-Cookie")
+                redactHeader("Proxy-Authorization")
+            }
     }
 
     @Provides

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -150,6 +150,7 @@ google-material3-themeadapter = { group = "com.google.accompanist", name = "acco
 google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 network-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+network-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 dates-jodatime = { group = "joda-time", name = "joda-time", version.ref = "jodatime" }
 dagger = { group = "com.google.dagger", name = "dagger", version.ref = "dagger" }
 dagger-compiler = { group = "com.google.dagger", name = "dagger-compiler", version.ref = "dagger" }


### PR DESCRIPTION
## Summary

`logging-interceptor:4.12.0` is on the runtime classpath (force-pinned in `app/build.gradle.kts`), but no app-owned `HttpLoggingInterceptor` exists with `redactHeader(...)` configured. A misconfigured dev build or a future SDK change that enables body-level logging would leak `Authorization` to logcat.

## Change

- Register one shared `HttpLoggingInterceptor` on `D2Configuration.networkInterceptors` in `ServerModule.getD2Configuration(...)`.
- `redactHeader("Authorization")`, `"Cookie"`, `"Set-Cookie"`, `"Proxy-Authorization"`.
- Level: `BASIC` in debug, `NONE` in release.

## Test plan

- [ ] Debug build: logcat shows method + URL for each request; `Authorization: ██` when BODY is enabled locally.
- [ ] Release build: logcat shows no request lines from this interceptor.
- [ ] Login + sync still work (sanity check the chain didn't break).