### PR TITLE
feat: implement sentry autofix [skip size]

### DIFF
--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: sentry-fix
+description: >
+  Given a Sentry issue ID, fetches the full event and stack trace, attributes
+  the crash to its owning repo (capture app, DHIS2 Android SDK, or mobile
+  design system), reads the relevant sources at the shipped version, diagnoses
+  the root cause, implements a fix in the owning repo following that repo's
+  conventions, writes unit tests, runs its lint/test tasks, and opens a draft
+  PR there. Invoke as /sentry-fix <issue-id> [--repo <slug>] or follow a
+  /sentry-triage report.
+---
+
+# Sentry Fix Skill
+
+Stack traces are deobfuscated (ProGuard mappings uploaded on release builds), so
+library frames carry real class names. The fix — and its PR — belongs in the
+repo that owns the bug, not necessarily this one.
+`.claude/skills/sentry-triage/references/repo-map.md` is the single source of
+truth for attribution, sibling-repo rules, per-repo commands, and PR
+conventions. Load it before Step 2.
+
+**Input**: one Sentry issue ID, e.g. `PROJ-1234` or the full numeric ID, plus an
+optional `--repo <slug>` hint from a triage report (advisory — re-verified in
+Step 2).
+
+---
+
+## Prerequisites — Sentry MCP plugin
+
+This skill requires the `sentry@claude-plugins-official` plugin. Before running any step,
+verify the plugin is available by checking whether `mcp__plugin_sentry_sentry__get_sentry_resource`
+is listed as an available tool.
+
+If the plugin is **not installed**, stop and tell the user:
+
+> The Sentry MCP plugin is not enabled in this session. To install it locally, run:
+> ```
+> /config
+> ```
+> Then navigate to **Extensions → Plugins**, find **Sentry**, and enable it. Alternatively,
+> add the following to your `~/.claude/settings.json` (user-level, not committed to the repo):
+> ```json
+> {
+>   "enabledPlugins": {
+>     "sentry@claude-plugins-official": true
+>   }
+> }
+> ```
+> Once enabled, restart the session and run `/sentry-fix <issue-id>` again.
+
+If invoked from a `/sentry-triage` report, the issue ID is in the "To fix" line of
+each issue entry.
+
+---
+
+## Step 0 — Discover Sentry org
+
+Call `mcp__plugin_sentry_sentry__find_organizations` to list accessible orgs. If there is
+only one, use it. If there are multiple, pick the one whose slug matches the GitHub org of
+the current repo (run `gh repo view --json owner -q .owner.login` to get it).
+
+Store the result as `ORG_SLUG` and the org's `regionUrl` as `REGION_URL`. These are used
+for all subsequent Sentry tool calls and to construct the Sentry issue URL:
+`https://<ORG_SLUG>.sentry.io/issues/<ISSUE-SHORT-ID>/`
+
+---
+
+## Step 1 — Fetch full issue and recent events
+
+Call `mcp__plugin_sentry_sentry__get_sentry_resource` with the issue ID and `ORG_SLUG`. Note: title, culprit, `firstSeen`,
+`lastSeen`, `userCount`, `count`, any linked tags.
+
+Then fetch recent events: discover the issue-events tool via
+`mcp__plugin_sentry_sentry__search_sentry_tools(query: "issue events")` and run
+it with `execute_sentry_tool` (limit: 5); if unavailable, work from the latest
+event embedded in the `get_sentry_resource` response. For each event extract:
+- Full stack trace (`exception.values[*].stacktrace.frames`) — all frames including SDK ones
+- All breadcrumbs (last 20, in chronological order) — reconstruct what the user was doing
+- `user`, `tags` (`release`, `environment`, `screen`), `extra`
+
+If the top frames differ significantly across the 5 events, note it before proceeding:
+the issue may aggregate multiple distinct root causes. Fix the most common pattern first
+and state what was skipped.
+
+---
+
+## Step 2 — Attribute to the owning repo and map frames to source files
+
+Load `.claude/skills/sentry-triage/references/repo-map.md` — classification
+table (§1), attribution heuristic (§2), per-repo facts (§3), sibling-repo rules
+(§4), version-skew rules (§5).
+
+1. Classify every frame by package prefix and apply the attribution heuristic to
+   determine the **owning repo**. A `--repo` hint from triage is a prior, not a
+   verdict: re-verify it, and if the evidence disagrees, say so and follow the
+   evidence.
+2. **Owner is an attribute-only lib** (rule engine, expression parser) → skip to
+   Step 8 and report a diagnosis plus an upstream recommendation; no clone, no PR.
+3. **Owner = app** → map frames with the app module table (repo-map §3) and read:
+   1. The **crash-site file** (first app-owned frame)
+   2. Files for the **3 frames above** the crash site in the call chain
+   3. The **repository interface** if the crash is in a repository implementation
+      (use `grep -r` to find the interface declaration)
+   4. The **UseCase** that calls the crashing repository or ViewModel method
+   5. The **Koin DI module** for the affected feature (injection and scope)
+4. **Owner = SDK or design system** →
+   1. Resolve the sibling clone and canonical remote (repo-map §4.1–4.2); if the
+      clone is missing, offer `gh repo clone` and stop if declined.
+   2. Resolve the **shipped lib version** from the crashing release — the
+      event's `release` tag names the app version;
+      `git show <app-tag>:gradle/libs.versions.toml` pins the lib — then the
+      diagnosis ref (repo-map §5).
+   3. Read the crash-site files at the diagnosis ref via
+      `git -C ../<repo> show <ref>:<path>` — never check anything out in the
+      user's clone.
+   4. **Already fixed upstream?** Compare the crash site at the diagnosis ref
+      against the PR base branch (repo-map §5.5). If fixed there, report
+      "bump `<version key>` in `gradle/libs.versions.toml`" and stop — no PR.
+   5. Create the isolated worktree (repo-map §4.3). All subsequent edits,
+      builds, and commits happen inside it.
+
+Skip frames whose `absPath` or `filename` is `SourceFile:N` (unresolvable).
+Never redirect a genuine library bug to "the first app-owned frame" — fix it in
+the owning repo.
+
+---
+
+## Step 3 — Diagnose root cause
+
+Identify precisely:
+- The exact line that throws / causes the bad state
+- The missing precondition: null check, unhandled empty collection, wrong state machine
+  transition, coroutine scope leaked after lifecycle end, unhandled `D2Error`, etc.
+- Whether the crash is in `commonMain` or `androidMain` (or, for library fixes,
+  which source set / module of that repo)
+- Whether the owner from Step 2 still holds: if the app violates a documented
+  library precondition, the fix belongs in the app even though the throw is in
+  the library; if the library mishandles valid input, fix the library. If the
+  diagnosis flips ownership, state it and redo Step 2's setup for the right repo.
+
+State the root cause in one sentence before writing any code.
+
+---
+
+## Step 4 — Plan the fix
+
+Before touching any file, state:
+- Which files will change and why
+- KMP placement decision:
+  - `commonMain` — if the fix is pure Kotlin logic with no Android API dependency
+  - `androidMain` — if it requires Android `Context`, DHIS2 `D2` object,
+    `CrashReportController`, or Android SDK APIs
+- If the crash site uses RxJava (`Observable`, `Single`, `Completable`): **do not add more
+  RxJava**. Wrap the existing RxJava call at the nearest boundary using a coroutine adapter
+  (`suspendCancellableCoroutine` or an existing wrapper in the codebase).
+- If new business logic is needed: create a new `UseCase<in R, out T>` from
+  `commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/domain/UseCase.kt`
+
+The KMP/UseCase bullets above apply to **app-owned** fixes. For **library-owned**
+fixes state the equivalent per target repo:
+- **SDK**: which `core/` classes change, and whether the public API surface
+  changes (`:core:apiCheck` will fail → plan `:core:apiDump` + commit the dump)
+- **Design system**: which source set (`commonMain` vs platform actuals), and
+  whether any Paparazzi golden image could be affected — if so, plan for the
+  "Generate Paparazzi Golden Images" CI workflow (repo-map §3); never regenerate
+  goldens locally
+
+---
+
+## Step 5 — Implement the fix
+
+For **app-owned** fixes follow all rules from `AGENTS.md`:
+
+- **ViewModels**: use `launchUseCase { }`, never `viewModelScope.launch` directly —
+  `launchUseCase` wraps `CoroutineTracker` for Espresso `IdlingResource` integration
+- **Repositories**: translate `D2Error` → domain errors via `DomainErrorMapper`
+  ```kotlin
+  import org.dhis2.mobile.commons.error.DomainErrorMapper
+  import org.hisp.dhis.android.core.maintenance.D2Error
+  ```
+- **Models**: `data class` for new data models; `sealed interface` for new UiState variants
+- **Style** (`ktlint_official`):
+  - No wildcard imports
+  - Trailing commas on every multi-line parameter/argument list
+  - Expression bodies for single-expression functions
+- **No comments** unless the WHY is non-obvious (hidden constraint, workaround for a
+  specific upstream bug)
+
+For **library-owned** fixes the app's conventions do NOT apply (no
+`launchUseCase`, no `DomainErrorMapper`). Follow the target repo's own guidance:
+- **SDK**: its committed `CLAUDE.md`
+- **Design system**: its `CLAUDE.md` if present (it is untracked and may be
+  absent), else `README.md` + `docs/`
+- Plus the hard constraints in repo-map §3 (SDK: `apiCheck`/`apiDump`; design
+  system: no local golden regeneration, `allWarningsAsErrors`)
+- Match the naming, idiom, and comment density of the surrounding code in that repo
+
+---
+
+## Step 6 — Write unit tests
+
+Load the `android-testing` skill for full patterns. At minimum write:
+
+**UseCase test** (if the UseCase was created or modified):
+- Success path
+- Failure path (wraps exception in `Result.failure`)
+- The specific edge case that caused the crash (e.g. empty list, null return from D2)
+
+**ViewModel test** (if the ViewModel was modified):
+- The state transition that was failing (use `app.cash.turbine` to assert `StateFlow` emissions)
+- Use `launchUseCase` / `CoroutineTracker` idiom — never `Thread.sleep()`
+
+**Repository test** (if the repository was modified):
+- Mock D2 with `mock(defaultAnswer = RETURNS_DEEP_STUBS)`
+- The `D2Error` → domain error mapping path
+
+**Placement**:
+- `commonTest/` — for classes in `commonMain`
+- `androidUnitTest/` — for classes in `androidMain`
+- Existing module test source set — for legacy Android modules (`form`, `commons`, `tracker`, `app`)
+- **SDK** — `core/src/test/java/`, class named `<Class>Should`, mirroring the
+  neighboring tests of the touched class
+- **Design system** — put pure-Kotlin tests next to the existing tests of the
+  same component (they run via `desktopTest`); add a Paparazzi snapshot test only
+  if a visual contract changed, and let CI generate the goldens
+
+---
+
+## Step 7 — Run lint and tests
+
+Run in this exact order, **inside the repo that owns the fix** (for libraries:
+inside the worktree from Step 2). Fix any failures before moving on.
+
+**App**:
+```bash
+# 1. Auto-fix formatting
+./gradlew ktlintFormat
+
+# 2. Verify no remaining violations
+./gradlew ktlintCheck
+
+# 3. Run tests for the affected module
+# KMP module (commonTest source set):
+./gradlew :<module>:testAndroidHostTest
+
+# KMP module (androidUnitTest source set):
+./gradlew :<module>:testAndroidDebugUnitTest
+
+# Legacy Android module:
+./gradlew :<module>:testDebugUnitTest
+```
+
+**SDK** (in the worktree):
+```bash
+./gradlew :core:ktlintFormat :core:ktlintCheck
+./gradlew :core:testDebugUnitTest
+./gradlew :core:apiCheck   # fails on public API change → :core:apiDump + commit the dump
+```
+
+**Design system** (in the worktree):
+```bash
+./gradlew ktlintFormat ktlintCheck
+./gradlew desktopTest
+./gradlew designsystem:testDebugUnitTest
+```
+
+If a Gradle build in a library worktree cannot locate the Android SDK, copy
+`local.properties` from the sibling clone root into the worktree.
+
+If tests fail, iterate on the fix. Do not skip or comment-out failing tests.
+
+---
+
+## Step 8 — Report
+
+Output a summary in this format:
+
+```
+## Fix Summary — <Issue ID>
+
+**Root cause**: <one sentence>
+**Owner**: <repo> (<"as triaged" | "overridden from --repo hint because …">)
+**Fix**: <what changed and why — 2-3 sentences>
+**Files changed**:
+- `path/to/File.kt` — <what changed>
+- `path/to/FileTest.kt` — <tests added>
+**Lint**: passed
+**Tests**: passed (<test class>::<method>, ...)
+**Ships via**: <library-owned only: lib release → gradle/libs.versions.toml bump → app release. If the crash is severe, propose an app-side defensive guard as a companion PR so shipped versions stop crashing sooner.>
+```
+
+If you cannot determine a safe fix — the owner is an attribute-only lib (rule
+engine, expression parser), or the root cause is genuinely unclear — state that
+with a recommended action: a diagnosis for a manual upstream fix, a defensive
+guard in the app to stop the crash surfacing to users, or a Sentry breadcrumb to
+improve future diagnosis.
+
+---
+
+## Step 9 — Create branch and open PR (in the owning repo)
+
+Every PR is opened as a **draft**, and every PR body includes a `## Sentry issue`
+section:
+
+```
+## Sentry issue
+Fixes <SENTRY-SHORT-ID>
+https://<ORG_SLUG>.sentry.io/issues/<SENTRY-SHORT-ID>/
+```
+
+- `Fixes <SENTRY-SHORT-ID>` — Sentry's GitHub integration scans PR bodies for it
+  and auto-links the PR on the issue page. It only fires for repos connected in
+  the Sentry org's GitHub integration (the app repo is; the library repos may
+  not be) — include it anyway.
+- The URL (from `ORG_SLUG` resolved in Step 0) always works regardless.
+
+### Step 9a — Owner = app (this repo)
+
+**CRITICAL**: The fix branch must be created FROM the branch where this skill is
+triggered, and the PR must target that same branch. Never use `main`, `develop`,
+or `origin/main` as the base unless you are explicitly told to. (This rule is
+app-repo-only — library base branches are fixed in Step 9b.)
+
+```bash
+# 1. Record the current branch BEFORE creating the fix branch
+BASE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# 2. Create fix branch FROM that base — never from main or origin/main
+git checkout -b fix/sentry-<issue-id-lowercase> "$BASE_BRANCH"
+
+# 3. Stage and commit — end the message with the Co-Authored-By trailer the
+#    harness specifies for the current model (never hardcode a model name)
+git add <files>
+git commit -m "fix: <short description of fix>"
+
+# 4. Push
+git push -u origin fix/sentry-<issue-id-lowercase>
+
+# 5. Open PR as draft targeting BASE_BRANCH (not main/develop)
+gh pr create \
+  --draft \
+  --base "$BASE_BRANCH" \
+  --title "fix: <short description>" \
+  --body "..."
+```
+
+### Step 9b — Owner = SDK or design system
+
+Work happens inside the worktree created in Step 2; the branch
+`fix/sentry-<short-id>` already exists there. Base branches are fixed per repo
+(repo-map §3): SDK → `develop`, design system → `develop`. Never `master`/`main`.
+
+1. **Jira**
+   - **SDK**: ask the user for an existing ANDROSDK ticket or offer to create
+     one via the Atlassian MCP. Ticket → rename the branch to it
+     (`git -C <worktree> branch -m ANDROSDK-XXXX`); declined → keep
+     `fix/sentry-<short-id>`.
+   - **Design system**: reference an ANDROAPP code in the title only if one
+     exists; do not create tickets for it.
+2. **Commit** — per-repo trailer rules: SDK commits carry **no Co-Authored-By
+   and no 🤖 footer** (its `open-pr` skill forbids both); design-system commits
+   keep the standard harness trailer.
+3. **Push** — check push rights first (repo-map §4.6): push the canonical dhis2
+   remote, or fall back to `gh repo fork --remote` + `--head <login>:<branch>`.
+4. **Open the draft PR** with title/body per repo-map §3:
+   - SDK: `fix: [ANDROSDK-XXXX] <short imperative>` (or `fix: <desc>` + body
+     note when no ticket), body 1–2 paragraphs + `Related task:` Jira link +
+     the Sentry issue section.
+   - Design system: `fix: [ANDROAPP-XXXX] <desc>` matching recent merged PRs +
+     the Sentry issue section.
+   ```bash
+   gh pr create --repo dhis2/<name> --base develop --draft \
+     --title "<per repo-map>" --body "..."
+   ```
+5. **After the PR**: keep the worktree for review iteration and print its
+   removal command (repo-map §4.5); optionally note the PR URL on the Sentry
+   issue via the MCP update tool (non-fatal if unavailable).
+6. **Delivery note**: end with the "Ships via" line from Step 8 — the fix
+   reaches users only after a library release plus an app version bump; for
+   severe crashes propose an app-side defensive guard as a companion PR.

