### PR TITLE
fix: [ANDROAPP-7694] allow cancel metadata sync on log out and delete account

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/main/MainViewModel.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/MainViewModel.kt
@@ -5,11 +5,11 @@ import android.net.Uri
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -82,6 +82,8 @@ class MainViewModel(
 ) : ViewModel() {
     private val _homeScreenState = MutableStateFlow(defaultHomeScreenState)
 
+    private var metadataSyncObserverJob: Job? = null
+
     private val _homeEffects = Channel<HomeEffect>(Channel.BUFFERED)
     val homeEffects = _homeEffects.receiveAsFlow()
 
@@ -131,10 +133,7 @@ class MainViewModel(
                 _homeEffects.send(HomeEffect.OrgUnitFilterRequest)
             }.launchIn(viewModelScope)
 
-        syncBackgroundJobAction
-            .observeMetadataJob()
-            .onEach(::handleMetadataSync)
-            .launchIn(viewModelScope)
+        observeMetadataSyncJob()
 
         launchUseCase(dispatcher.io()) {
             launchInitialSync().fold(
@@ -232,6 +231,14 @@ class MainViewModel(
         }
     }
 
+    private fun observeMetadataSyncJob() {
+        metadataSyncObserverJob =
+            syncBackgroundJobAction
+                .observeMetadataJob()
+                .onEach(::handleMetadataSync)
+                .launchIn(viewModelScope)
+    }
+
     private fun handleMetadataSync(jobs: List<SyncJobStatus>) {
         jobs.forEach { job ->
             if (job.tags.contains(METADATA_SYNC_NOW)) {
@@ -274,6 +281,7 @@ class MainViewModel(
     }
 
     fun logOut() {
+        metadataSyncObserverJob?.cancel()
         launchUseCase(dispatcher.io()) {
             matomoAnalyticsController.trackEvent(HOME, CLOSE_SESSION, CLICK)
             logOutUser().fold(
@@ -282,6 +290,7 @@ class MainViewModel(
                 },
                 onFailure = {
                     Timber.e(it)
+                    observeMetadataSyncJob()
                 },
             )
         }
@@ -289,6 +298,7 @@ class MainViewModel(
 
     context(context: Context)
     fun onDeleteAccount() {
+        metadataSyncObserverJob?.cancel()
         launchUseCase(dispatcher.io()) {
             _homeEffects.send(HomeEffect.ShowDeleteNotification)
             deleteAccount(context.cacheDir).fold(
@@ -298,6 +308,7 @@ class MainViewModel(
                 },
                 onFailure = {
                     Timber.e(it)
+                    observeMetadataSyncJob()
                 },
             )
         }

--- a/app/src/test/java/org/dhis2/usescases/main/MainViewModelTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/main/MainViewModelTest.kt
@@ -51,7 +51,6 @@ import org.dhis2.utils.MainCoroutineScopeRule
 import org.dhis2.utils.analytics.CLOSE_SESSION
 import org.dhis2.utils.customviews.navigationbar.NavigationPage
 import org.hisp.dhis.mobile.ui.designsystem.component.navigationBar.NavigationBarItem
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -59,6 +58,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -101,6 +101,15 @@ class MainViewModelTest {
     private val syncStatusFlow = MutableStateFlow(SyncStatusData())
     private val newVersionFlow = MutableSharedFlow<String>()
     private val metadataJobFlow = MutableStateFlow<List<SyncJobStatus>>(emptyList())
+
+    private val succeededMetadataJob =
+        listOf(
+            SyncJobStatus(
+                tags = listOf(METADATA_SYNC_NOW),
+                status = SyncStatus.Succeed,
+                message = null,
+            ),
+        )
 
     @Before
     fun setUp() = runTest {
@@ -168,6 +177,58 @@ class MainViewModelTest {
                 advanceUntilIdle()
                 verify(matomoAnalyticsController).trackEvent(HOME, CLOSE_SESSION, CLICK)
                 assertTrue(awaitItem() == HomeEffect.GoToLogin(1, false))
+            }
+        }
+
+    @Test
+    fun `Should reconfigure navigation bar when metadata sync succeeds`() =
+        runTest {
+            whenever(configureHomeNavigationBar()) doReturn Result.success(emptyList())
+            metadataJobFlow.emit(succeededMetadataJob)
+            advanceUntilIdle()
+            verify(configureHomeNavigationBar).invoke(Unit)
+        }
+
+    @Test
+    fun `Should not reconfigure navigation bar when metadata sync emits after logout`() =
+        runTest {
+            whenever(logOutUser()) doReturn Result.success(1)
+            viewModel.homeEffects.test {
+                viewModel.logOut()
+                metadataJobFlow.emit(succeededMetadataJob)
+                advanceUntilIdle()
+                assertTrue(awaitItem() == HomeEffect.GoToLogin(1, false))
+                verify(configureHomeNavigationBar, never()).invoke(Unit)
+            }
+        }
+
+    @Test
+    fun `Should keep observing metadata sync when logout fails`() =
+        runTest {
+            whenever(logOutUser()) doReturn Result.failure(Exception("logout failed"))
+            whenever(configureHomeNavigationBar()) doReturn Result.success(emptyList())
+            viewModel.logOut()
+            advanceUntilIdle()
+            metadataJobFlow.emit(succeededMetadataJob)
+            advanceUntilIdle()
+            verify(configureHomeNavigationBar).invoke(Unit)
+        }
+
+    @Test
+    fun `Should not reconfigure navigation bar when metadata sync emits after account deletion`() =
+        runTest {
+            whenever(deleteAccount(any())) doReturn Result.success(1)
+            viewModel.homeEffects.test {
+                val mockedContext = mock<Context>()
+                whenever(mockedContext.cacheDir) doReturn File("random")
+                with(mockedContext) {
+                    viewModel.onDeleteAccount()
+                }
+                metadataJobFlow.emit(succeededMetadataJob)
+                advanceUntilIdle()
+                assertTrue(awaitItem() == HomeEffect.ShowDeleteNotification)
+                assertTrue(awaitItem() == HomeEffect.GoToLogin(1, true))
+                verify(configureHomeNavigationBar, never()).invoke(Unit)
             }
         }
 


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7694).

cancel metadata sync jobs when login out or deleting account