### PR TITLE
docs: update OpenID/OAuth configuration instructions

### DIFF
--- a/docs/configure-openid-oauth.md
+++ b/docs/configure-openid-oauth.md
@@ -6,75 +6,133 @@ sidebar_position: 3
 
 ## Configure OpenID / OAuth
 
-Since version 2.4. The DHIS2 android app supports login with an OpenID or OAuth provider. This
-feature is not available by default, you need to add the configuration provided below and distribute
-your own apk. OpenID has to be enabled in the web as well and the user OpenID parameter must be
-configured.
+Since version 2.4, the DHIS2 Android app supports login with an OpenID Connect or OAuth 2.0
+provider. This feature is not available by default — you need to supply the configuration described
+below and distribute your own APK. OpenID Connect must also be enabled on the DHIS2 web server and
+the user's OpenID parameter must be configured.
 
-Under the **app/src/main/res/raw** you will find the **openid_config** file.
+### Configuration
 
-```json
-{
-  "serverUrl": "<your server url>",
-  "loginLabel": "<text to display in the open id login button>",
-  "clientId": "<client id from the auth provider>",
-  "redirectUri": "<redirect uri from the auth provider>",
-  "discoveryUri": "<openid discovery url from the auth provider",
-  "authorizationUrl": "<authorization url from the auth provider>",
-  "tokenUrl": "<toker url from the auth provider>"
-}
+All OpenID configuration is supplied via **environment variables** (or `local.properties` for local
+development). The build script reads these values and embeds them in `BuildConfig` at compile time.
+
+#### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `OPEN_ID_TYPE` | Yes | Mode: `discovery` (recommended) or `token` |
+| `OPEN_ID_SERVER` | Yes | Your DHIS2 server URL |
+| `OPEN_ID_CLIENT` | Yes | Client ID from the auth provider |
+| `OPEN_ID_REDIRECT_URI` | Yes | Redirect URI registered with the auth provider |
+| `OPEN_ID_AUTH_SCHEME` | Yes | URI scheme of the redirect URI (e.g. `com.googleusercontent.apps.CLIENT_ID_PREFIX`) |
+| `OPEN_ID_DISCOVERY_URI` | Discovery mode | OpenID discovery endpoint (e.g. `https://provider/.well-known/openid-configuration`) |
+| `OPEN_ID_AUTHORIZATION_URL` | Token mode | Authorization endpoint URL |
+| `OPEN_ID_TOKEN_URL` | Token mode | Token endpoint URL |
+| `OPEN_ID_BUTTON_TEXT` | No | Custom label for the OpenID login button |
+| `OPEN_ID_PROMPT` | No | OpenID `prompt` parameter (e.g. `login`, `consent`, `select_account`) |
+
+For local development you can place the same key-value pairs in `local.properties` at the project
+root instead of setting environment variables. The build script checks environment variables first
+and falls back to `local.properties`.
+
+#### Discovery mode vs Token mode
+
+Set `OPEN_ID_TYPE` to choose how the app locates the provider endpoints:
+
+- **`discovery`** (recommended) — supply `OPEN_ID_DISCOVERY_URI`. The app fetches the provider's
+  metadata document at startup and resolves the authorization and token endpoints automatically.
+- **`token`** — supply `OPEN_ID_AUTHORIZATION_URL` and `OPEN_ID_TOKEN_URL` directly, without a
+  discovery document.
+
+Use `discovery` whenever the provider publishes a `.well-known/openid-configuration` endpoint.
+
+#### Google example (discovery mode)
+
+```properties
+# local.properties or environment variables
+OPEN_ID_TYPE=discovery
+OPEN_ID_SERVER=https://play.dhis2.org/android-current
+OPEN_ID_CLIENT=CLIENT_ID_PREFIX.apps.googleusercontent.com
+OPEN_ID_REDIRECT_URI=com.googleusercontent.apps.CLIENT_ID_PREFIX:/oauth2
+OPEN_ID_AUTH_SCHEME=com.googleusercontent.apps.CLIENT_ID_PREFIX
+OPEN_ID_DISCOVERY_URI=https://accounts.google.com/.well-known/openid-configuration
+OPEN_ID_BUTTON_TEXT=Login with Google
 ```
 
-How you should fill this file depends on the provider you are using. The following example shows how
-the file would look like using Google as the provider:
+### AndroidManifest.xml
 
-```json
-{
-  "serverUrl": "https://play.dhis2.org/android-current",
-  "loginLabel": "Login with google",
-  "clientId": "CLIEND_ID_PREFIX.apps.googleusercontent.com",
-  "redirectUri": "com.googleusercontent.apps.CLIEND_ID_PREFIX:/oauth2",
-  "discoveryUri": "https://accounts.google.com/.well-known/openid-configuration",
-  "authorizationUrl": null,
-  "tokenUrl": null
-}
-```
+The app's `AndroidManifest.xml` already contains the `RedirectUriReceiverActivity` declaration.
+The redirect URI scheme is injected automatically from `OPEN_ID_AUTH_SCHEME` — **no manual editing
+of the manifest is required**.
 
