### PR TITLE
fix: [SENTRY-7X2R] NPE when event.programStage() is null in EventCaptureRepositoryImpl

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureRepositoryImpl.java
+++ b/app/src/main/java/org/dhis2/usescases/eventsWithoutRegistration/eventCapture/EventCaptureRepositoryImpl.java
@@ -65,7 +65,11 @@ public class EventCaptureRepositoryImpl implements EventCaptureContract.EventCap
     @NonNull
     @Override
     public Flowable<String> programStageName() {
-        return d2.programModule().programStages().uid(getCurrentEvent().programStage()).get()
+        Event currentEvent = getCurrentEvent();
+        if (currentEvent == null || currentEvent.programStage() == null) {
+            return Flowable.empty();
+        }
+        return d2.programModule().programStages().uid(currentEvent.programStage()).get()
                 .map(BaseIdentifiableObject::displayName)
                 .toFlowable();
     }
@@ -116,7 +120,11 @@ public class EventCaptureRepositoryImpl implements EventCaptureContract.EventCap
     @NonNull
     @Override
     public Observable<String> programStage() {
-        return Observable.just(Objects.requireNonNull(getCurrentEvent().programStage()));
+        Event currentEvent = getCurrentEvent();
+        if (currentEvent == null || currentEvent.programStage() == null) {
+            return Observable.empty();
+        }
+        return Observable.just(currentEvent.programStage());
     }
 
     @Override
@@ -186,6 +194,9 @@ public class EventCaptureRepositoryImpl implements EventCaptureContract.EventCap
     @Override
     public boolean hasAnalytics() {
         Event currentEvent = getCurrentEvent();
+        if (currentEvent == null || currentEvent.program() == null) {
+            return false;
+        }
         boolean hasProgramIndicators = !d2.programModule().programIndicators().byProgramUid().eq(currentEvent.program()).blockingIsEmpty();
         List<ProgramRule> programRules = d2.programModule().programRules().withProgramRuleActions()
                 .byProgramUid().eq(currentEvent.program()).blockingGet();


### PR DESCRIPTION
## Summary
- Fixes `NullPointerException` crash blocking event capture for **530 users** (1,573 events)
- Root cause: `getCurrentEvent()` can return `null` (event deleted during sync) and `programStage()`/`program()` can be `null` on partially-synced events; code used `Objects.requireNonNull` without guards
- Fix: added `null` guards in three methods — `programStageName()`, `programStage()`, `hasAnalytics()` — returning empty observables or `false` instead of throwing

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-7X2R
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-7X2R/

## Test plan
- [ ] `./gradlew :app:ktlintCheck` passes
- [ ] `./gradlew :app:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)