### PR TITLE
fix(sentry-83rw): wrap blockingIsEditable in runCatching in EventRepository

### DIFF
--- a/form/src/main/java/org/dhis2/form/data/EventRepository.kt
+++ b/form/src/main/java/org/dhis2/form/data/EventRepository.kt
@@ -216,10 +216,12 @@ class EventRepository(
     override fun isEvent(): Boolean = true
 
     override fun isEventEditable() =
-        d2
-            .eventModule()
-            .eventService()
-            .blockingIsEditable(eventUid)
+        runCatching {
+            d2
+                .eventModule()
+                .eventService()
+                .blockingIsEditable(eventUid)
+        }.getOrDefault(false)
 
     override fun eventMode(): EventMode = eventMode
 


### PR DESCRIPTION
## Summary
- `blockingIsEditable()` throws `D2Error` when the event or its program stage is not found in the local database
- Wrapping with `runCatching` and defaulting to `false` prevents an unhandled crash and treats unknown events as non-editable

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-83RW
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-83RW/

## Test plan
- [ ] Events open normally in event capture form
- [ ] Event form correctly shows read-only state when event is non-editable
- [ ] App does not crash when event data is unexpectedly missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)