### PR TITLE
fix(sentry-83nf): move blockingGet calls off main thread in SplashPresenter

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/splash/SplashPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/splash/SplashPresenter.kt
@@ -33,20 +33,23 @@ class SplashPresenter internal constructor(
                 userManager.isUserLoggedIn
                     .delay(2000, TimeUnit.MILLISECONDS, schedulerProvider.io())
                     .subscribeOn(schedulerProvider.io())
+                    .map { userLogged ->
+                        if (userLogged && trackingPermissionGranted()) {
+                            val systemInfo =
+                                userManager.d2
+                                    .systemInfoModule()
+                                    .systemInfo()
+                                    .blockingGet()
+                            trackUserInfo(
+                                serverUrl = systemInfo?.contextPath() ?: "",
+                                serverVersion = systemInfo?.version() ?: "",
+                            )
+                        }
+                        userLogged
+                    }
                     .observeOn(schedulerProvider.ui())
                     .subscribe(
                         { userLogged ->
-                            if (userLogged && trackingPermissionGranted()) {
-                                val systemInfo =
-                                    userManager.d2
-                                        .systemInfoModule()
-                                        .systemInfo()
-                                        .blockingGet()
-                                trackUserInfo(
-                                    serverUrl = systemInfo?.contextPath() ?: "",
-                                    serverVersion = systemInfo?.version() ?: "",
-                                )
-                            }
                             view.goToNextScreen(
                                 userLogged,
                                 preferenceProvider.getBoolean(


### PR DESCRIPTION
## Summary
- Moves `trackingPermissionGranted()` and `systemInfo.blockingGet()` from the UI thread (inside `.subscribe()` after `.observeOn(schedulerProvider.ui())`) to the IO thread (inside `.map()` before `.observeOn()`)
- Prevents ANR caused by blocking disk/database reads on the main thread during splash screen initialization

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-83NF
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-83NF/

## Test plan
- [ ] App launches normally when user is logged in
- [ ] Crash analytics tracking still fires when permission is granted
- [ ] Session lock and sync state routing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)