### PR TITLE
deps: Remove sonatype legacy dependency resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,6 @@ dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
         mavenLocal()
-        maven("https://oss.sonatype.org/content/repositories/snapshots")
         maven("https://central.sonatype.com/repository/maven-snapshots")
         google()
         mavenCentral()


### PR DESCRIPTION
## Description

Remove oss.sonatype.org dependency repository which is legacy and was returning 504 (server error) which aborts the resolution