--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -9,8 +9,9 @@ description: >
   PR there — linking a Jira ticket for app-owned fixes when Jira access is
   available. Then watches the PR for the rest of the session, answering
   questions and pushing follow-up fixes for review comments until it is merged
-  or closed. Invoke as /sentry-fix <issue-id> [--repo <slug>] or follow a
-  /sentry-triage report.
+  or closed, and schedules a check to auto-resolve the Sentry issue once that
+  Jira ticket reaches Done. Invoke as /sentry-fix <issue-id> [--repo <slug>]
+  or follow a /sentry-triage report.
 ---
 
 # Sentry Fix Skill
@@ -486,3 +487,46 @@ the comment back in.
    left mid-review in an earlier session, just re-arm the Monitor from step 1
    using that PR's number; say so if the user seems to expect it persisted
    automatically.
+
+---
+
+## Step 11 — Auto-resolve the Sentry issue once the Jira ticket is Done
+
+Only applies when Step 9a's Jira sub-step produced a `JIRA_KEY` (skip this
+step entirely if there is none — nothing to close the loop with).
+
+Jira polling can't be a `Monitor` bash script like Step 10's — there is no CLI
+for the Atlassian MCP the way `gh` is a CLI for GitHub, so a detached shell
+process cannot call `getJiraIssue`. Only the agent itself can, which means
+this has to run as scheduled **prompts** (`CronCreate`), not a background
+script.
+
+1. **Check once immediately** when Step 10 reports the PR as `MERGED` (tickets
+   are sometimes auto-transitioned by a smart commit on merge, so this can
+   resolve instantly): call `getJiraIssue` on `JIRA_KEY` with
+   `fields: ["status"]`. If `status.statusCategory.key == "done"`, skip
+   straight to step 3.
+2. **Otherwise, schedule a recurring check** — `CronCreate` with a
+   self-contained prompt (it must carry everything needed, since it runs as a
+   fresh turn with no memory of this conversation):
+   > Check Jira issue `<JIRA_KEY>`'s status via the Atlassian MCP
+   > (`getJiraIssue`, `fields: ["status"]`). If `status.statusCategory.key` is
+   > `"done"`, mark Sentry issue `<SENTRY-SHORT-ID>` resolved via the Sentry
+   > MCP (`update_issue`, `status: "resolved"`, `reason: "Closed via Jira
+   > <JIRA_KEY>"`, `organizationSlug: "<ORG_SLUG>"`), then delete this cron
+   > job with `CronDelete`. Otherwise do nothing — the next scheduled run will
+   > check again.
+
+   A cadence of every few hours (e.g. `"17 */6 * * *"`) is plenty — Jira
+   tickets move on the order of days, not minutes. Tell the user the cadence
+   chosen and both caveats up front: recurring cron jobs auto-expire after 7
+   days, and none of this survives the session ending. If either limit is hit
+   before the ticket is closed, the Sentry issue is left as-is with no
+   automatic follow-up — say so plainly rather than implying it will
+   eventually resolve on its own.
+3. **Resolve**: call the Sentry MCP's `update_issue` with
+   `status: "resolved"` and `reason: "Closed via Jira <JIRA_KEY>"` on the
+   original Sentry issue. Report the resolution back — inline if step 1
+   caught it immediately, or (when this fires later from the cron job, in
+   what may be a different session) that report is simply the cron prompt's
+   own final message.

