### PR TITLE
fix: [SENTRY-83QB] IllegalStateException after onSaveInstanceState in SyncStatusDialog

### DIFF
--- a/app/src/main/java/org/dhis2/utils/granularsync/SyncStatusDialog.kt
+++ b/app/src/main/java/org/dhis2/utils/granularsync/SyncStatusDialog.kt
@@ -112,9 +112,9 @@ class SyncStatusDialog :
                     val syncState by viewModel.currentState.collectAsState()
                     syncState?.let { syncUiState ->
                         when {
-                            syncUiState.shouldDismissOnUpdate -> dismiss()
+                            syncUiState.shouldDismissOnUpdate -> dismissAllowingStateLoss()
                             syncing && syncUiState.syncState == SyncStatus.SYNCED -> {
-                                dismiss()
+                                dismissAllowingStateLoss()
                                 Toast
                                     .makeText(
                                         requireContext(),


### PR DESCRIPTION
## Summary
- Fixes `IllegalStateException: Can not perform this action after onSaveInstanceState` in `SyncStatusDialog` affecting **676 users** (1,017 events)
- Root cause: two `dismiss()` calls inside a Compose `setContent` block are triggered by `StateFlow` recomposition, which can fire asynchronously after `onSaveInstanceState` (e.g. when a sync update arrives while the user navigates away)
- Fix: changed both `dismiss()` calls to `dismissAllowingStateLoss()` — safe here because the dialog is a UI overlay with no data consequences if its dismiss state is lost

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-83QB
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-83QB/

## Test plan
- [ ] `./gradlew :app:ktlintCheck` passes
- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] Manually verify sync dialog dismisses correctly after a sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)