### PR TITLE
fix: [ANDROAPP-7647] clear stale program results on new TEI search

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -371,13 +371,18 @@ class SearchTEList : FragmentGlobalAbstract() {
         displayResult(null)
     }
 
+    private var lastSearchPagingData: Any? = null
+
     private fun initData() {
         displayLoadingData()
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.searchPagingData.collect { data ->
-                    hideStaleProgramResults()
+                    if (data !== lastSearchPagingData) {
+                        lastSearchPagingData = data
+                        hideStaleProgramResults()
+                    }
                     liveAdapter.addOnPagesUpdatedListener {
                         onInitDataLoaded()
                         CoroutineTracker.decrement()

--- a/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
+++ b/app/src/main/java/org/dhis2/usescases/searchTrackEntity/listView/SearchTEList.kt
@@ -331,6 +331,10 @@ class SearchTEList : FragmentGlobalAbstract() {
         }
 
         liveAdapter.addLoadStateListener { state ->
+            val adapterDetached = !listAdapter.adapters.contains(liveAdapter)
+            if (adapterDetached && state.refresh is LoadState.NotLoading) {
+                restoreProgramAdapterAfterRefresh()
+            }
             if (state.append == LoadState.Loading) {
                 displayResult(
                     listOf(SearchResult(SearchResult.SearchResultType.LOADING)),
@@ -373,6 +377,7 @@ class SearchTEList : FragmentGlobalAbstract() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.searchPagingData.collect { data ->
+                    hideStaleProgramResults()
                     liveAdapter.addOnPagesUpdatedListener {
                         onInitDataLoaded()
                         CoroutineTracker.decrement()
@@ -442,5 +447,15 @@ class SearchTEList : FragmentGlobalAbstract() {
         recycler.post {
             resultAdapter.submitList(result)
         }
+    }
+
+    private fun hideStaleProgramResults() {
+        listAdapter.removeAdapter(liveAdapter)
+        initLoading(listOf(SearchResult(SearchResult.SearchResultType.LOADING)))
+    }
+
+    private fun restoreProgramAdapterAfterRefresh() {
+        listAdapter.addAdapter(1, liveAdapter)
+        initLoading(null)
     }
 }


### PR DESCRIPTION
Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7647).
  
## Problem

When a user starts a new TEI search, `liveAdapter` keeps the previous search's `PagingData` items visible while `searchPagingData` emits new data, so the old result list — and a stale loading indicator — stays on screen until the new page loads.

## Solution

Detach `liveAdapter` from `listAdapter` and show the loading indicator as soon as a new search starts (`hideStaleProgramResults`), then re-insert`liveAdapter` and hide the indicator once the refresh `LoadState`transitions to `NotLoading` (`restoreProgramAdapterAfterRefresh`). This guarantees the indicator is shown on every new search — regardless of whether the previous search had results — and that stale results never remain visible while new data loads.