--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -321,6 +321,41 @@ triggered, and the PR must target that same branch. Never use `main`, `develop`,
 or `origin/main` as the base unless you are explicitly told to. (This rule is
 app-repo-only — library base branches are fixed in Step 9b.)
 
+**0. Jira (optional, before creating the branch)**
+
+- Check whether Atlassian/Jira MCP tools are connected: search for them (e.g.
+  `ToolSearch` with a query like `"jira accessible resources create issue search"`).
+  Tool names are prefixed with a connection-specific server ID, so match by
+  keyword, not by a hardcoded name.
+- **Not connected** → ask the user once: "I can create/link a Jira issue for
+  this fix if you connect the Atlassian MCP — want me to, or should I skip
+  Jira for this fix?" Declined, or still unavailable after asking → skip Jira
+  entirely and continue to step 1 below with no ticket reference (the PR
+  title/body stay exactly as documented further down, no `[ANDROAPP-XXXX]`
+  prefix, no `Related task:` line).
+- **Connected** → resolve `cloudId` via the accessible-resources tool, then:
+  1. Search the `ANDROAPP` project for an issue that already covers this
+     crash — narrow JQL by the Sentry short-ID, the crash-site class name, or
+     a distinctive phrase from the culprit (`project = ANDROAPP AND text ~
+     "<term>"`, `fields: ["summary","status"]`). Prefer several narrow queries
+     over one broad one — an unscoped `text ~` search across the whole
+     project can return an oversized result.
+  2. **Found an existing open issue** covering the same crash → reuse its key
+     as `JIRA_KEY`; do not create a duplicate.
+  3. **Nothing found** → create a new `Bug` in `ANDROAPP`: summary matching
+     the Sentry issue title, description with the Sentry issue link, a
+     trimmed stack trace, the one-sentence root cause from Step 3, and (once
+     known) the PR link. Before creating, fetch this issue type's required
+     fields (`getJiraIssueTypeMetaWithFields`) — at the time of writing `Bug`
+     requires `components` (use `AndroidApp` unless a more specific component
+     obviously fits), `environment` (free text — release + platform is
+     enough), and `versions` (`Affects versions` — the crashing release, e.g.
+     the `release` tag from Step 1). Store the new key as `JIRA_KEY`.
+  4. If the search in 1 (or a `/sentry-triage` report) surfaced a clearly
+     related prior ticket — same anti-pattern, adjacent call site or repo —
+     link `JIRA_KEY` to it (`createIssueLink`, type `Relates`) and mention the
+     link when reporting back.
+
 ```bash
 # 1. Record the current branch BEFORE creating the fix branch
 BASE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -336,12 +371,20 @@ git commit -m "fix: <short description of fix>"
 # 4. Push
 git push -u origin fix/sentry-<issue-id-lowercase>
 
-# 5. Open PR as draft targeting BASE_BRANCH (not main/develop)
+# 5. Open PR as draft targeting BASE_BRANCH (not main/develop). Title gets the
+#    [JIRA_KEY] prefix only if step 0 produced one:
 gh pr create \
   --draft \
   --base "$BASE_BRANCH" \
-  --title "fix: <short description>" \
+  --title "fix: [<JIRA_KEY>] <short description>" \
   --body "..."
+# (title is "fix: <short description>", no brackets, when there is no JIRA_KEY)
+```
+
+When `JIRA_KEY` exists, add one line to the `## Sentry issue` section of the PR
+body (format below):
+```
+Related task: [<JIRA_KEY>](https://<atlassian-site>/browse/<JIRA_KEY>)
 ```
 
 ### Step 9b — Owner = SDK or design system

