### PR TITLE
fix: [SENTRY-83MK] catch D2Error in TrackedEntityDataValue blockingSetCheck

### DIFF
--- a/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
@@ -197,17 +197,22 @@ fun TrackedEntityDataValueObjectRepository.blockingSetCheck(
     d2: D2,
     deUid: String,
     value: String,
-): Boolean =
-    d2.dataElementModule().dataElements().uid(deUid).blockingGet()?.let {
+): Boolean {
+    return d2.dataElementModule().dataElements().uid(deUid).blockingGet()?.let {
         if (check(d2, it.valueType(), it.optionSet()?.uid(), value)) {
             val finalValue = assureCodeForOptionSet(d2, it.optionSet()?.uid(), value)
-            blockingSet(finalValue)
+            try {
+                blockingSet(finalValue)
+            } catch (e: Exception) {
+                return false
+            }
             true
         } else {
             blockingDeleteIfExist()
             false
         }
     } ?: false
+}
 
 fun String?.withValueTypeCheck(valueType: ValueType?): String? {
     return this?.let {


### PR DESCRIPTION
## Summary
- Fixes `AutoValue_D2Error` crash in `ValueExtensions.blockingSetCheck` affecting **700 users** (1,156 events) in `com.dhis2@3.4.0+153`
- Root cause: `TrackedEntityDataValueObjectRepository.blockingSetCheck` called `blockingSet()` without a try-catch; the sibling `TrackedEntityAttributeValueObjectRepository` version already had this guard but it was never added to the data-value variant
- Fix: wrapped `blockingSet(finalValue)` in try-catch returning `false` on any exception, consistent with the TEAttribute pattern

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-83MK
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-83MK/

## Test plan
- [ ] `./gradlew :commons:ktlintCheck` passes
- [ ] `./gradlew :commons:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)