### PR TITLE
fix: [ANDROAPP-7661] condition race to sync image using granular sync 

### DIFF
--- a/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
@@ -60,7 +60,7 @@ class SyncPresenterImpl(
         return syncRepository
             .downLoadEvent(eventUid)
             .map { it as D2Progress }
-            .mergeWith(syncRepository.downloadEventFiles(eventUid))
+            .concatWith(syncRepository.downloadEventFiles(eventUid))
     }
 
     override fun blockSyncGranularProgram(programUid: String): ListenableWorker.Result {
@@ -180,7 +180,7 @@ class SyncPresenterImpl(
                 syncRepository.downloadEventProgram(uid)
             }
         }?.map { it as D2Progress }
-            ?.mergeWith(syncRepository.downloadProgramFiles(uid))
+            ?.concatWith(syncRepository.downloadProgramFiles(uid))
             ?: Observable.empty()
 
     override fun syncGranularTEI(uid: String): Observable<D2Progress> {
@@ -194,9 +194,7 @@ class SyncPresenterImpl(
         return syncRepository
             .downloadTei(teiUid, programUid)
             .map { it as D2Progress }
-            .mergeWith(
-                syncRepository.downloadTeiFiles(teiUid, programUid),
-            )
+            .concatWith(syncRepository.downloadTeiFiles(teiUid, programUid))
     }
 
     override fun syncGranularDataSet(uid: String): Observable<D2Progress> =


### PR DESCRIPTION
Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7661).
  
## Problem

When a user triggers a granular sync (TEI, event, or program), SyncPresenterImpl combines the data download with the file/image download using mergeWith, which subscribes to both Observables concurrently.

The file resource downloader queries the local database for TrackedEntityAttributeValue/TrackedEntityDataValue referencing pending file resources, but if that query runs before the TEI/event/program has finished being persisted, it finds nothing pending and the image download completes without downloading anything — silently, with no error and no FileResource created locally.
  
## Solution

Replace mergeWith with concatWith in syncGranularTEI, syncGranularEvent, and syncGranularProgram. With concatWith, the file download Observable is not subscribed until the data download Observable completes, guaranteeing the TEI/event/program is fully persisted before the file resource downloader queries for pending images — matching the same sequential behavior already used by the full background sync (SyncDataWorker).