--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -6,7 +6,10 @@ description: >
   design system), reads the relevant sources at the shipped version, diagnoses
   the root cause, implements a fix in the owning repo following that repo's
   conventions, writes unit tests, runs its lint/test tasks, and opens a draft
-  PR there. Invoke as /sentry-fix <issue-id> [--repo <slug>] or follow a
+  PR there — linking a Jira ticket for app-owned fixes when Jira access is
+  available. Then watches the PR for the rest of the session, answering
+  questions and pushing follow-up fixes for review comments until it is merged
+  or closed. Invoke as /sentry-fix <issue-id> [--repo <slug>] or follow a
   /sentry-triage report.
 ---
 
@@ -421,3 +424,65 @@ Work happens inside the worktree created in Step 2; the branch
 6. **Delivery note**: end with the "Ships via" line from Step 8 — the fix
    reaches users only after a library release plus an app version bump; for
    severe crashes propose an app-side defensive guard as a companion PR.
+
+---
+
+## Step 10 — Monitor the PR until merged or closed
+
+Once a PR exists (from either 9a or 9b), don't stop at "opened" — stay attached
+so review feedback gets answered without the user having to ask again or paste
+the comment back in.
+
+1. Start a persistent `Monitor` polling the PR every ~30s for anything new
+   since the last poll, emitting one line per new item, and exiting once the
+   PR's state is no longer `OPEN`:
+   ```bash
+   last=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   while true; do
+     state=$(gh pr view <PR-NUMBER> --repo <owner>/<repo> --json state -q .state)
+     now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+     gh api "repos/<owner>/<repo>/issues/<PR-NUMBER>/comments?since=$last" \
+       --jq '.[] | "issue-comment \(.id) \(.user.login): \(.body)"'
+     gh api "repos/<owner>/<repo>/pulls/<PR-NUMBER>/comments?since=$last" \
+       --jq '.[] | "review-comment \(.id) \(.path):\(.line // .original_line) \(.user.login): \(.body)"'
+     gh api "repos/<owner>/<repo>/pulls/<PR-NUMBER>/reviews" \
+       --jq --arg since "$last" '.[] | select(.submitted_at > $since and .body != "") | "review \(.id) \(.user.login) \(.state): \(.body)"'
+     last=$now
+     if [ "$state" != "OPEN" ]; then echo "pr-state $state"; break; fi
+     sleep 30
+   done
+   ```
+   Use `persistent: true` (no timeout) and a description naming the PR, e.g.
+   `"PR #<N> comments/reviews"`.
+
+2. **On each new-comment/review notification**:
+   - Re-sync first — other work may have moved the worktree since the PR was
+     opened: `git checkout <branch> && git pull --ff-only` (app repo) or
+     `git -C <worktree> pull --ff-only` (library repo).
+   - Read the full comment and classify it:
+     - **Pure status/bot noise** (a CI check going green, a coverage report, a
+       passing quality-gate summary with nothing flagged) → no action.
+     - **A question** → answer directly by replying on the same thread — no
+       code change needed.
+     - **A requested change or a spotted bug** → re-run Steps 3–7 (diagnose,
+       implement, test, lint) for the new scope, commit, and push to the same
+       branch.
+   - For anything you acted on or answered, reply on that specific thread
+     (`gh api repos/<owner>/<repo>/pulls/<PR-NUMBER>/comments/<comment-id>/replies`
+     for inline review comments, `gh pr comment` for issue-level ones) with a
+     one-line summary of what changed — or why not, if you decided against it
+     — ending with the line
+     `_🤖 Addressed by [Claude Code](https://claude.com/claude-code)_`. Then
+     resolve the thread if it's an inline review thread (GraphQL
+     `resolveReviewThread` on the thread ID from `reviewThreads` in the PR's
+     GraphQL query). Skip replies for anything you didn't act on.
+
+3. **Stop condition**: the moment the poll reports `pr-state MERGED` or
+   `pr-state CLOSED`, stop watching and tell the user the final state.
+
+4. **Session-scoped caveat**: this watch runs only for the lifetime of the
+   current session — it is not a durable cron job, and it does not survive a
+   session ending or being cleared. If asked to resume watching a PR that was
+   left mid-review in an earlier session, just re-arm the Monitor from step 1
+   using that PR's number; say so if the user seems to expect it persisted
+   automatically.

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: sentry-triage
+description: >
+  Fetches unresolved Sentry issues for the latest production release,
+  attributes each issue to its owning repo (capture app, DHIS2 Android SDK,
+  or mobile design system), scores it on Impact (1-5) and Effort (1-5), and
+  outputs a prioritized impact/effort quadrant report with ready-to-run
+  /sentry-fix commands. Use when you want to decide what to fix next.
+---
+
+# Sentry Triage Skill
+
+Stack traces are deobfuscated (ProGuard mappings uploaded on release builds), so
+library frames carry real class names. Crashes may originate in DHIS2-owned
+libraries shipped inside the APK — `references/repo-map.md` is the single source
+of truth for package→repo attribution and per-repo facts. Load it before Step 4.
+
+---
+
+## Prerequisites — Sentry MCP plugin
+
+This skill requires the `sentry@claude-plugins-official` plugin. Before running any step,
+verify the plugin is available by checking whether `mcp__plugin_sentry_sentry__find_organizations`
+is listed as an available tool.
+
+Tool names vary across plugin versions: newer versions expose a small core set
+plus a catalog — discover anything not listed (releases, issue events, …) with
+`mcp__plugin_sentry_sentry__search_sentry_tools` and run it with
+`mcp__plugin_sentry_sentry__execute_sentry_tool`.
+
+If the plugin is **not installed**, stop and tell the user:
+
+> The Sentry MCP plugin is not enabled in this session. To install it locally, run:
+> ```
+> /config
+> ```
+> Then navigate to **Extensions → Plugins**, find **Sentry**, and enable it. Alternatively,
+> add the following to your `~/.claude/settings.json` (user-level, not committed to the repo):
+> ```json
+> {
+>   "enabledPlugins": {
+>     "sentry@claude-plugins-official": true
+>   }
+> }
+> ```
+> Once enabled, restart the session and run `/sentry-triage` again.
+
+---
+
+## Step 0 — Discover Sentry org and project
+
+Call `mcp__plugin_sentry_sentry__find_organizations` to list accessible orgs. If there is
+only one, use it. If there are multiple, pick the one whose slug matches the GitHub org of
+the current repo (run `gh repo view --json owner -q .owner.login` to get it).
+
+Store the result as `ORG_SLUG` and the org's `regionUrl` as `REGION_URL`.
+
+Then call `mcp__plugin_sentry_sentry__find_projects` with `organizationSlug: ORG_SLUG`.
+Match the project whose slug or name most closely corresponds to this Android app (look for
+`android`, `capture`, or the repo name). Store this as `PROJECT_SLUG`.
+
+---
+
+## Step 1 — Resolve the latest production version
+
+Do **not** read `gradle/libs.versions.toml` — the working branch is always ahead of what is
+shipped. Determine the last production release using one of these methods, in order:
+
+1. Query the project's releases (tool `find_releases` if listed, else discover it
+   via `search_sentry_tools(query: "list releases")` and run it with
+   `execute_sentry_tool`) for `PROJECT_SLUG`, filter by environment `production`,
+   sort by `date` descending, take the first entry's `version` string.
+2. If that returns no results, run:
+   ```
+   gh repo view --json nameWithOwner -q .nameWithOwner | xargs -I{} gh release list --repo {} --limit 5
+   ```
+   and pick the most recent non-prerelease tag. Strip a leading `v` if present.
+
+Store this as `PROD_VERSION` for use in all subsequent queries.
+
+Then resolve the library versions that release shipped: find the git tag matching
+`PROD_VERSION` (strip any `+<build>` metadata) and run
+
+```bash
+git show <tag>:gradle/libs.versions.toml | grep -E "dhis2sdk|designSystem"
+```
+
+Store `SDK_VERSION` and `DESIGN_SYSTEM_VERSION` — they go in the report header
+and pin the diagnosis ref when reading library code (repo-map §5).
+
+---
+
+## Step 2 — Query top unresolved issues
+
+Call `mcp__plugin_sentry_sentry__search_issues` with:
+- `organizationSlug`: `ORG_SLUG`
+- `regionUrl`: `REGION_URL`
+- `projectSlug`: `PROJECT_SLUG`
+- `query`: `is:unresolved release:<PROD_VERSION> !is:ignored`
+- `sort`: `user` (the enum is `date` | `freq` | `new` | `user` — note: singular `user`, not `users`)
+- `limit`: 10
+
+Note: `PROD_VERSION` is the full release string including the package and build,
+e.g. `com.dhis2@3.4.1+156`. The `sort: user` window is release-scoped, so the
+returned order can differ from each issue's all-release user total shown in the
+issue detail — use the per-issue `Users Impacted` for Impact scoring and note the
+distinction.
+
+If 0 results come back, retry in this order:
+1. Try `release:<PROD_VERSION>+<build-number>` — the Sentry Gradle plugin sometimes uploads
+   releases in `<vName>+<vCode>` format. Inspect the first few Sentry releases to find the
+   matching string.
+2. If still 0, remove the `release:` filter entirely. Note in the report that the filter was
+   relaxed and which version was targeted.
+
+---
+
+## Step 3 — Fetch latest event per issue
+
+For each issue, fetch its latest event with
+`mcp__plugin_sentry_sentry__get_sentry_resource` (issue short ID; add
+`resourceType: "breadcrumbs"` for the breadcrumb trail). If you need more than
+the latest event, discover the issue-events tool via
+`search_sentry_tools(query: "issue events")` and fetch up to 3. From the most
+recent event extract:
+- `exception.values[0].stacktrace.frames` — full frame list
+- `breadcrumbs.values` — last 10 entries (reveals the user flow)
+- `user` — for uniqueness; note if absent (unauthenticated session)
+- `tags` — look for `release`, `environment`, `screen`, `flow`
+
+If events vary significantly across the 3 fetched (different top frames), note it in the
+Scoring Detail — it means the issue aggregates multiple distinct bugs.
+
+---
+
+## Step 4 — Attribute each issue to an owning repo and map frames
+
+Load `references/repo-map.md` (classification table §1, attribution heuristic §2,
+per-repo facts §3).
+
+Walk the innermost exception's frames from the crash site outward, classifying
+each frame by package prefix (app / SDK / design system / rule engine /
+expression parser / platform). Apply the attribution heuristic to determine
+**Thrown in**, **Owner**, and **Confidence**, with a one-clause reason.
+
+- `org.hisp.dhis.rules.*` / `org.hisp.dhis.lib.expression.*` → attribute and
+  mark "external DHIS2 lib — no automated fix flow".
+- Low confidence → add "verify ownership during fix" to the issue entry.
+
+Then read the **top 3-5 owned files** starting from the crash site upward in the
+call chain:
+
+- **App-owned frames**: map with the app module table in repo-map §3.
+- **Library-owned frames**: read from the sibling clone at the shipped version —
+  `git -C ../<repo> show <diagnosis-ref>:<path>` (ref resolution: repo-map §5,
+  using `SDK_VERSION` / `DESIGN_SYSTEM_VERSION` from Step 1). If the sibling
+  clone is missing, attribute by package only and note it — do not clone during
+  triage.
+
+If a frame's `absPath` or `filename` is `SourceFile:N` (unresolved), skip it and
+continue to the next frame.
+
+---
+
+## Step 5 — Score each issue
+
+### Impact (1–5)
+
+Take the **highest** matching base score, then apply modifiers:
+
+| Score | Base criteria |
+|-------|---------------|
+| 5 | Crash (unhandled exception / ANR) affecting ≥ 100 unique users |
+| 4 | Crash affecting 10–99 unique users |
+| 3 | Non-crash degradation (wrong data, feature disabled, blank screen) affecting ≥ 50 users |
+| 2 | Non-crash affecting 10–49 users OR crash affecting < 10 users |
+| 1 | Non-crash < 10 users OR cosmetic / UI glitch |
+
+**Modifiers** (cap total at 5):
+- +1 if the crash site is in the login flow (`org.dhis2.usescases.login`, `org.dhis2.mobile.login`)
+  or sync flow (`org.dhis2.mobile.sync`, `org.dhis2.usescases.sync`)
+- +1 if the crash site is in data-entry/enrollment/form flow (`org.dhis2.form`,
+  `org.dhis2.usescases.eventsWithoutRegistration`, `org.dhis2.usescases.enrollment`)
+- +1 if `times_seen / users_seen` ratio > 5 (the same users are hitting it repeatedly)
+
+### Effort (1–5)
+
+SDK and design-system bugs are fixed **directly in their repos** (see
+`/sentry-fix`), so score them on the same complexity criteria as app code — the
+old "SDK = workaround only" penalty no longer applies.
+
+Take the **highest** matching base score, then apply modifiers:
+
+| Score | Base criteria |
+|-------|---------------|
+| 5 | Fix spans two repos (lib fix + app adaptation), or breaks a public SDK API (`:core:apiCheck`), or needs a new full arch layer (UseCase + Repository + ViewModel) |
+| 4 | 3–4 source files OR `androidMain`-only change with no `commonMain` path OR crash site uses RxJava that would need migration |
+| 3 | 2 files, mixed source sets, or new UseCase only (no repo change) — in whichever repo owns the fix |
+| 2 | 1–2 files, known pattern (null guard, default value, missing catch), in the owning repo |
+| 1 | Single-line fix in any file |
+
+**Modifiers** (cap total at 5):
+- +1 if owned stack depth > 10 frames (deep call chains require careful tracing)
+- +1 if the owner is a library repo — the fix only reaches users after a library
+  release plus an app version bump (record a "Ships via" line in the Scoring Detail)
+
+---
+
+## Step 6 — Classify into quadrants
+
+| Quadrant | Condition | Label |
+|----------|-----------|-------|
+| Q1 | Impact ≥ 4 AND Effort ≤ 2 | Fix ASAP |
+| Q2 | Impact ≥ 4 AND Effort ≥ 3 | Plan carefully |
+| Q3 | Impact ≤ 3 AND Effort ≤ 2 | Quick wins |
+| Q4 | Impact ≤ 3 AND Effort ≥ 3 | Defer |
+
+---
+
+## Step 7 — Output the triage report
+
+Produce a markdown report with this structure:
+
+```
+## Sentry Triage Report — <PROJECT_SLUG>
+Production release: <PROD_VERSION> (SDK <SDK_VERSION>, design system <DESIGN_SYSTEM_VERSION>)
+Generated: <today's date>
+[Note if release filter was relaxed and why]
+
+### Q1: Fix ASAP (High Impact, Low Effort)
+| Issue ID | Title | Impact | Effort | Owner | Crash site | To fix |
+|----------|-------|--------|--------|-------|------------|--------|
+| SENTRY-X | ...   | 5      | 1      | app   | Foo.kt:42  | `/sentry-fix SENTRY-X` |
+| SENTRY-Y | ...   | 4      | 2      | SDK   | Bar.kt:99  | `/sentry-fix SENTRY-Y --repo dhis2/dhis2-android-sdk` |
+
+### Q2: Plan Carefully (High Impact, High Effort)
+...
+
+### Q3: Quick Wins (Low Impact, Low Effort)
+...
+
+### Q4: Defer (Low Impact, High Effort)
+...
+
+---
+
+### Scoring Detail
+
+#### SENTRY-X — <title>
+- **Impact**: X/5 — <one-sentence rationale>
+- **Effort**: X/5 — <one-sentence rationale>
+- **Owner**: <repo> (thrown in <repo>; confidence high|medium|low — <one-clause reason>)
+- **Crash site**: `ClassName.kt:lineN`
+- **Flow**: <login | sync | data-entry | tracker | dashboard | settings | other>
+- **Users affected**: <count>
+- **Events**: <count> (ratio <times_seen/users_seen>)
+- **Root cause hint**: <one sentence from reading the crash-site file>
+- **Shipped lib version**: <only for library-owned issues, e.g. SDK 1.14.1>
+- **Ships via**: <only for library-owned issues: lib release → libs.versions.toml bump → app release; note if an app-side defensive guard is worth a companion fix>
+- **To fix**: `/sentry-fix SENTRY-X [--repo <slug>]`
+```
+
+The `--repo` hint is advisory — `/sentry-fix` re-verifies ownership against real
+code and may override it. Issues owned by attribute-only libs (rule engine,
+expression parser) get a "manual upstream fix" note instead of a `/sentry-fix`
+command.
+
+If no issues were found even after relaxing the filter, state clearly which org and project
+were resolved in Step 0, and suggest the user verify they are correct.

