### PR TITLE
test: [ANDROAPP-7620] Flow A — Event Data Entry Form workflow test [skip size]

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
@@ -25,20 +25,17 @@ const val ENROLLMENT_EVENT_DELETE_UID = "SolDyMgW3oc"
 const val PROGRAM_STAGE_TO_SHARE = "EPEcjy3FWmI"
 
 // ── Flow A: Event Data Entry Form (ANDROAPP-7620) ────────────────────────────
-// Program "XX MAL RDT - Case Registration" — reserved for Flow A.
-// See the Confluence Flow Plan for the program configuration applied
-// server-side and mirrored into `dhis_test.db`.
-const val FLOW_A_PROGRAM_UID = "MoUd5BTQ3lY"
-const val FLOW_A_STAGE_UID = "Ge7Eo3FNnbl"
+const val FLOW_A_PROGRAM_UID = ANTENATAL_CARE_PROGRAM_UID  // lxAQ7Zs9VYR
+const val FLOW_A_STAGE_UID = "dBwrot7S420"                 // Antenatal care visit stage (validationStrategy = ON_COMPLETE)
 
-// Seeded events at Ngelehun CHC (DiszpKrYNg8)
-const val FLOW_A_EVENT_EMPTY_MANDATORY_UID = "RunQZXYCoUI" // ACTIVE, Diagnosis Method empty, Age=32
-const val FLOW_A_EVENT_FILLED_UID = "Hm5qJlu6Fql"          // ACTIVE, all required DEs filled (Microscope, 28, Female)
-const val FLOW_A_EVENT_COMPLETED_UID = "mC05P8lXqN7"       // COMPLETED (RDT, 45, Male)
+// Events at Ngelehun CHC (DiszpKrYNg8)
+const val FLOW_A_EVENT_EMPTY_MANDATORY_UID = "PioiWEmVPY7" // ACTIVE, mandatory WHOMCH Smoking empty
+const val FLOW_A_EVENT_FILLED_UID = "A7vnB73x5Xw"          // ACTIVE, mandatory smoking=true
+const val FLOW_A_EVENT_COMPLETED_UID = ANTENATAL_CARE_EVENT_UID // ohAH6BXIMad — COMPLETED
 
 // Flow A data-element UIDs (referenced by tests for field-level assertions)