-For OpenID providers it is **recommended** to use the discoveryUri parameter if possible instead of
-the authorizationUrl and tokenUrl.
-
-The next step is to include the following activity in the **AndroidManifest.xml** file. You will
-need to replace the scheme so that the android app can be relaunched after a successful login.
+For reference, the relevant activity entry looks like:
 
 ```xml
-
 <activity android:name="net.openid.appauth.RedirectUriReceiverActivity" android:exported="true"
     tools:node="replace">
     <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="<your redirect url scheme>" />
+        <data android:scheme="${openIdAuthScheme}" />
     </intent-filter>
 </activity>
 ```
 
-Following our example, the Google scheme would be:
-`com.googleusercontent.apps.CLIEND_ID_PREFIX`
+#### Advanced: hardcoding OidcInfo in source code
 
-When launching the app, a new button will be displayed in the login screen.
+As an alternative to environment variables, you can hardcode the provider configuration directly in
+`login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/LoginScreen.kt` by replacing
+the body of `fixedOpenIdProvider`:
+
+```kotlin
+// Discovery mode
+private fun fixedOpenIdProvider(oidcInfo: OidcInfo): OidcInfo =
+    OidcInfo.Discovery(
+        server = "https://play.dhis2.org/android-current",
+        loginButtonText = "Login with Google",
+        clientId = "CLIENT_ID_PREFIX.apps.googleusercontent.com",
+        redirectUri = "com.googleusercontent.apps.CLIENT_ID_PREFIX:/oauth2",
+        discoveryUri = "https://accounts.google.com/.well-known/openid-configuration",
+        prompt = null,
+    )
+
+// Token mode
+private fun fixedOpenIdProvider(oidcInfo: OidcInfo): OidcInfo =
+    OidcInfo.Token(
+        server = "https://your.dhis2.server",
+        loginLabel = "Login with MyProvider",
+        clientId = "your-client-id",
+        redirectUri = "your.app.scheme:/oauth2",
+        authorizationUrl = "https://provider/oauth2/authorize",
+        tokenUrl = "https://provider/oauth2/token",
+        prompt = null,
+    )
+```
+
+You still need to set `OPEN_ID_AUTH_SCHEME` (or the `manifestPlaceholders["openIdAuthScheme"]`
+value in `app/build.gradle.kts`) to match the URI scheme in `redirectUri`, so the OS can redirect
+back to the app after a successful login.
+
+> **This approach is not recommended.** It embeds credentials in source code, complicates
+> multi-environment builds, and requires a code change to rotate any value. Prefer environment
+> variables for all production and CI/CD builds.
+
+### Login screen
+
+When the configuration is present, a new button is displayed on the login screen.
 
 ![](resources/open_id_login.png)
 
 ### OpenID providers and configuration guidelines
 
-Here you will find a list of available providers and how to get any info needed to set the *
-*openid_config** file.
+Here you will find a list of available providers and how to obtain the values needed for the
+configuration variables above.
 
 * [Google](https://github.com/openid/AppAuth-Android/blob/master/app/README-Google.md)
 * [GitHub](https://docs.github.com/en/developers/apps/authorizing-oauth-apps)
 * [ID-porten](https://docs.digdir.no/oidc_protocol_authorize.html)
 * [OKTA](https://github.com/openid/AppAuth-Android/blob/master/app/README-Okta.md)
 * [KeyCloak](https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_authorization_api)
-* [Azure AD](https://docs.microsoft.com/es-es/azure/active-directory-b2c/signin-appauth-android?tabs=app-reg-ga)
+* [Azure AD](https://learn.microsoft.com/en-us/azure/active-directory-b2c/configure-authentication-sample-android-app?tabs=kotlin)
 * [WS02](https://medium.com/@maduranga.siriwardena/configuring-appauth-android-with-wso2-identity-server-8d378835c10a)


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7593).

Updates the documentation to reflect changes in the OpenID and OAuth configuration process. The configuration has moved from a static JSON file to environment variables and `local.properties`, which are now injected via `BuildConfig` and manifest placeholders.

Key changes include:
* Added documentation for new environment variables (e.g., `OPEN_ID_TYPE`, `OPEN_ID_AUTH_SCHEME`).
* Described the difference between **discovery** and **token** modes.
* Updated `AndroidManifest.xml` instructions to use automatic scheme injection via `${openIdAuthScheme}`.
* Added a section on hardcoding `OidcInfo` in source code for advanced use cases.
* Updated external provider reference links.