--- a/.claude/skills/sentry-triage/references/repo-map.md
+++ b/.claude/skills/sentry-triage/references/repo-map.md
@@ -1,0 +1,216 @@
+# Repo Attribution Map — DHIS2 mobile repositories
+
+Single source of truth for multi-repo Sentry triage and fixes. Loaded by both
+`/sentry-triage` and `/sentry-fix`. Everything repo-specific (attribution,
+commands, PR conventions, constraints) lives here so the skills stay
+orchestration-only.
+
+The capture app APK ships code from several DHIS2-owned repositories. Stack
+frames are deobfuscated (ProGuard mappings cover the whole APK), so library
+frames carry real class/file names and are attributed by package prefix.
+
+---
+
+## 1. Classification table
+
+| Package prefix | Repo | GitHub slug | Local clone | Support |
+|---|---|---|---|---|
+| `org.dhis2.*` | Capture app | `dhis2/dhis2-android-capture-app` | this repo | full |
+| `org.hisp.dhis.android.*` | Android SDK | `dhis2/dhis2-android-sdk` | `../dhis2-android-sdk` | full |
+| `org.hisp.dhis.mobile.ui.*` | Design system | `dhis2/dhis2-mobile-ui` | `../dhis2-mobile-ui` | full |
+| `org.hisp.dhis.rules.*` | Rule engine | `dhis2/dhis2-rule-engine` | — | attribute-only |
+| `org.hisp.dhis.lib.expression.*` | Expression parser | `dhis2/expression-parser` | — | attribute-only |
+| `androidx.*`, `android.*`, `java.*`, `kotlin.*`, `kotlinx.*`, `io.sentry.*` | Platform / third-party | — | — | ignore |
+
+- **full** — `/sentry-fix` implements, tests, and opens a draft PR in that repo.
+- **attribute-only** — triage names the repo so the crash is not misattributed to
+  the nearest app frame; `/sentry-fix` reports a diagnosis and recommends a manual
+  upstream fix (no clone, no PR). Verify the slug with `gh repo view` before
+  linking it in a report.
+- **ignore** — never the owner; skip these frames when walking the stack.
+
+---
+
+## 2. Attribution heuristic — "thrown in" vs "owner"
+
+Walk the innermost exception's frames from the crash site outward.
+
+- **Thrown in** = repo of the innermost DHIS2-owned frame.
+- **Owner** = the repo whose code is actually wrong. It differs from *thrown in*
+  only when the innermost owned frame is a library frame at the app↔lib boundary
+  (an app frame directly beneath it in the call chain) AND the exception is a
+  precondition failure — `IllegalArgumentException`, `IllegalStateException`,
+  NPE on a parameter, a `require(...)`/`checkNotNull(...)` message. That is API
+  misuse: owner = the **calling** repo, confidence medium.
+- ≥3 consecutive library frames beyond the last app frame, or no app frames at
+  all (SDK-internal sync engine, background workers) → owner = the library,
+  confidence high.
+- Interleaved `app → designsystem → app` frames (composable content lambdas) →
+  owner = app unless the crash is inside design-system internals, confidence medium.
+- Anything unclear → owner = thrown-in repo, confidence low; `/sentry-fix` must
+  re-verify before writing code.
+
+Always record: `Owner`, `Thrown in`, `Confidence (high|medium|low)` plus a
+one-clause reason. Triage's attribution is a **hypothesis**: `/sentry-fix`
+re-derives ownership from real code at the shipped version and overrides it when
+the evidence disagrees — and says so explicitly when that happens.
+
+---
+
+## 3. Per-repo facts
+
+### dhis2/dhis2-android-capture-app — "app" (this repo)
+
+- PR base: the branch the skill was triggered from — never `main`/`develop`
+  unless explicitly told.
+- PRs: **draft**, title `fix: <desc>`, `## Sentry issue` section, and the
+  harness-provided `Co-Authored-By` trailer (never hardcode a model name).
+- Conventions: `AGENTS.md` (launchUseCase, DomainErrorMapper, KMP placement,
+  ktlint, testing rules).
+- Lint/tests: `./gradlew ktlintFormat ktlintCheck` + per-module test task
+  (`testDebugUnitTest` legacy modules · `testAndroidHostTest` KMP commonTest ·
+  `testAndroidDebugUnitTest` KMP androidUnitTest).
+- Module mapping for `org.dhis2.*` frames:
+
+| Package prefix | Source root |
+|----------------|-------------|
+| `org.dhis2.mobile.login.*` | `login/src/(commonMain\|androidMain)/kotlin/` |
+| `org.dhis2.mobile.sync.*` | `sync/src/commonMain/kotlin/` |
+| `org.dhis2.mobile.commons.*` | `commonskmm/src/commonMain/kotlin/` |
+| `org.dhis2.mobile.aggregates.*` | `aggregates/src/commonMain/kotlin/` |
+| `org.dhis2.mobileProgramRules.*` | `dhis2-mobile-program-rules/src/main/java/` |
+| `org.dhis2.tracker.*` | `tracker/src/(commonMain\|androidMain)/kotlin/` |
+| `org.dhis2.form.*` | `form/src/main/java/` |
+| `org.dhis2.commons.*` | `commons/src/main/java/` |
+| `org.dhis2.*` (remaining) | `app/src/main/java/` |
+
+### dhis2/dhis2-android-sdk — "SDK"
+
+- Local sibling: `../dhis2-android-sdk` · toml version key: `dhis2sdk`
+  (artifact `org.hisp.dhis:android-core`) · release tags look like `1.14.1`.
+- PR base branch: **`develop`** (`origin/HEAD` points at `master` — do not use it).
+- Module `core/`; sources `core/src/main/java/` (Kotlin + Java); unit tests
+  `core/src/test/java/`, classes named `<Class>Should`.
+- Verify:
+  ```bash
+  ./gradlew :core:ktlintFormat :core:ktlintCheck
+  ./gradlew :core:testDebugUnitTest
+  ./gradlew :core:apiCheck   # public API changed intentionally → :core:apiDump and commit the dump
+  ```
+- Conventions: committed `CLAUDE.md`; PR style per its own `.claude/skills/open-pr`
+  skill: title `fix: [ANDROSDK-XXXX] <short imperative>`, body 1–2 paragraphs
+  ending `Related task: [ANDROSDK-XXXX](https://dhis2.atlassian.net/browse/ANDROSDK-XXXX)`,
+  **no Co-Authored-By, no 🤖 footer**. No ticket → `fix: <desc>` title + a body
+  note that no Jira ticket exists yet.
+- Jira: Sentry-originated SDK fixes ask the user for an existing ANDROSDK ticket
+  or offer to create one via the Atlassian MCP; if declined, keep the
+  `fix/sentry-<short-id>` branch name.
+- Sentry-fix policy: PR opened as **draft** (agent-authored) even though the
+  repo norm is non-draft.
+
+### dhis2/dhis2-mobile-ui — "design system"
+
+- Local sibling: `../dhis2-mobile-ui` · toml version key: `designSystem`
+  (artifact `org.hisp.dhis.mobile:designsystem`) · tags may lag releases
+  (0.7.1 shipped with no tag — see §5 fallback chain).
+- PR base branch: **`develop`** — verified from merged-PR history: `fix:` PRs
+  merge to `develop`; `main` only receives release PRs.
+- Module `:designsystem`, package root `org.hisp.dhis.mobile.ui.designsystem`;
+  KMP source sets `commonMain`/`androidMain`/`desktopMain`/`iosMain`; Kotlin
+  tests run on the desktop target; Paparazzi snapshot tests live in
+  `androidUnitTest`.
+- Verify:
+  ```bash
+  ./gradlew ktlintFormat ktlintCheck
+  ./gradlew desktopTest
+  ./gradlew designsystem:testDebugUnitTest
+  ```
+- Hard constraints: **never regenerate Paparazzi golden images locally** — if a
+  golden must change, push the branch and run the "Generate Paparazzi Golden
+  Images" GitHub Actions workflow on it; `allWarningsAsErrors` is on, so a new
+  compiler warning fails the build.
+- Conventions: `CLAUDE.md` is untracked (may be absent in other clones) — read
+  it if present, else `README.md` + `docs/` + probe recent merged PRs
+  (`gh pr list --repo dhis2/dhis2-mobile-ui --state merged --limit 5 --json title,baseRefName`).
+  Title style `fix: [ANDROAPP-XXXX] <desc>` (mobile-ui uses the app's Jira
+  project); omit the code if there is no ticket. PR **draft**, `## Sentry issue`
+  section, standard Co-Authored-By trailer.
+
+---
+
+## 4. Working in a sibling repo
+
+1. **Clone**: if the sibling path is missing, offer
+   `gh repo clone dhis2/<name> ../<name>` and stop if declined.
+2. **Canonical remote** = the remote whose URL matches `github.com[:/]dhis2/<name>`
+   in `git -C ../<name> remote -v`. Never assume `origin` or the first listed —
+   clones may have fork remotes configured before it.
+3. **Never touch the user's checkout** — sibling clones are live workspaces
+   (arbitrary branch, possibly dirty). Isolate all work in a worktree:
+   ```bash
+   git -C ../<name> fetch <remote> <base-branch>
+   grep -qx ".claude/worktrees/" ../<name>/.git/info/exclude 2>/dev/null || \
+     echo ".claude/worktrees/" >> ../<name>/.git/info/exclude
+   git -C ../<name> worktree add .claude/worktrees/sentry-<short-id> \
+     -b fix/sentry-<short-id> <remote>/<base-branch>
+   ```
+   All edits, builds, commits, and pushes happen inside
+   `../<name>/.claude/worktrees/sentry-<short-id>`.
+4. **Android SDK location**: if a Gradle build inside the worktree cannot locate
+   the Android SDK, copy `local.properties` from the sibling clone root into the
+   worktree (it is untracked, so worktrees do not inherit it).
+5. **Cleanup**: keep the worktree after opening the PR (review iteration) and
+   print the removal command:
+   `git -C ../<name> worktree remove .claude/worktrees/sentry-<short-id>`.
+   At skill start, remove leftover `sentry-*` worktrees whose branch's PR is
+   merged or closed (`gh pr view <branch> --repo dhis2/<name> --json state`).
+6. **Push rights**: `gh api repos/dhis2/<name> --jq .permissions.push` —
+   `true` → push the canonical remote, then
+   `gh pr create --repo dhis2/<name> --base <base-branch> --draft …`;
+   `false` → `gh repo fork --remote`, push the fork, add `--head <login>:<branch>`.
+7. First Bash commands in sibling directories may trigger one-time permission
+   prompts — expected; file tools are pre-authorized via
+   `permissions.additionalDirectories` in `.claude/settings.json`.
+
+---
+
+## 5. Version skew — diagnose at what shipped, fix on the base branch
+
+The app's working branch is ahead of production; the library code in a Sentry
+trace is the version **pinned by the crashing release**, not the library's base
+branch.
+
+1. Pinned versions:
+   `git show <app-release-tag>:gradle/libs.versions.toml | grep -E "dhis2sdk|designSystem"`.
+2. Diagnosis ref in the library clone — first match wins:
+   exact tag (`X.Y.Z` or `vX.Y.Z`) → `release/X.Y.Z*` branch → the version-bump
+   commit on the release line → `<remote>/<base-branch>` plus an explicit warning
+   that the shipped code could not be pinned.
+3. Timestamped SNAPSHOT (e.g. `1.15.0-20260709.080146-51`): parse the timestamp →
+   `git -C ../<name> rev-list -1 --before="2026-07-09 08:01" <remote>/develop`.
+4. Read files at the ref without checking anything out:
+   `git -C ../<name> show <ref>:<path>`.
+5. **Already fixed upstream?** Before implementing, compare the crash site at the
+   diagnosis ref against the PR base branch. If the bug is already fixed there,
+   do NOT open a PR — recommend bumping the version key in
+   `gradle/libs.versions.toml` instead, naming the fixing commit/PR if findable.
+
+---
+
+## 6. Sentry ↔ GitHub linking
+
+`Fixes <SHORT-ID>` in a PR body auto-links only if that GitHub repo is connected
+in the Sentry org's GitHub integration (the app repo is; the library repos may
+not be). Include it anyway, plus the full issue URL — the URL always works.
+After opening a library PR, optionally note the PR URL on the Sentry issue via
+the MCP update tool; failure is non-fatal.
+
+---
+
+## 7. Delivery note for library fixes
+
+A library fix reaches users only after: library release → app bumps the version
+key in `gradle/libs.versions.toml` → app release. Every library-fix report must
+state this as a "Ships via" line and, for severe crashes, consider proposing a
+defensive guard in the app as a companion PR so already-shipped versions stop
+crashing sooner.

