### PR TITLE
chore: [ANDROAPP-7592] adapt to SDK domain model changes

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/EventInitialTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/eventsWithoutRegistration/eventDetails/EventInitialTest.kt
@@ -91,9 +91,9 @@ class EventInitialTest {
     private val categoryOptionCombo: CategoryOptionCombo = mock {
         on { uid() } doReturn CAT_OPTION_COMBO_UID
     }
-    private val orgUnit: OrganisationUnit = mock {
-        on { uid() } doReturn ORG_UNIT_UID
-    }
+    private val orgUnit: OrganisationUnit = OrganisationUnit.builder()
+        .uid(ORG_UNIT_UID)
+        .build()
     private val geometryModel: FieldUiModel = mock {
         on { value } doReturn COORDINATES
     }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/BaseIndicatorRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/BaseIndicatorRepository.kt
@@ -13,6 +13,7 @@ import org.dhis2.mobileProgramRules.RuleConstants
 import org.dhis2.mobileProgramRules.RuleEngineHelper
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl
+import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.ProgramRuleActionType
 import org.hisp.dhis.rules.models.RuleEffect
@@ -26,6 +27,9 @@ abstract class BaseIndicatorRepository(
     open val programUid: String,
     open val resourceManager: ResourceManager,
 ) : IndicatorRepository {
+    private val defaultCategoryCombo =
+        d2.categoryModule().categoryCombos().byIsDefault().eq(true).blockingGet().first()
+
     fun getIndicators(
         filter: Boolean = true,
         indicatorValueCalculator: (String) -> String,
@@ -120,6 +124,8 @@ abstract class BaseIndicatorRepository(
                                 .builder()
                                 .uid(UidGeneratorImpl().generate())
                                 .displayName((ruleAction).content())
+                                .categoryCombo(ObjectWithUid.create(defaultCategoryCombo.uid()))
+                                .attributeCombo(ObjectWithUid.create(defaultCategoryCombo.uid()))
                                 .build(),
                             ruleEffect.data,
                             color,
@@ -134,6 +140,8 @@ abstract class BaseIndicatorRepository(
                             ProgramIndicator
                                 .builder()
                                 .uid(UidGeneratorImpl().generate())
+                                .attributeCombo(ObjectWithUid.create(defaultCategoryCombo.uid()))
+                                .categoryCombo(ObjectWithUid.create(defaultCategoryCombo.uid()))
                                 .displayName("${ruleAction.content() ?: ""}${ruleEffect.data}")
                                 .build(),
                             "",
@@ -242,7 +250,7 @@ abstract class BaseIndicatorRepository(
                         addAll(
                             ruleIndicators.filter {
                                 it is IndicatorModel &&
-                                    it.location == LOCATION_INDICATOR_WIDGET
+                                        it.location == LOCATION_INDICATOR_WIDGET
                             },
                         )
                     }.sortedBy { (it as IndicatorModel).programIndicator?.displayName() }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/BaseIndicatorRepository.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/BaseIndicatorRepository.kt
@@ -27,9 +27,6 @@ abstract class BaseIndicatorRepository(
     open val programUid: String,
     open val resourceManager: ResourceManager,
 ) : IndicatorRepository {
-    private val defaultCategoryCombo =
-        d2.categoryModule().categoryCombos().byIsDefault().eq(true).blockingGet().first()
-
     fun getIndicators(
         filter: Boolean = true,
         indicatorValueCalculator: (String) -> String,
@@ -106,6 +103,8 @@ abstract class BaseIndicatorRepository(
 
     private fun applyRuleEffectForIndicators(calcResult: Result<List<RuleEffect>>): List<IndicatorModel> {
         val indicators = arrayListOf<IndicatorModel>()
+        val defaultCategoryCombo =
+            d2.categoryModule().categoryCombos().byIsDefault().eq(true).blockingGet().first()
 
         if (calcResult.isFailure) {
             Timber.e(calcResult.exceptionOrNull())

--- a/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/eventsWithoutRegistration/eventInitial/EventInitialPresenterTest.kt
@@ -360,9 +360,9 @@ class EventInitialPresenterTest {
     }
 
     private fun initMocks(
-        uid: String?,
+        uid: String,
         eventId: String?,
-        programStageUid: String?,
+        programStageUid: String,
         moreOrgUnits: Boolean = false,
     ) {
         val program =

--- a/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/searchTrackEntity/SearchRepositoryTest.kt
@@ -290,7 +290,7 @@ class SearchRepositoryTest {
         ) doReturn enrollmentsForInfoToReturn
 
         val programUid =
-            if (enrollmentsForInfoToReturn.isNotEmpty()) enrollmentsForInfoToReturn[0].program() else "programUid"
+            if (enrollmentsForInfoToReturn.isNotEmpty()) enrollmentsForInfoToReturn[0].program()!! else "programUid"
         whenever(d2.programModule().programs()) doReturn programCollectionRepository
         whenever(
             programCollectionRepository.uid(any()),

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/TeiAttributesProviderTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/TeiAttributesProviderTest.kt
@@ -241,7 +241,7 @@ class TeiAttributesProviderTest {
 
     private fun mockProgramTrackedEntityAttributes(
         teType: String,
-        program: String? = "program",
+        program: String = "program",
     ) {
         whenever(d2.programModule().programs()) doReturn mock()
         whenever(d2.programModule().programs().byTrackedEntityTypeUid()) doReturn mock()

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/EventIndicatorRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/EventIndicatorRepositoryTest.kt
@@ -6,6 +6,10 @@ import kotlinx.coroutines.test.runTest
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.mobileProgramRules.RuleEngineHelper
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
+import org.hisp.dhis.android.core.category.CategoryCombo
+import org.hisp.dhis.android.core.category.CategoryComboCollectionRepository
+import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.ProgramRuleAction
@@ -28,6 +32,7 @@ class EventIndicatorRepositoryTest {
 
     @Before
     fun setUp() {
+        stubDefaultCategoryComboChain()
         whenever(
             d2
                 .enrollmentModule()
@@ -73,11 +78,11 @@ class EventIndicatorRepositoryTest {
                 .one()
                 .blockingGet(),
         ) doReturn
-            Enrollment
-                .builder()
-                .uid("enrollmentUid")
-                .attributeOptionCombo("attributeOptionComboUid")
-                .build()
+                Enrollment
+                    .builder()
+                    .uid("enrollmentUid")
+                    .attributeOptionCombo("attributeOptionComboUid")
+                    .build()
         whenever(
             resourceManager.sectionIndicators(),
         ) doReturn "Indicators"
@@ -223,10 +228,10 @@ class EventIndicatorRepositoryTest {
         val result = repository.fetchData()
         assertTrue(
             result.size == 5 &&
-                result[0] is SectionTitle &&
-                (result[0] as SectionTitle).title == "Feedback" &&
-                result[2] is SectionTitle &&
-                (result[2] as SectionTitle).title == "Indicators",
+                    result[0] is SectionTitle &&
+                    (result[0] as SectionTitle).title == "Feedback" &&
+                    result[2] is SectionTitle &&
+                    (result[2] as SectionTitle).title == "Indicators",
         )
     }
 
@@ -236,11 +241,15 @@ class EventIndicatorRepositoryTest {
                 .builder()
                 .uid("programIndicatorUid_1")
                 .displayInForm(true)
+                .attributeCombo(ObjectWithUid.create("defaultCC"))
+                .categoryCombo(ObjectWithUid.create("defaultCC"))
                 .build(),
             ProgramIndicator
                 .builder()
                 .uid("programIndicatorUid_2")
                 .displayInForm(false)
+                .attributeCombo(ObjectWithUid.create("defaultCC"))
+                .categoryCombo(ObjectWithUid.create("defaultCC"))
                 .build(),
         )
 
@@ -278,4 +287,14 @@ class EventIndicatorRepositoryTest {
                 ),
             ),
         )
+
+    private fun stubDefaultCategoryComboChain() {
+        val booleanFilter: BooleanFilterConnector<CategoryComboCollectionRepository> = mock()
+        val categoryCombosRepo: CategoryComboCollectionRepository = mock {
+            on { byIsDefault() } doReturn booleanFilter
+            on { blockingGet() } doReturn listOf(CategoryCombo.builder().uid("defaultCC").build())
+        }
+        doReturn(categoryCombosRepo).whenever(booleanFilter).eq(true)
+        whenever(d2.categoryModule().categoryCombos()) doReturn categoryCombosRepo
+    }
 }

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/IndicatorsPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/IndicatorsPresenterTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.dhis2.commons.viewmodel.DispatcherProvider
+import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.junit.After
 import org.junit.Before
@@ -75,6 +76,8 @@ class IndicatorsPresenterTest {
                     .builder()
                     .uid("indicator_uid")
                     .displayInForm(true)
+                    .attributeCombo(ObjectWithUid.create("defaultCC"))
+                    .categoryCombo(ObjectWithUid.create("defaultCC"))
                     .build(),
                 "indicator_value",
                 "#ffffff",

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/TrackerAnalyticsRepositoryTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/dashboardfragments/indicators/TrackerAnalyticsRepositoryTest.kt
@@ -8,6 +8,10 @@ import kotlinx.coroutines.test.runTest
 import org.dhis2.commons.resources.ResourceManager
 import org.dhis2.mobileProgramRules.RuleEngineHelper
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
+import org.hisp.dhis.android.core.category.CategoryCombo
+import org.hisp.dhis.android.core.category.CategoryComboCollectionRepository
+import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.common.RelativePeriod
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.period.PeriodType
@@ -34,6 +38,7 @@ class TrackerAnalyticsRepositoryTest {
 
     @Before
     fun setUp() {
+        stubDefaultCategoryComboChain()
         whenever(
             d2
                 .enrollmentModule()
@@ -520,11 +525,15 @@ class TrackerAnalyticsRepositoryTest {
                 .builder()
                 .uid("programIndicatorUid_1")
                 .displayInForm(true)
+                .attributeCombo(ObjectWithUid.create("defaultCC"))
+                .categoryCombo(ObjectWithUid.create("defaultCC"))
                 .build(),
             ProgramIndicator
                 .builder()
                 .uid("programIndicatorUid_2")
                 .displayInForm(false)
+                .attributeCombo(ObjectWithUid.create("defaultCC"))
+                .categoryCombo(ObjectWithUid.create("defaultCC"))
                 .build(),
         )
 
@@ -573,4 +582,14 @@ class TrackerAnalyticsRepositoryTest {
                 10,
             ),
         )
+
+    private fun stubDefaultCategoryComboChain() {
+        val booleanFilter: BooleanFilterConnector<CategoryComboCollectionRepository> = mock()
+        val categoryCombosRepo: CategoryComboCollectionRepository = mock {
+            on { byIsDefault() } doReturn booleanFilter
+            on { blockingGet() } doReturn listOf(CategoryCombo.builder().uid("defaultCC").build())
+        }
+        doReturn(categoryCombosRepo).whenever(booleanFilter).eq(true)
+        whenever(d2.categoryModule().categoryCombos()) doReturn categoryCombosRepo
+    }
 }

--- a/dhis_android_analytics/src/test/java/dhis2/org/analytics/charts/ChartsRepositoryTest.kt
+++ b/dhis_android_analytics/src/test/java/dhis2/org/analytics/charts/ChartsRepositoryTest.kt
@@ -669,6 +669,8 @@ class ChartsRepositoryTest {
                     ProgramIndicator
                         .builder()
                         .uid("indicator_1")
+                        .attributeCombo(ObjectWithUid.create("defaultCC"))
+                        .categoryCombo(ObjectWithUid.create("defaultCC"))
                         .build(),
                 )
         }


### PR DESCRIPTION
In the context of the transition towards a KMP, the domain models need to be migrated from Java to Kotlin. The SDK has started this process and small changes are expected to be done, in this case, just  nullable uid types need to be changed to non-null in some tests.

Also, from another PR merge, other changes are required concerning the PI disaggregation metadata download, which added two new mandatory fields to the PI model. Some tests need to be updated by adding the new parameters.

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7592).
