### PR TITLE
fix: [ANDROAPP-7708] guard against null activity view before showing sync-offline snackbar

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
@@ -166,7 +166,7 @@ class ProgramFragment :
                         .make(
                             contextView,
                             R.string.sync_offline_check_connection,
-                            Snackbar.LENGTH_LONG,
+                            Snackbar.LENGTH_SHORT,
                         ).show()
                 }
             }.show(FRAGMENT_TAG)

--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
@@ -166,7 +166,7 @@ class ProgramFragment :
                         .make(
                             contextView,
                             R.string.sync_offline_check_connection,
-                            Snackbar.LENGTH_SHORT,
+                            Snackbar.LENGTH_LONG,
                         ).show()
                 }
             }.show(FRAGMENT_TAG)

--- a/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/main/program/ProgramFragment.kt
@@ -161,13 +161,14 @@ class ProgramFragment :
                     }
                 },
             ).onNoConnectionListener {
-                val contextView = activity?.findViewById<View>(R.id.navigationBar)
-                Snackbar
-                    .make(
-                        contextView!!,
-                        R.string.sync_offline_check_connection,
-                        Snackbar.LENGTH_SHORT,
-                    ).show()
+                activity?.findViewById<View>(R.id.navigationBar)?.let { contextView ->
+                    Snackbar
+                        .make(
+                            contextView,
+                            R.string.sync_offline_check_connection,
+                            Snackbar.LENGTH_SHORT,
+                        ).show()
+                }
             }.show(FRAGMENT_TAG)
     }
 


### PR DESCRIPTION
## Summary
- `ProgramFragment.showSyncDialog`'s `onNoConnectionListener` looked up the `navigationBar` view via `activity?.findViewById<View>(...)` and then force-unwrapped it with `!!`.
- When the fragment's activity is null at the time the granular-sync "no connection" callback fires (e.g. the fragment has been detached/backgrounded), the `!!` throws, surfacing in Sentry as `NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference` — a fatal crash affecting 300+ users in production.
- Replaced the unsafe `!!` with a null-safe `?.let { }` so the snackbar is only shown when a valid view is available; if the view isn't there, there's no UI to show it in anyway, so silently skipping is correct.

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-89RF
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-89RF/

Related task: [ANDROAPP-7708](https://dhis2.atlassian.net/browse/ANDROAPP-7708)

## Test plan
- [x] `./gradlew ktlintFormat` — no changes needed
- [x] `./gradlew ktlintCheck` — passed
- [x] `./gradlew :app:compileDhis2DebugKotlin` — builds clean
- [x] `./gradlew :app:testDhis2DebugUnitTest --tests "org.dhis2.usescases.main.program.*"` — 7/7 passed
- No new unit test added: this is a one-line null-safety guard inside a `Fragment`'s Android-view-lookup lambda (`activity?.findViewById`, `Snackbar`), a code shape this codebase doesn't unit-test elsewhere (no Robolectric harness exists for `ProgramFragment`); the existing Robot-pattern instrumented tests don't cover this offline-snackbar path either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ANDROAPP-7708]: https://dhis2.atlassian.net/browse/ANDROAPP-7708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