--- a/.claude/skills/sentry-triage/references/repo-map.md
+++ b/.claude/skills/sentry-triage/references/repo-map.md
@@ -63,8 +63,14 @@ the evidence disagrees — and says so explicitly when that happens.
 
 - PR base: the branch the skill was triggered from — never `main`/`develop`
   unless explicitly told.
-- PRs: **draft**, title `fix: <desc>`, `## Sentry issue` section, and the
-  harness-provided `Co-Authored-By` trailer (never hardcode a model name).
+- PRs: **draft**, title `fix: <desc>` (or `fix: [ANDROAPP-XXXX] <desc>` when
+  `/sentry-fix` linked a Jira ticket — see its Step 9a), `## Sentry issue`
+  section, and the harness-provided `Co-Authored-By` trailer (never hardcode a
+  model name).
+- Jira: optional, app-repo fixes don't require a ticket. When the Atlassian
+  MCP is connected, `/sentry-fix` searches `ANDROAPP` for an existing issue
+  covering the crash and creates one if none exists (repo-map doesn't need
+  updating when this changes — see the skill for current field requirements).
 - Conventions: `AGENTS.md` (launchUseCase, DomainErrorMapper, KMP placement,
   ktlint, testing rules).
 - Lint/tests: `./gradlew ktlintFormat ktlintCheck` + per-module test task

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,3 +190,32 @@ For patterns, examples, and common mistakes load the **android-testing** skill.
 3. **KMP first**: put business logic in `commonMain`; keep `androidMain` to SDK/platform specifics
 4. **No RxJava in new code**: migrate to Coroutines/Flow; wrap existing RxJava at boundaries
 5. **ktlint must pass** before committing — run `./gradlew ktlintFormat` then `ktlintCheck`
