### PR TITLE
fix: [ANDROAPP-7661] condition race to sync image using granular sync

### DIFF
--- a/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
@@ -63,7 +63,7 @@ class SyncPresenterImpl(
             syncRepository
                 .downLoadEvent(eventUid, programUid)
                 .map { it as D2Progress }
-                .mergeWith(syncRepository.downloadEventFiles(eventUid))
+                .concatWith(syncRepository.downloadEventFiles(eventUid))
         } ?: Observable.empty()
     }
 
@@ -184,7 +184,7 @@ class SyncPresenterImpl(
                 syncRepository.downloadEventProgram(uid)
             }
         }?.map { it as D2Progress }
-            ?.mergeWith(syncRepository.downloadProgramFiles(uid))
+            ?.concatWith(syncRepository.downloadProgramFiles(uid))
             ?: Observable.empty()
 
     override fun syncGranularTEI(uid: String): Observable<D2Progress> {
@@ -198,7 +198,7 @@ class SyncPresenterImpl(
         return syncRepository
             .downloadTei(teiUid, programUid)
             .map { it as D2Progress }
-            .mergeWith(
+            .concatWith(
                 syncRepository.downloadTeiFiles(teiUid, programUid),
             )
     }


### PR DESCRIPTION
PR originally opened by @xurxodev in https://github.com/dhis2/dhis2-android-capture-app/pull/4907 


Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7661).

Problem
When a user triggers a granular sync (TEI, event, or program), SyncPresenterImpl combines the data download with the file/image download using mergeWith, which subscribes to both Observables concurrently.

The file resource downloader queries the local database for TrackedEntityAttributeValue/TrackedEntityDataValue referencing pending file resources, but if that query runs before the TEI/event/program has finished being persisted, it finds nothing pending and the image download completes without downloading anything — silently, with no error and no FileResource created locally.

Solution
Replace mergeWith with concatWith in syncGranularTEI, syncGranularEvent, and syncGranularProgram. With concatWith, the file download Observable is not subscribed until the data download Observable completes, guaranteeing the TEI/event/program is fully persisted before the file resource downloader queries for pending images — matching the same sequential behavior already used by the full background sync (SyncDataWorker).

