### PR TITLE
test: [ANDROAPP-7655] PI disaggregation visualisations automatic tests [skip size]

### DIFF
--- a/app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/main/MainRobot.kt
@@ -18,6 +18,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.matcher.RootMatchers.isPlatformPopup
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
@@ -178,5 +179,11 @@ class MainRobot(val composeTestRule: ComposeTestRule) : BaseRobot() {
                 ),
             ),
         )
+    }
+
+    fun scrollToChart(itemPosition: Int) {
+        onView(withId(R.id.analytics_recycler))
+            .perform(scrollToPosition<RecyclerView.ViewHolder>(itemPosition))
+        composeTestRule.waitForIdle()
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/main/MainTest.kt
@@ -82,10 +82,23 @@ class MainTest : BaseTest() {
             checkChartName(0, "Android: Malaria case count pie")
             checkChartTypeRendered(0, ChartType.PIE_CHART)
             checkNoErrorIcon(0)
+
+            // [ANDROAPP-7714] PI disaggregation - Rendering: open the "PI disaggregation" group
+            checkChartGroupTabDisplayed("PI disaggregation")
+            clickChartGroup("PI disaggregation")
+            for (position in 0 until PI_DISAGGREGATION_VISUALIZATION_COUNT) {
+                scrollToChart(position)
+                checkChartTypeRendered(position, ChartType.TABLE)
+                checkNoErrorIcon(position)
+            }
         }
     }
 
     private fun startActivity(intent: Intent) {
         rule.launch(intent)
+    }
+
+    private companion object {
+        const val PI_DISAGGREGATION_VISUALIZATION_COUNT = 13
     }
 }


### PR DESCRIPTION
extend analytics test to include PI disaggregation visualisations. 
Edit assertion in datasetAutomate test periodically when updating test_db file

## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7655).

Please provide a clear definition of the problem and explain your solution.