+
+---
+
+## Sentry Skills
+
+Two custom skills for Sentry error triage and remediation. They are **multi-repo**:
+crashes are attributed to the repo that owns the bug — this app, the DHIS2 Android SDK
+(`dhis2/dhis2-android-sdk`), or the mobile design system (`dhis2/dhis2-mobile-ui`) —
+using `.claude/skills/sentry-triage/references/repo-map.md` as the single source of
+truth (package→repo attribution, per-repo commands, PR conventions). The two library
+repos are expected as sibling clones (`../dhis2-android-sdk`, `../dhis2-mobile-ui`);
+the skills offer to clone them if missing.
+
+- **`/sentry-triage`** — Resolves the latest production release (and the SDK /
+  design-system versions it pinned), queries the configured Sentry project for top
+  unresolved issues, attributes each to its owning repo, scores Impact (1-5) and
+  Effort (1-5), and outputs a prioritized impact/effort quadrant report. Requires the
+  `sentry@claude-plugins-official` plugin installed locally in `~/.claude/settings.json`.
+
+- **`/sentry-fix <issue-id> [--repo <slug>]`** — Fetches the full Sentry event and stack
+  trace, re-verifies ownership, reads the relevant sources at the shipped version, and
+  implements the fix **in the owning repo**: app fixes follow these AGENTS.md guidelines;
+  library fixes run in an isolated git worktree of the sibling clone (never disturbing
+  its checked-out branch), follow that repo's own conventions, and open the draft PR
+  there. Usable standalone or from a `/sentry-triage` report.
+
+Stack traces are deobfuscated (ProGuard mappings are uploaded on every release build),
+so library frames carry real class names. Sentry org and project are resolved
+dynamically from the plugin at runtime.