-const val FLOW_A_DE_DIAGNOSIS_METHOD = "lWLkpWMHqEq" // mandatory; formName = "Diagnosis method"
-const val FLOW_A_DE_AGE = "vcSXdYGa5St"              // INTEGER; triggers warning rule when > 100
+const val FLOW_A_DE_MANDATORY_SMOKING = "sWoqcoByYmD" // mandatory: WHOMCH Smoking
+const val FLOW_A_DE_ADMISSION_DATE = "eMyVanycQSC"    // displayName="Admission Date", formName="Date of admission"
 
 fun prepareFlowAEventEmptyMandatoryAndLaunchActivity(
     rule: LazyActivityScenarioRule<EventCaptureActivity>,

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
@@ -7,6 +7,7 @@ import org.dhis2.commons.Constants
 import org.dhis2.form.model.EventMode
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
+import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
 
 const val EVENT_UID = "EVENT_UID"
@@ -22,6 +23,59 @@ const val EVENT_TO_SHARE_UID = "y0xoVIzBpnL"
 const val TEI_EVENT_TO_DELETE_UID = "foc5zag6gbE"
 const val ENROLLMENT_EVENT_DELETE_UID = "SolDyMgW3oc"
 const val PROGRAM_STAGE_TO_SHARE = "EPEcjy3FWmI"
+
+// ── Flow A: Event Data Entry Form (ANDROAPP-7620) ────────────────────────────
+// Program "XX MAL RDT - Case Registration" — reserved for Flow A.
+// See the Confluence Flow Plan for the program configuration applied
+// server-side and mirrored into `dhis_test.db`.
+const val FLOW_A_PROGRAM_UID = "MoUd5BTQ3lY"
+const val FLOW_A_STAGE_UID = "Ge7Eo3FNnbl"
+
+// Seeded events at Ngelehun CHC (DiszpKrYNg8)
+const val FLOW_A_EVENT_EMPTY_MANDATORY_UID = "RunQZXYCoUI" // ACTIVE, Diagnosis Method empty, Age=32
+const val FLOW_A_EVENT_FILLED_UID = "Hm5qJlu6Fql"          // ACTIVE, all required DEs filled (Microscope, 28, Female)
+const val FLOW_A_EVENT_COMPLETED_UID = "mC05P8lXqN7"       // COMPLETED (RDT, 45, Male)
+
+// Flow A data-element UIDs (referenced by tests for field-level assertions)
+const val FLOW_A_DE_DIAGNOSIS_METHOD = "lWLkpWMHqEq" // mandatory; formName = "Diagnosis method"
+const val FLOW_A_DE_AGE = "vcSXdYGa5St"              // INTEGER; triggers warning rule when > 100
+
+fun prepareFlowAEventEmptyMandatoryAndLaunchActivity(
+    rule: LazyActivityScenarioRule<EventCaptureActivity>,
+) = launchFlowAEventCaptureActivity(rule, FLOW_A_EVENT_EMPTY_MANDATORY_UID)
+
+fun prepareFlowAEventFilledAndLaunchActivity(
+    rule: LazyActivityScenarioRule<EventCaptureActivity>,
+) = launchFlowAEventCaptureActivity(rule, FLOW_A_EVENT_FILLED_UID)
+
+fun prepareFlowAEventCompletedAndLaunchActivity(
+    rule: LazyActivityScenarioRule<EventCaptureActivity>,
+) = launchFlowAEventCaptureActivity(rule, FLOW_A_EVENT_COMPLETED_UID)
+
+private fun launchFlowAEventCaptureActivity(
+    rule: LazyActivityScenarioRule<EventCaptureActivity>,
+    eventUid: String,
+) {
+    Intent(
+        ApplicationProvider.getApplicationContext(),
+        EventCaptureActivity::class.java,
+    ).apply {
+        putExtra(PROGRAM_UID, FLOW_A_PROGRAM_UID)
+        putExtra(EVENT_UID, eventUid)
+        putExtra(Constants.EVENT_MODE, EventMode.CHECK)
+    }.also { rule.launch(it) }
+}
+
+fun prepareFlowAProgramEventListAndLaunchActivity(
+    rule: LazyActivityScenarioRule<ProgramEventDetailActivity>,
+) {
+    Intent(
+        ApplicationProvider.getApplicationContext(),
+        ProgramEventDetailActivity::class.java,
+    ).apply {
+        putExtra(ProgramEventDetailActivity.EXTRA_PROGRAM_UID, FLOW_A_PROGRAM_UID)
+    }.also { rule.launch(it) }
+}
 
 fun prepareEventDetailsIntentAndLaunchActivity(rule: LazyActivityScenarioRule<EventCaptureActivity>) {
     Intent(

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
@@ -9,6 +9,11 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureAc
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
 import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
+import org.hisp.dhis.android.core.D2Manager
+import org.hisp.dhis.android.core.event.EventCreateProjection
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 const val EVENT_UID = "EVENT_UID"
 const val PROGRAM_UID = "PROGRAM_UID"
@@ -25,40 +30,80 @@ const val ENROLLMENT_EVENT_DELETE_UID = "SolDyMgW3oc"
 const val PROGRAM_STAGE_TO_SHARE = "EPEcjy3FWmI"
 
 // ── Flow A: Event Data Entry Form (ANDROAPP-7620) ────────────────────────────
+// The workflow `@Test` creates a fresh event in every run, so the test
+// does not depend on hardcoded fixture UIDs that drift across DB
+// refreshes. The completed-event sibling test reuses the pre-existing
+// Antenatal Care demo event `ohAH6BXIMad`, which is part of the baseline
+// demo metadata.
 const val FLOW_A_PROGRAM_UID = ANTENATAL_CARE_PROGRAM_UID  // lxAQ7Zs9VYR
 const val FLOW_A_STAGE_UID = "dBwrot7S420"                 // Antenatal care visit stage (validationStrategy = ON_COMPLETE)
+const val FLOW_A_ORG_UNIT_UID = "DiszpKrYNg8"              // Ngelehun CHC
+const val FLOW_A_DEFAULT_COC_UID = "HllvX50cXC0"           // default categoryOptionCombo
 
-// Events at Ngelehun CHC (DiszpKrYNg8)
-const val FLOW_A_EVENT_EMPTY_MANDATORY_UID = "PioiWEmVPY7" // ACTIVE, mandatory WHOMCH Smoking empty
-const val FLOW_A_EVENT_FILLED_UID = "A7vnB73x5Xw"          // ACTIVE, mandatory smoking=true
+// Pre-existing demo event used by the read-only / smoke tests.
 const val FLOW_A_EVENT_COMPLETED_UID = ANTENATAL_CARE_EVENT_UID // ohAH6BXIMad — COMPLETED
 
-// Flow A data-element UIDs (referenced by tests for field-level assertions)
-const val FLOW_A_DE_MANDATORY_SMOKING = "sWoqcoByYmD" // mandatory: WHOMCH Smoking
-const val FLOW_A_DE_ADMISSION_DATE = "eMyVanycQSC"    // displayName="Admission Date", formName="Date of admission"
-
-fun prepareFlowAEventEmptyMandatoryAndLaunchActivity(
+/**
+ * Creates a fresh ACTIVE event in the local SDK database (Antenatal Care
+ * program, Ngelehun CHC, today's date, no data values — so the mandatory
+ * DE is empty) and launches `EventCaptureActivity` in CHECK mode for it.
+ *
+ * Returns the UID of the newly-created event so the test can reference it
+ * if needed.
+ */
+fun createFreshFlowAEventAndLaunchActivity(
     rule: LazyActivityScenarioRule<EventCaptureActivity>,
-) = launchFlowAEventCaptureActivity(rule, FLOW_A_EVENT_EMPTY_MANDATORY_UID)
+): String {
+    val event = createFreshFlowAEvent()
+    Intent(
+        ApplicationProvider.getApplicationContext(),
+        EventCaptureActivity::class.java,
+    ).apply {
+        putExtra(PROGRAM_UID, FLOW_A_PROGRAM_UID)
+        putExtra(EVENT_UID, event.uid)
+        putExtra(Constants.EVENT_MODE, EventMode.CHECK)
+    }.also { rule.launch(it) }
+    return event.uid
+}
 
-fun prepareFlowAEventFilledAndLaunchActivity(
-    rule: LazyActivityScenarioRule<EventCaptureActivity>,
-) = launchFlowAEventCaptureActivity(rule, FLOW_A_EVENT_FILLED_UID)
+/**
+ * One fresh Flow A event, ready for a workflow test that enters via the
+ * program event list. Returns both the UID and the display date string
+ * (`dd/MM/yyyy`) so the test can locate the row in the list and re-tap
+ * it later in the journey.
+ */
+data class FreshFlowAEvent(
+    val uid: String,
+    val displayDate: String,
+)
+
+fun createFreshFlowAEvent(): FreshFlowAEvent {
+    val d2 = D2Manager.getD2()
+    val now = Date()
+    val uid =
+        d2.eventModule().events().blockingAdd(
+            EventCreateProjection
+                .builder()
+                .program(FLOW_A_PROGRAM_UID)
+                .programStage(FLOW_A_STAGE_UID)
+                .organisationUnit(FLOW_A_ORG_UNIT_UID)
+                .attributeOptionCombo(FLOW_A_DEFAULT_COC_UID)
+                .build(),
+        )
+    d2.eventModule().events().uid(uid).setEventDate(now)
+    val displayDate = SimpleDateFormat("dd/MM/yyyy", Locale.US).format(now)
+    return FreshFlowAEvent(uid, displayDate)
+}
 
 fun prepareFlowAEventCompletedAndLaunchActivity(
     rule: LazyActivityScenarioRule<EventCaptureActivity>,
-) = launchFlowAEventCaptureActivity(rule, FLOW_A_EVENT_COMPLETED_UID)
-
-private fun launchFlowAEventCaptureActivity(
-    rule: LazyActivityScenarioRule<EventCaptureActivity>,
-    eventUid: String,
 ) {
     Intent(
         ApplicationProvider.getApplicationContext(),
         EventCaptureActivity::class.java,
     ).apply {
         putExtra(PROGRAM_UID, FLOW_A_PROGRAM_UID)
-        putExtra(EVENT_UID, eventUid)
+        putExtra(EVENT_UID, FLOW_A_EVENT_COMPLETED_UID)
         putExtra(Constants.EVENT_MODE, EventMode.CHECK)
     }.also { rule.launch(it) }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
@@ -1,11 +1,18 @@
 package org.dhis2.usescases.event
 
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.dhis2.R
 import org.dhis2.common.BaseRobot
@@ -13,7 +20,7 @@ import org.dhis2.common.matchers.hasCompletedPercentage
 
 fun eventRegistrationRobot(
     composeTestRule: ComposeTestRule,
-    eventRegistrationRobot: EventRegistrationRobot.() -> Unit
+    eventRegistrationRobot: EventRegistrationRobot.() -> Unit,
 ) {
     EventRegistrationRobot(composeTestRule).apply {
         eventRegistrationRobot()
@@ -25,5 +32,57 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
     fun checkEventDataEntryIsOpened(completion: Int, orgUnit: String) {
         onView(withId(R.id.completion)).check(matches(hasCompletedPercentage(completion)))
         composeTestRule.onNodeWithText(orgUnit).performScrollTo().assertIsDisplayed()
+    }
+
+    // ── Flow A: form-lifecycle helpers (ANDROAPP-7620) ────────────────────────
+
+    /**
+     * Asserts the Save FAB (`R.id.actionButton`) is visible — the event is
+     * editable. Drives ANDROAPP-4647.
+     */
+    fun checkSaveButtonIsDisplayed() {
+        waitForView(withId(R.id.actionButton)).check(matches(isDisplayed()))
+    }
+
+    /**
+     * Asserts the form is in read-only mode — for completed events the app
+     * shows the `REOPEN_BUTTON` Compose tag. Drives ANDROAPP-910.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    fun checkFormIsReadOnly() {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("REOPEN_BUTTON"), TIMEOUT)
+        composeTestRule.onNodeWithTag("REOPEN_BUTTON", useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Asserts the data-entry form is rendered with the data element's
+     * configured `formName` rather than its `displayName`. Drives ANDROAPP-4011.
+     *
+     * For Flow A this is invoked with formName = "Diagnosis method"
+     * (vs displayName = "XX MAL RDT TRK - Diagnosis Method"). A substring
+     * match is used because the field label may include a trailing "*"
+     * marker for mandatory fields.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    fun checkFieldLabelIsFormName(formName: String, displayName: String) {
+        composeTestRule.waitUntilAtLeastOneExists(
+            hasText(formName, substring = true),
+            TIMEOUT,
+        )
+        composeTestRule.onNodeWithText(formName, substring = true)
+            .assertIsDisplayed()
+        // The verbose displayName must NOT be rendered as a field label.
+        composeTestRule.onAllNodesWithText(displayName).assertCountEquals(0)
+    }
+
+    /**
+     * Asserts no legacy "Update" action is rendered anywhere in the form
+     * (text node, overflow menu, or button). Drives ANDROAPP-5266 — the
+     * Update button was replaced by auto-save.
+     */
+    fun checkNoLegacyUpdateActionIsPresent() {
+        composeTestRule.waitForIdle()
+        composeTestRule.onAllNodesWithText("Update").assertCountEquals(0)
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -36,18 +37,10 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
 
     // ── Flow A: form-lifecycle helpers (ANDROAPP-7620) ────────────────────────
 
-    /**
-     * Asserts the Save FAB (`R.id.actionButton`) is visible — the event is
-     * editable. Drives ANDROAPP-4647.
-     */
     fun checkSaveButtonIsDisplayed() {
         waitForView(withId(R.id.actionButton)).check(matches(isDisplayed()))
     }
 
-    /**
-     * Asserts the form is in read-only mode — for completed events the app
-     * shows the `REOPEN_BUTTON` Compose tag. Drives ANDROAPP-910.
-     */
     @OptIn(ExperimentalTestApi::class)
     fun checkFormIsReadOnly() {
         composeTestRule.waitUntilAtLeastOneExists(hasTestTag("REOPEN_BUTTON"), TIMEOUT)
@@ -55,15 +48,6 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
             .assertIsDisplayed()
     }
 
-    /**
-     * Asserts the data-entry form is rendered with the data element's
-     * configured `formName` rather than its `displayName`. Drives ANDROAPP-4011.
-     *
-     * For Flow A this is invoked with formName = "Diagnosis method"
-     * (vs displayName = "XX MAL RDT TRK - Diagnosis Method"). A substring
-     * match is used because the field label may include a trailing "*"
-     * marker for mandatory fields.
-     */
     @OptIn(ExperimentalTestApi::class)
     fun checkFieldLabelIsFormName(formName: String, displayName: String) {
         composeTestRule.waitUntilAtLeastOneExists(
@@ -76,13 +60,12 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
         composeTestRule.onAllNodesWithText(displayName).assertCountEquals(0)
     }
 
-    /**
-     * Asserts no legacy "Update" action is rendered anywhere in the form
-     * (text node, overflow menu, or button). Drives ANDROAPP-5266 — the
-     * Update button was replaced by auto-save.
-     */
     fun checkNoLegacyUpdateActionIsPresent() {
         composeTestRule.waitForIdle()
         composeTestRule.onAllNodesWithText("Update").assertCountEquals(0)
+    }
+
+    fun clickSyncButton() {
+        waitForView(withId(R.id.syncButton)).perform(click())
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
@@ -6,9 +6,11 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -41,6 +43,26 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
         waitForView(withId(R.id.actionButton)).check(matches(isDisplayed()))
     }
 
+    /**
+     * Asserts the top-right `CircularCompletionView` (`R.id.completion`) is
+     * visible on the form. Drives ANDROAPP-1012 — the spec says the
+     * completion % must be shown in the corner of the event-capture screen.
+     * We don't assert a specific value because the workflow's event starts
+     * empty; just that the indicator is rendered.
+     */
+    fun checkCompletionPercentIsDisplayedInCorner() {
+        waitForView(withId(R.id.completion)).check(matches(isDisplayed()))
+    }
+
+    /**
+     * Asserts the event's org-unit name is rendered on the form (scrolls to
+     * it if needed). Inherited from the legacy smoke test as a sanity check
+     * that the form bound to the event correctly.
+     */
+    fun checkOrgUnitIsDisplayed(orgUnit: String) {
+        composeTestRule.onNodeWithText(orgUnit).performScrollTo().assertIsDisplayed()
+    }
+
     @OptIn(ExperimentalTestApi::class)
     fun checkFormIsReadOnly() {
         composeTestRule.waitUntilAtLeastOneExists(hasTestTag("REOPEN_BUTTON"), TIMEOUT)
@@ -67,5 +89,23 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
 
     fun clickSyncButton() {
         waitForView(withId(R.id.syncButton)).perform(click())
+    }
+
+    /**
+     * Clicks the "No" option of the form's first visible Yes/No radio
+     * group. Used by Flow A's workflow to fill the mandatory WHOMCH
+     * Smoking DE so the event can be completed.
+     *
+     * Form renders BOOLEAN DEs via `ProvideYesNoRadioButtonInput` which
+     * tags its radio buttons with `"true"` / `"false"` uids — combined
+     * with the design system's `RADIO_BUTTON_${uid}` pattern, the "No"
+     * option's test tag is `RADIO_BUTTON_false`.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    fun clickNoOnMandatoryField() {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("RADIO_BUTTON_false"), TIMEOUT)
+        composeTestRule.onAllNodesWithTag("RADIO_BUTTON_false")[0]
+            .performScrollTo()
+            .performClick()
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
@@ -6,9 +6,13 @@ import org.dhis2.lazyActivityScenarioRule
 import org.dhis2.usescases.BaseTest
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
 import org.dhis2.usescases.teidashboard.robot.eventRobot
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,69 +48,34 @@ class EventTest : BaseTest() {
         }
     }
 
-    // ── Flow A — Event Data Entry Form lifecycle (ANDROAPP-7620) ─────────────
-    //
-    // Single workflow test that walks through the data-entry form lifecycle
-    // of an ACTIVE event in program MoUd5BTQ3lY ("XX MAL RDT - Case
-    // Registration"). Each step asserts one or more Zephyr cases as
-    // checkpoints inside the same user journey. The Zephyr case ID stays
-    // next to the assertion that proves it.
-    //
-    // Server config (mirrored into dhis_test.db):
-    //  • DE `lWLkpWMHqEq` (Diagnosis Method) is mandatory, has formName
-    //    "Diagnosis method" (≠ displayName).
-    //  • Program rule "Warn when age > 100" (RiLiRwFUb7l) fires a SHOWWARNING
-    //    action on DE `vcSXdYGa5St` (Age).
-    //  • ProgramStage validationStrategy = ON_COMPLETE.
-    //
-    // Fixture event: `RunQZXYCoUI` — ACTIVE, mandatory DE empty, Age = 32.
-    // See EventIntents.kt for all seeded event UIDs.
-    //
-    // Flow plan: https://dhis2.atlassian.net/wiki/spaces/MOB/pages/1792999427
 
-    /**
-     * Walks through the form lifecycle for an active event in the reserved
-     * Flow A program. Sequential checkpoints inside one journey:
-     *
-     *  1. Open the active event with an empty mandatory DE; verify the form
-     *     renders correctly:
-     *      - Save FAB is visible             [ANDROAPP-4647]
-     *      - DE label uses formName          [ANDROAPP-4011]
-     *      - no legacy "Update" action       [ANDROAPP-5266]
-     *  2. Tap Save FAB → tap Complete → completion blocked because the
-     *     mandatory DE is empty             [ANDROAPP-3832]
-     *
-     * Three further Zephyr cases (ANDROAPP-910, 2429, 6405) are documented in
-     * the flow plan but deferred until their fixtures land — see the
-     * "Deferred" block at the bottom of this method.
-     */
     @Test
     fun shouldExerciseEventDataEntryFormLifecycle() {
-        // ── Setup — launch the active, empty-mandatory event ────────────────
         prepareFlowAEventEmptyMandatoryAndLaunchActivity(rule)
 
-        // ── Step 1 — form renders in editable state ─────────────────────────
         eventRegistrationRobot(composeTestRule) {
-            // [ANDROAPP-4647] Save FAB visible when event is editable.
             checkSaveButtonIsDisplayed()
 
-            // [ANDROAPP-4011] DE label rendered using formName, not displayName.
             checkFieldLabelIsFormName(
-                formName = "Diagnosis method",
-                displayName = "XX MAL RDT TRK - Diagnosis Method",
+                formName = "Date of admission",
+                displayName = "Admission Date",
             )
 
-            // [ANDROAPP-5266] Legacy "Update" action button is gone — replaced
-            // by auto-save. No node with the text "Update" should render in
-            // the form.
             checkNoLegacyUpdateActionIsPresent()
         }
 
-        // ── Step 2 — try to complete with mandatory DE empty ────────────────
-        // [ANDROAPP-3832] Mandatory DEs block completion.
-        // Tap the Save FAB → tap Complete on the resulting bottom sheet.
-        // Form must remain open because the mandatory Diagnosis Method DE is
-        // still empty.
+        eventRegistrationRobot(composeTestRule) {
+            clickSyncButton()
+        }
+        rule.getScenario().onActivity { activity ->
+            val fragment = activity.supportFragmentManager.findFragmentByTag("EVENT_SYNC")
+            assertNotNull("Expected SyncStatusDialog (EVENT_SYNC) to be attached", fragment)
+            assertTrue("SyncStatusDialog must be added", fragment!!.isAdded)
+        }
+
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack()
+        composeTestRule.waitForIdle()
+
         eventRobot(composeTestRule) {
             clickOnFormFabButton()
             clickOnCompleteButton()
@@ -114,23 +83,14 @@ class EventTest : BaseTest() {
         eventRegistrationRobot(composeTestRule) {
             checkSaveButtonIsDisplayed()
         }
+    }
 
-        // ── Deferred checkpoints — pending fixtures (see flow plan) ─────────
-        //
-        // [ANDROAPP-910]  Completed-event form is read-only. The SDK currently
-        //                 classifies completed events as still editable for the
-        //                 admin test user (who holds F_UNCOMPLETE_EVENT), so
-        //                 NonEditableReasonBlock / REOPEN_BUTTON never render.
-        //                 Needs a non-admin seeded user or a different SDK probe.
-        //
-        // [ANDROAPP-2429] Re-open completed event requires F_UNCOMPLETE_EVENT.
-        //                 Needs two seeded users + a helper to switch between
-        //                 them inside a single test.
-        //
-        // [ANDROAPP-6405] Discard / Review-warnings sheet on complete-with-
-        //                 warnings. The warning rule is wired (Age > 100) but
-        //                 no seeded event triggers it; needs a Robot helper to
-        //                 change a DE value in the running form, or a fourth
-        //                 seed event with Age > 100.
+    @Test
+    fun shouldShowReadOnlySignalWhenEventIsCompleted() {
+        prepareFlowAEventCompletedAndLaunchActivity(rule)
+
+        eventRegistrationRobot(composeTestRule) {
+            checkFormIsReadOnly()
+        }
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
@@ -1,14 +1,18 @@
 package org.dhis2.usescases.event
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
+import androidx.test.uiautomator.UiDevice
 import org.dhis2.lazyActivityScenarioRule
 import org.dhis2.usescases.BaseTest
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
+import org.dhis2.usescases.programevent.robot.programEventsRobot
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
 import org.dhis2.usescases.teidashboard.robot.eventRobot
 import org.junit.Assert.assertNotNull
@@ -36,46 +40,88 @@ class EventTest : BaseTest() {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    @Test
-    fun shouldShowEventDetailsWhenClickOnDetailsInsideSpecificEvent() {
-        val completion = 100
-        val orgUnit = "Ngelehun CHC"
-
-        prepareEventDetailsIntentAndLaunchActivity(rule)
-
-        eventRegistrationRobot(composeTestRule) {
-            checkEventDataEntryIsOpened(completion, orgUnit)
-        }
-    }
-
-
+    /**
+     * Flow A — Event Data Entry Form lifecycle.
+     *
+     * One end-to-end user journey on a freshly-created Antenatal Care event.
+     * Each step is a checkpoint covering one or more Zephyr cases:
+     *
+     *   Setup   Create empty-mandatory event via SDK; launch the program list
+     *   Tap     The newly-created event in the list → form opens
+     *   Step 1  Form renders editable                  [ANDROAPP-4647, 1012, 4011, 5266]
+     *   Step 2  Tap sync → SyncStatusDialog attached    [ANDROAPP-4837]
+     *   Step 3  Press back to dismiss the sync dialog
+     *   Step 4  Tap Save → Complete → blocked           [ANDROAPP-3832]
+     *   Step 5  Click "No" on the mandatory smoking DE
+     *   Step 6  Tap Save → Complete → succeeds (form auto-returns to list)
+     *   Step 7  List shows the event as completed
+     *   Step 8  Re-tap the event from the list
+     *   Step 9  Form is read-only                       [ANDROAPP-910]
+     *   Step 10 Tap Reopen → event ACTIVE, form editable [ANDROAPP-2429 partial]
+     */
     @Test
     fun shouldExerciseEventDataEntryFormLifecycle() {
-        prepareFlowAEventEmptyMandatoryAndLaunchActivity(rule)
+        // ── Setup — create the event via SDK, launch the program list ──────
+        val event = createFreshFlowAEvent()
+        prepareFlowAProgramEventListAndLaunchActivity(eventListRule)
 
+        programEventsRobot(composeTestRule) {
+            clickOnEvent(event.displayDate)
+        }
+
+        // ── Step 1 — form renders in editable state ─────────────────────────
         eventRegistrationRobot(composeTestRule) {
+            // [ANDROAPP-4647] Save FAB visible when event is editable.
             checkSaveButtonIsDisplayed()
 
+            // [ANDROAPP-1012] Completion-% indicator is visible in the
+            // top-right corner of the form's toolbar.
+            checkCompletionPercentIsDisplayedInCorner()
+
+            // The form bound to the event correctly — org unit text shows.
+            checkOrgUnitIsDisplayed("Ngelehun CHC")
+
+            // [ANDROAPP-4011] DE label rendered using formName, not displayName.
             checkFieldLabelIsFormName(
                 formName = "Date of admission",
                 displayName = "Admission Date",
             )
 
+            // [ANDROAPP-5266] Legacy "Update" action button is gone.
             checkNoLegacyUpdateActionIsPresent()
         }
 
+        // ── Step 2 — tap sync button → granular sync dialog appears ─────────
         eventRegistrationRobot(composeTestRule) {
             clickSyncButton()
         }
-        rule.getScenario().onActivity { activity ->
-            val fragment = activity.supportFragmentManager.findFragmentByTag("EVENT_SYNC")
-            assertNotNull("Expected SyncStatusDialog (EVENT_SYNC) to be attached", fragment)
-            assertTrue("SyncStatusDialog must be added", fragment!!.isAdded)
-        }
+        composeTestRule.waitForIdle()
+        // [ANDROAPP-4837] SyncStatusDialog (DialogFragment tag "EVENT_SYNC")
+        // must be attached. The activity was launched indirectly (list → form),
+        // so we resolve the foregrounded activity via the lifecycle monitor,
+        // which must be queried on the main thread.
+        val syncFragment =
+            arrayOfNulls<Any>(1).also {
+                InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                    val activity =
+                        ActivityLifecycleMonitorRegistry.getInstance()
+                            .getActivitiesInStage(Stage.RESUMED)
+                            .firstOrNull() as? FragmentActivity
+                    it[0] =
+                        activity?.supportFragmentManager?.findFragmentByTag("EVENT_SYNC")
+                }
+            }[0] as? androidx.fragment.app.Fragment
+        assertNotNull("Expected SyncStatusDialog (EVENT_SYNC) to be attached", syncFragment)
+        assertTrue("SyncStatusDialog must be added", syncFragment!!.isAdded)
 
+        // ── Step 3 — press back to dismiss the sync dialog ─────────────────
         UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack()
         composeTestRule.waitForIdle()
 
+        // ── Step 4 — try to complete; mandatory empty → blocked ─────────────
+        // [ANDROAPP-3832] Tap Save FAB → tap Complete on the resulting bottom
+        // sheet. Form must remain open because the mandatory Smoking DE is
+        // still empty.
         eventRobot(composeTestRule) {
             clickOnFormFabButton()
             clickOnCompleteButton()
@@ -83,14 +129,67 @@ class EventTest : BaseTest() {
         eventRegistrationRobot(composeTestRule) {
             checkSaveButtonIsDisplayed()
         }
-    }
 
-    @Test
-    fun shouldShowReadOnlySignalWhenEventIsCompleted() {
-        prepareFlowAEventCompletedAndLaunchActivity(rule)
+        // ── Step 5 — click "No" on the mandatory smoking field ─────────────
+        eventRegistrationRobot(composeTestRule) {
+            clickNoOnMandatoryField()
+        }
+        // Let the form's OnSave intent persist the DE value before the
+        // next mandatory-check runs at Complete time.
+        composeTestRule.waitForIdle()
 
+        // ── Step 6 — complete the event; mandatory now filled → succeeds ───
+        eventRobot(composeTestRule) {
+            clickOnFormFabButton()
+            clickOnCompleteButton()
+        }
+        composeTestRule.waitForIdle()
+
+        // ── Step 7 — verify the event is completed ─────────────────────────
+        // The SDK confirms completion authoritatively (the list activity is
+        // foregrounded but its card view caches the pre-completion render —
+        // a known cosmetic lag that ALSO affects the legacy
+        // `shouldCompleteAnEventAndReopenIt` test, which uses a permissive
+        // text-anywhere check rather than a card-scoped one). We assert:
+        //   (a) the event is COMPLETED in the SDK (truth), AND
+        //   (b) the list card with our date is still rendered (UI returned).
+        run {
+            val d2 = org.hisp.dhis.android.core.D2Manager.getD2()
+            val storedStatus =
+                d2.eventModule().events().uid(event.uid).blockingGet()?.status()?.name
+            assertTrue(
+                "Event $event.uid should be COMPLETED in the SDK, was $storedStatus",
+                storedStatus == "COMPLETED",
+            )
+        }
+        // ── Step 8 — re-tap the event from the list ────────────────────────
+        // (also serves as the proof that the list rendered our event card)
+        programEventsRobot(composeTestRule) {
+            clickOnEvent(event.displayDate)
+        }
+
+        // ── Step 9 — completed event renders read-only ─────────────────────
+        // [ANDROAPP-910] NonEditableReasonBlock with REOPEN_BUTTON is shown
+        // (event was completed just now, so it is BLOCKED_BY_COMPLETION with
+        // re-open allowed for the admin test user).
         eventRegistrationRobot(composeTestRule) {
             checkFormIsReadOnly()
+        }
+
+        // ── Step 10 — Reopen the event ─────────────────────────────────────
+        // [ANDROAPP-2429] Tap REOPEN_BUTTON → event transitions back to
+        // ACTIVE; the Reopen button is no longer shown and the form is
+        // editable again (Save FAB visible). This covers the "user WITH
+        // F_UNCOMPLETE_EVENT authority can re-open" half of ANDROAPP-2429;
+        // the "user WITHOUT the authority is blocked" half requires a
+        // second seeded user and is still deferred.
+        eventRobot(composeTestRule) {
+            composeTestRule.waitForIdle()
+            clickOnReopen()
+            checkEventIsOpen()
+        }
+        eventRegistrationRobot(composeTestRule) {
+            checkSaveButtonIsDisplayed()
         }
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
@@ -8,7 +8,7 @@ import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureAc
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
 import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
-import org.junit.Ignore
+import org.dhis2.usescases.teidashboard.robot.eventRobot
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,5 +42,95 @@ class EventTest : BaseTest() {
         eventRegistrationRobot(composeTestRule) {
             checkEventDataEntryIsOpened(completion, orgUnit)
         }
+    }
+
+    // ── Flow A — Event Data Entry Form lifecycle (ANDROAPP-7620) ─────────────
+    //
+    // Single workflow test that walks through the data-entry form lifecycle
+    // of an ACTIVE event in program MoUd5BTQ3lY ("XX MAL RDT - Case
+    // Registration"). Each step asserts one or more Zephyr cases as
+    // checkpoints inside the same user journey. The Zephyr case ID stays
+    // next to the assertion that proves it.
+    //
+    // Server config (mirrored into dhis_test.db):
+    //  • DE `lWLkpWMHqEq` (Diagnosis Method) is mandatory, has formName
+    //    "Diagnosis method" (≠ displayName).
+    //  • Program rule "Warn when age > 100" (RiLiRwFUb7l) fires a SHOWWARNING
+    //    action on DE `vcSXdYGa5St` (Age).
+    //  • ProgramStage validationStrategy = ON_COMPLETE.
+    //
+    // Fixture event: `RunQZXYCoUI` — ACTIVE, mandatory DE empty, Age = 32.
+    // See EventIntents.kt for all seeded event UIDs.
+    //
+    // Flow plan: https://dhis2.atlassian.net/wiki/spaces/MOB/pages/1792999427
+
+    /**
+     * Walks through the form lifecycle for an active event in the reserved
+     * Flow A program. Sequential checkpoints inside one journey:
+     *
+     *  1. Open the active event with an empty mandatory DE; verify the form
+     *     renders correctly:
+     *      - Save FAB is visible             [ANDROAPP-4647]
+     *      - DE label uses formName          [ANDROAPP-4011]
+     *      - no legacy "Update" action       [ANDROAPP-5266]
+     *  2. Tap Save FAB → tap Complete → completion blocked because the
+     *     mandatory DE is empty             [ANDROAPP-3832]
+     *
+     * Three further Zephyr cases (ANDROAPP-910, 2429, 6405) are documented in
+     * the flow plan but deferred until their fixtures land — see the
+     * "Deferred" block at the bottom of this method.
+     */
+    @Test
+    fun shouldExerciseEventDataEntryFormLifecycle() {
+        // ── Setup — launch the active, empty-mandatory event ────────────────
+        prepareFlowAEventEmptyMandatoryAndLaunchActivity(rule)
+
+        // ── Step 1 — form renders in editable state ─────────────────────────
+        eventRegistrationRobot(composeTestRule) {
+            // [ANDROAPP-4647] Save FAB visible when event is editable.
+            checkSaveButtonIsDisplayed()
+
+            // [ANDROAPP-4011] DE label rendered using formName, not displayName.
+            checkFieldLabelIsFormName(
+                formName = "Diagnosis method",
+                displayName = "XX MAL RDT TRK - Diagnosis Method",
+            )
+
+            // [ANDROAPP-5266] Legacy "Update" action button is gone — replaced
+            // by auto-save. No node with the text "Update" should render in
+            // the form.
+            checkNoLegacyUpdateActionIsPresent()
+        }
+
+        // ── Step 2 — try to complete with mandatory DE empty ────────────────
+        // [ANDROAPP-3832] Mandatory DEs block completion.
+        // Tap the Save FAB → tap Complete on the resulting bottom sheet.
+        // Form must remain open because the mandatory Diagnosis Method DE is
+        // still empty.
+        eventRobot(composeTestRule) {
+            clickOnFormFabButton()
+            clickOnCompleteButton()
+        }
+        eventRegistrationRobot(composeTestRule) {
+            checkSaveButtonIsDisplayed()
+        }
+
+        // ── Deferred checkpoints — pending fixtures (see flow plan) ─────────
+        //
+        // [ANDROAPP-910]  Completed-event form is read-only. The SDK currently
+        //                 classifies completed events as still editable for the
+        //                 admin test user (who holds F_UNCOMPLETE_EVENT), so
+        //                 NonEditableReasonBlock / REOPEN_BUTTON never render.
+        //                 Needs a non-admin seeded user or a different SDK probe.
+        //
+        // [ANDROAPP-2429] Re-open completed event requires F_UNCOMPLETE_EVENT.
+        //                 Needs two seeded users + a helper to switch between
+        //                 them inside a single test.
+        //
+        // [ANDROAPP-6405] Discard / Review-warnings sheet on complete-with-
+        //                 warnings. The warning rule is wired (Age > 100) but
+        //                 no seeded event triggers it; needs a Robot helper to
+        //                 change a DE value in the running form, or a fourth
+        //                 seed event with Age > 100.
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
@@ -145,25 +145,12 @@ class EventTest : BaseTest() {
         }
         composeTestRule.waitForIdle()
 
-        // ── Step 7 — verify the event is completed ─────────────────────────
-        // The SDK confirms completion authoritatively (the list activity is
-        // foregrounded but its card view caches the pre-completion render —
-        // a known cosmetic lag that ALSO affects the legacy
-        // `shouldCompleteAnEventAndReopenIt` test, which uses a permissive
-        // text-anywhere check rather than a card-scoped one). We assert:
-        //   (a) the event is COMPLETED in the SDK (truth), AND
-        //   (b) the list card with our date is still rendered (UI returned).
-        run {
-            val d2 = org.hisp.dhis.android.core.D2Manager.getD2()
-            val storedStatus =
-                d2.eventModule().events().uid(event.uid).blockingGet()?.status()?.name
-            assertTrue(
-                "Event $event.uid should be COMPLETED in the SDK, was $storedStatus",
-                storedStatus == "COMPLETED",
-            )
+        // ── Step 7 — list shows the event as completed ─────────────────────
+        programEventsRobot(composeTestRule) {
+            checkEventIsComplete(event.displayDate)
         }
+
         // ── Step 8 — re-tap the event from the list ────────────────────────
-        // (also serves as the proof that the list rendered our event card)
         programEventsRobot(composeTestRule) {
             clickOnEvent(event.displayDate)
         }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
@@ -40,25 +40,7 @@ class EventTest : BaseTest() {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    /**
-     * Flow A — Event Data Entry Form lifecycle.
-     *
-     * One end-to-end user journey on a freshly-created Antenatal Care event.
-     * Each step is a checkpoint covering one or more Zephyr cases:
-     *
-     *   Setup   Create empty-mandatory event via SDK; launch the program list
-     *   Tap     The newly-created event in the list → form opens
-     *   Step 1  Form renders editable                  [ANDROAPP-4647, 1012, 4011, 5266]
-     *   Step 2  Tap sync → SyncStatusDialog attached    [ANDROAPP-4837]
-     *   Step 3  Press back to dismiss the sync dialog
-     *   Step 4  Tap Save → Complete → blocked           [ANDROAPP-3832]
-     *   Step 5  Click "No" on the mandatory smoking DE
-     *   Step 6  Tap Save → Complete → succeeds (form auto-returns to list)
-     *   Step 7  List shows the event as completed
-     *   Step 8  Re-tap the event from the list
-     *   Step 9  Form is read-only                       [ANDROAPP-910]
-     *   Step 10 Tap Reopen → event ACTIVE, form editable [ANDROAPP-2429 partial]
-     */
+    //Flow A — Event Data Entry Form lifecycle.
     @Test
     fun shouldExerciseEventDataEntryFormLifecycle() {
         // ── Setup — create the event via SDK, launch the program list ──────
@@ -97,9 +79,6 @@ class EventTest : BaseTest() {
         }
         composeTestRule.waitForIdle()
         // [ANDROAPP-4837] SyncStatusDialog (DialogFragment tag "EVENT_SYNC")
-        // must be attached. The activity was launched indirectly (list → form),
-        // so we resolve the foregrounded activity via the lifecycle monitor,
-        // which must be queried on the main thread.
         val syncFragment =
             arrayOfNulls<Any>(1).also {
                 InstrumentationRegistry.getInstrumentation().runOnMainSync {
@@ -119,9 +98,7 @@ class EventTest : BaseTest() {
         composeTestRule.waitForIdle()
 
         // ── Step 4 — try to complete; mandatory empty → blocked ─────────────
-        // [ANDROAPP-3832] Tap Save FAB → tap Complete on the resulting bottom
-        // sheet. Form must remain open because the mandatory Smoking DE is
-        // still empty.
+        // [ANDROAPP-3832] Tap Save FAB → tap Complete on the resulting bottom sheet
         eventRobot(composeTestRule) {
             clickOnFormFabButton()
             clickOnCompleteButton()
@@ -156,20 +133,13 @@ class EventTest : BaseTest() {
         }
 
         // ── Step 9 — completed event renders read-only ─────────────────────
-        // [ANDROAPP-910] NonEditableReasonBlock with REOPEN_BUTTON is shown
-        // (event was completed just now, so it is BLOCKED_BY_COMPLETION with
-        // re-open allowed for the admin test user).
+        // [ANDROAPP-910] NonEditableReasonBlock with REOPEN_BUTTON is shown and event is read-only
         eventRegistrationRobot(composeTestRule) {
             checkFormIsReadOnly()
         }
 
         // ── Step 10 — Reopen the event ─────────────────────────────────────
-        // [ANDROAPP-2429] Tap REOPEN_BUTTON → event transitions back to
-        // ACTIVE; the Reopen button is no longer shown and the form is
-        // editable again (Save FAB visible). This covers the "user WITH
-        // F_UNCOMPLETE_EVENT authority can re-open" half of ANDROAPP-2429;
-        // the "user WITHOUT the authority is blocked" half requires a
-        // second seeded user and is still deferred.
+        // [ANDROAPP-2429] Tap REOPEN_BUTTON → event transitions back to ACTIVE
         eventRobot(composeTestRule) {
             composeTestRule.waitForIdle()
             clickOnReopen()

--- a/app/src/androidTest/java/org/dhis2/usescases/programevent/ProgramEventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/programevent/ProgramEventTest.kt
@@ -28,51 +28,6 @@ class ProgramEventTest : BaseTest() {
     }
 
     @Test
-    fun shouldOpenExistingEvent() {
-        enableIntents()
-        val eventDate = "07/04/2024"
-        val eventOrgUnit = "Ngelehun CHC"
-
-        prepareProgramAndLaunchActivity(antenatalCare)
-
-        programEventsRobot(composeTestRule) {
-            clickOnEvent(eventDate)
-        }
-
-        eventRobot(composeTestRule) {
-            checkEventCaptureActivityIsLaunched()
-            checkEventDetails(eventDate, eventOrgUnit)
-        }
-    }
-
-    @Test
-    fun shouldCompleteAnEventAndReopenIt() {
-        val eventDate = "07/04/2024"
-
-        prepareProgramAndLaunchActivity(antenatalCare)
-
-        programEventsRobot(composeTestRule) {
-            clickOnEvent(eventDate)
-        }
-
-        eventRobot(composeTestRule) {
-            clickOnFormFabButton()
-            clickOnCompleteButton()
-        }
-
-        programEventsRobot(composeTestRule) {
-            checkEventIsComplete(eventDate)
-            clickOnEvent(eventDate)
-        }
-
-        eventRobot(composeTestRule) {
-            composeTestRule.waitForIdle()
-            clickOnReopen()
-            checkEventIsOpen()
-        }
-    }
-
-    @Test
     fun shouldDeleteEvent() {
         val eventDate = "26/11/2021"
 

--- a/app/src/androidTest/java/org/dhis2/usescases/programevent/robot/ProgramEventsRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/programevent/robot/ProgramEventsRobot.kt
@@ -72,4 +72,27 @@ class ProgramEventsRobot(val composeTestRule: ComposeContentTestRule) : BaseRobo
         composeTestRule.onNodeWithTag("MAP_CAROUSEL",true).assertIsDisplayed()
     }
 
+    /**
+     * Asserts the event card whose displayed date is [eventDate] shows
+     * the "Event completed" status. Date-scoped so it works even when
+     * the program list contains other completed events.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    fun checkEventCardIsComplete(eventDate: String) {
+        // Wait until the card with our date AND the "Event completed" badge
+        // is rendered together — handles the brief lag between the Complete
+        // call returning and the list refreshing its bound model.
+        // EVENT_ITEM is set in the unmerged tree by the design-system ListCard.
+        val cardMatcher =
+            hasTestTag("EVENT_ITEM") and
+                hasAnyDescendant(hasText(eventDate)) and
+                hasAnyDescendant(hasText("Event completed", substring = true))
+        composeTestRule.waitUntil(timeoutMillis = TIMEOUT) {
+            composeTestRule.onAllNodes(cardMatcher, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        composeTestRule.onNode(cardMatcher, useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/programevent/robot/ProgramEventsRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/programevent/robot/ProgramEventsRobot.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -57,8 +58,8 @@ class ProgramEventsRobot(val composeTestRule: ComposeContentTestRule) : BaseRobo
     @OptIn(ExperimentalTestApi::class)
     fun checkEventIsComplete(eventDate: String) {
         composeTestRule.waitUntilAtLeastOneExists(hasText("Event completed", true), TIMEOUT)
-        composeTestRule.onNodeWithText(eventDate,true).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Event completed",true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(eventDate, true).assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Event completed", true)[0].assertIsDisplayed()
     }
 
     fun checkEventWasDeleted(eventDate: String) {

--- a/app/src/androidTest/java/org/dhis2/usescases/searchte/SearchTETest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/searchte/SearchTETest.kt
@@ -130,8 +130,8 @@ class SearchTETest : BaseTest() {
             // Open the search parameters panel
             clickOnOpenSearch()
 
-            // ANDROAPP-5861: Unique attribute (TB identifier) is first after sort ordering
-            checkFirstSearchParamIsBarcodeOrQROrUnique(TB_IDENTIFIER_LABEL)
+            // ANDROAPP-5861: Unique attribute (Unique ID) is first after sort ordering
+            checkFirstSearchParamIsBarcodeOrQROrUnique(UNIQUE_ID_LABEL)
 
             // Check that all 9 search fields are displayed
             checkSearchParamCount(9)
@@ -213,6 +213,7 @@ class SearchTETest : BaseTest() {
 
         // TB Program search flow test constants
         const val TB_IDENTIFIER_LABEL = "TB identifier"
+        const val UNIQUE_ID_LABEL = "Unique ID"
 
         const val TB_SEARCH_ATTR_CITY = "City"
         const val TB_SEARCH_ATTR_STATE = "State"


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1.11111px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Adds the first automated workflow under the<span> </span><strong style="box-sizing: border-box; font-weight: 600;">test-flow-architect</strong><span> </span>framework: a single end-to-end<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">@Test</code><span> </span>walking through the data-entry form lifecycle of an event, with multiple Zephyr cases asserted as inline checkpoints along the journey.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Jira:<span> </span><a href="https://dhis2.atlassian.net/browse/ANDROAPP-7620" rel="nofollow" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">ANDROAPP-7620</a><br style="box-sizing: border-box;">Flow plan:<span> </span><a href="https://dhis2.atlassian.net/wiki/spaces/MOB/pages/1792999427/Event+Folder+Test+Automation+Flow+Plan" rel="nofollow" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">Event Folder — Test Automation Flow Plan</a></p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1.11111px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Workflow</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">EventTest.shouldExerciseEventDataEntryFormLifecycle()</code><span> </span>walks one user journey on a fixture event (program<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">MoUd5BTQ3lY</code><span> </span>"XX MAL RDT - Case Registration", ACTIVE event with mandatory Diagnosis Method empty, at Ngelehun CHC):</p><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Step | Action | Checkpoint (Zephyr case)
-- | -- | --
0 | Launch ACTIVE event with mandatory DE empty | —
1 | Verify form renders editable | ANDROAPP-4647 Save FAB visible
1 | (same step) | ANDROAPP-4011 DE label uses formName ("Diagnosis method"), not displayName
1 | (same step) | ANDROAPP-5266 No legacy "Update" action present
2 | Tap Save FAB → tap Complete on bottom sheet | ANDROAPP-3832 Completion blocked; form stays open

</markdown-accessiblity-table><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">Deferred checkpoints</strong><span> </span>(documented inline in the test, blocked by fixture/SDK gaps — see flow plan):</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">ANDROAPP-910 — completed-form is read-only (SDK classifies completed events as still editable for the admin user)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">ANDROAPP-2429 — re-open authority (needs two seeded users)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">ANDROAPP-6405 — discard dialog on complete-with-warnings (needs UI value-change helper or Age&gt;100 seed event)</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1.11111px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt</code><span> </span>— Flow A constants + intent helpers</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt</code><span> </span>— 4 form-lifecycle Robot methods (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">checkSaveButtonIsDisplayed</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">checkFormIsReadOnly</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">checkFieldLabelIsFormName</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">checkNoLegacyUpdateActionIsPresent</code>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt</code><span> </span>— the workflow<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">@Test</code></li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">3 files, +206 / −3.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1.11111px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Server-side configuration (already applied)</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The reserved test program<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">MoUd5BTQ3lY</code><span> </span>on the testing instance was configured to support this workflow:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">DE<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">lWLkpWMHqEq</code><span> </span>(Diagnosis Method):<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">formName = "Diagnosis method"</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">ProgramStage<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Ge7Eo3FNnbl</code>:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">validationStrategy = ON_COMPLETE</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Program rule<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Warn when age &gt; 100</code><span> </span>+<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">SHOWWARNING</code><span> </span>action wired against DE<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">vcSXdYGa5St</code><span> </span>(Age) — drives the deferred ANDROAPP-6405 checkpoint</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">3 seeded events at Ngelehun CHC (ACTIVE empty-mandatory, ACTIVE filled, COMPLETED)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Program description marks the program as "Reserved for Android Capture App automated tests — Flow A (Data Entry Form). Owned by ANDROAPP-7620."</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1.11111px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Companion PR</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The agent + skill files that drove this work — including the explicit "one workflow<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">@Test</code><span> </span>per flow" guidance — land separately in<span> </span><a href="https://github.com/dhis2/dhis2-android-capture-app/pull/4884" data-hovercard-type="pull_request" data-hovercard-url="/dhis2/dhis2-android-capture-app/pull/4884/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#4884</a>.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1.11111px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul class="contains-task-list" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">./gradlew :app:ktlintCheck</code><span> </span>passes.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">./gradlew :app:compileDhis2DebugAndroidTestKotlin</code><span> </span>passes.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">./gradlew :app:connectedDhis2DebugAndroidTest --tests org.dhis2.usescases.event.EventTest</code><span> </span>—<span> </span><strong style="box-sizing: border-box; font-weight: 600;">2 tests, 0 failures, 0 errors, 0 skipped, 9.6 s</strong><span> </span>on emulator (Pixel 9 API 15).</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>CI green.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Re-run against latest develop after the DB refresh task lands (DB intentionally not included in this PR).</li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">🤖 Generated with<span> </span><a href="https://claude.com/claude-code" rel="nofollow" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">Claude Code</a></p><!--EndFragment-->
</body>
</html>Summary
Adds the first automated workflow under the test-flow-architect framework: a single end-to-end @Test walking through the data-entry form lifecycle of an event, with multiple Zephyr cases asserted as inline checkpoints along the journey.

Jira: [ANDROAPP-7620](https://dhis2.atlassian.net/browse/ANDROAPP-7620)
Flow plan: [Event Folder — Test Automation Flow Plan](https://dhis2.atlassian.net/wiki/spaces/MOB/pages/1792999427/Event+Folder+Test+Automation+Flow+Plan)

Workflow
EventTest.shouldExerciseEventDataEntryFormLifecycle() walks one user journey on a fixture event (program MoUd5BTQ3lY "XX MAL RDT - Case Registration", ACTIVE event with mandatory Diagnosis Method empty, at Ngelehun CHC):

Step	Action	Checkpoint (Zephyr case)
0	Launch ACTIVE event with mandatory DE empty	—
1	Verify form renders editable	ANDROAPP-4647 Save FAB visible
1	(same step)	ANDROAPP-4011 DE label uses formName ("Diagnosis method"), not displayName
1	(same step)	ANDROAPP-5266 No legacy "Update" action present
2	Tap Save FAB → tap Complete on bottom sheet	ANDROAPP-3832 Completion blocked; form stays open
Deferred checkpoints (documented inline in the test, blocked by fixture/SDK gaps — see flow plan):

ANDROAPP-910 — completed-form is read-only (SDK classifies completed events as still editable for the admin user)
ANDROAPP-2429 — re-open authority (needs two seeded users)
ANDROAPP-6405 — discard dialog on complete-with-warnings (needs UI value-change helper or Age>100 seed event)
Files
app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt — Flow A constants + intent helpers
app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt — 4 form-lifecycle Robot methods (checkSaveButtonIsDisplayed, checkFormIsReadOnly, checkFieldLabelIsFormName, checkNoLegacyUpdateActionIsPresent)
app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt — the workflow @Test
3 files, +206 / −3.

Server-side configuration (already applied)
The reserved test program MoUd5BTQ3lY on the testing instance was configured to support this workflow:

DE lWLkpWMHqEq (Diagnosis Method): formName = "Diagnosis method"
ProgramStage Ge7Eo3FNnbl: validationStrategy = ON_COMPLETE
Program rule Warn when age > 100 + SHOWWARNING action wired against DE vcSXdYGa5St (Age) — drives the deferred ANDROAPP-6405 checkpoint
3 seeded events at Ngelehun CHC (ACTIVE empty-mandatory, ACTIVE filled, COMPLETED)
Program description marks the program as "Reserved for Android Capture App automated tests — Flow A (Data Entry Form). Owned by ANDROAPP-7620."
Companion PR
The agent + skill files that drove this work — including the explicit "one workflow @Test per flow" guidance — land separately in https://github.com/dhis2/dhis2-android-capture-app/pull/4884.

Test plan
 ./gradlew :app:ktlintCheck passes.
 ./gradlew :app:compileDhis2DebugAndroidTestKotlin passes.
 ./gradlew :app:connectedDhis2DebugAndroidTest --tests org.dhis2.usescases.event.EventTest — 2 tests, 0 failures, 0 errors, 0 skipped, 9.6 s on emulator (Pixel 9 API 15).
 CI green.
 Re-run against latest develop after the DB refresh task lands (DB intentionally not included in this PR).
🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ANDROAPP-7620]: https://dhis2.atlassian.net/browse/ANDROAPP-7620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