### PR DESCRIPTION
## Description

Adds two Claude Code skills for triaging and auto-fixing Sentry crashes across the DHIS2 Android ecosystem — this app, the [DHIS2 Android SDK](https://github.com/dhis2/dhis2-android-sdk), and the [mobile design system](https://github.com/dhis2/dhis2-mobile-ui).

### `/sentry-triage`
Resolves the latest production release (and the SDK/design-system versions it shipped), queries the Sentry project for the top unresolved issues, attributes each one to its owning repo, scores it on Impact (1-5) and Effort (1-5), and outputs a prioritized impact/effort quadrant report with a ready-to-run `/sentry-fix` command per issue.

### `/sentry-fix <issue-id>`
Given a single Sentry issue ID:
1. Fetches the full event + stack trace, re-verifies which repo actually owns the bug (app-code frames vs. library frames, using the attribution heuristics in `repo-map.md`).
2. Reads the relevant source **at the version that actually shipped the crash** — for library bugs, in an isolated worktree of the sibling clone, never touching the user's own checkout.
3. Diagnoses the root cause and implements the fix following that repo's own conventions (this app's `AGENTS.md`; the SDK's/design system's own `CLAUDE.md`/PR style).
4. Writes unit tests, runs the owning repo's lint/test tasks, and opens a **draft PR** there with a `## Sentry issue` section that auto-links back to Sentry.
5. **Jira** — for app-owned fixes, if Jira/Atlassian access is available, searches `ANDROAPP` for an existing ticket covering the crash (or creates one) and links it in the PR title/body; if Jira isn't connected, it asks once and skips cleanly if declined.
6. **Stays attached to the PR** for the rest of the session — a background watch answers reviewer questions, implements requested changes, replies to threads with an automated-footer note, and resolves them, until the PR is merged or closed.
7. **Closes the loop** — once the linked Jira ticket reaches *Done*, the corresponding Sentry issue is automatically marked resolved (checked once on merge, otherwise via a scheduled recheck).

### Shared reference
`.claude/skills/sentry-triage/references/repo-map.md` is the single source of truth both skills load: package→repo attribution rules, per-repo PR/branch conventions, sibling-worktree handling, and version-skew resolution (diagnosing against the exact shipped version of a dependency, not its current `develop`).

### Validated on a real crash
Used live against [DHIS2-ANDROID-CAPTURE-89RF](https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-89RF/) → [PR #4973](https://github.com/dhis2/dhis2-android-capture-app/pull/4973) + [ANDROAPP-7708](https://dhis2.atlassian.net/browse/ANDROAPP-7708), including reviewer back-and-forth (requested changes, a revert) handled entirely by the PR watch.

## Related task
[ANDROAPP-7700](https://dhis2.atlassian.net/browse/ANDROAPP-7700)


[ANDROAPP-7708]: https://dhis2.atlassian.net/browse/ANDROAPP-7708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