### PR TITLE
fix(translations): [ANDROAPP-7721] remove KMP-incompatible escaped question marks (main)

### DIFF
--- a/commonskmm/src/commonMain/composeResources/values-cs/strings.xml
+++ b/commonskmm/src/commonMain/composeResources/values-cs/strings.xml
@@ -23,7 +23,7 @@
     <string name="conf_error_value_option_set">Hodnota pole %s nepatří do možnosti nastavené v položce %s</string>
     <string name="field_is_mandatory">Toto pole je povinné</string>
     <string name="missing_warning_fields_completed_events">Máte několik varovných hlášení.</string>
-    <string name="missing_warning_fields_events">Máte několik varovných hlášení.\nChcete tento formulář označit jako dokončený\?</string>
+    <string name="missing_warning_fields_events">Máte několik varovných hlášení.\nChcete tento formulář označit jako dokončený?</string>
     <string name="required">Vyžadováno</string>
     <string name="polygon">Polygon</string>
     <string name="latitude">Zeměpisná šířka</string>
@@ -47,9 +47,9 @@
     <string name="complete">Dokončit</string>
     <string name="discard_changes">Zrušit změny</string>
     <string name="saved">Uloženo!</string>
-    <string name="event_error_on_complete">Máte několik chybových hlášení.\nChcete je zkontrolovat\?</string>
-    <string name="missing_error_fields_events">Některá pole obsahují chyby a neukládají se. \nChcete formulář zkontrolovat\?</string>
-    <string name="review_message">Některé oblasti vyžadují vaši pozornost.\nChcete formulář zkontrolovat\?</string>
+    <string name="event_error_on_complete">Máte několik chybových hlášení.\nChcete je zkontrolovat?</string>
+    <string name="missing_error_fields_events">Některá pole obsahují chyby a neukládají se. \nChcete formulář zkontrolovat?</string>
+    <string name="review_message">Některé oblasti vyžadují vaši pozornost.\nChcete formulář zkontrolovat?</string>
     <string name="not_now">Teď ne</string>
     <string name="keep_editing">Pokračovat v úpravách</string>
     <string name="event_can_be_completed">Chcete tento formulář označit jako vyplněný?</string>

--- a/commonskmm/src/commonMain/composeResources/values-es/strings.xml
+++ b/commonskmm/src/commonMain/composeResources/values-es/strings.xml
@@ -23,7 +23,7 @@
     <string name="conf_error_value_option_set">El valor del campo %s no pertenece al conjunto de opciones en %s</string>
     <string name="field_is_mandatory">El campo es obligatorio</string>
     <string name="missing_warning_fields_completed_events">Tienes algunos mensajes de aviso.</string>
-    <string name="missing_warning_fields_events">Tiene algunos mensajes de advertencia.\n¿Deseas marcar este formulario como completo\?</string>
+    <string name="missing_warning_fields_events">Tiene algunos mensajes de advertencia.\n¿Deseas marcar este formulario como completo?</string>
     <string name="required">Necesario</string>
     <string name="polygon">Polígono</string>
     <string name="latitude">Latitud</string>
@@ -47,9 +47,9 @@
     <string name="complete">Completar</string>
     <string name="discard_changes">Descartar los cambios</string>
     <string name="saved">¡Guardado!</string>
-    <string name="event_error_on_complete">Tienes algunos mensajes de error.\n¿Deseas revisarlos\?</string>
-    <string name="missing_error_fields_events">Algunos campos tienen errores y no se han guardado.\n¿Deseas revisar el formulario\?</string>
-    <string name="review_message">Algunos campos necesitan tu atención.\n¿Deseas revisar el formulario\?</string>
+    <string name="event_error_on_complete">Tienes algunos mensajes de error.\n¿Deseas revisarlos?</string>
+    <string name="missing_error_fields_events">Algunos campos tienen errores y no se han guardado.\n¿Deseas revisar el formulario?</string>
+    <string name="review_message">Algunos campos necesitan tu atención.\n¿Deseas revisar el formulario?</string>
     <string name="not_now">Ahora no</string>
     <string name="keep_editing">Seguir editando</string>
     <string name="event_can_be_completed">¿Desea marcar este formulario como completo?</string>

--- a/commonskmm/src/commonMain/composeResources/values-ru/strings.xml
+++ b/commonskmm/src/commonMain/composeResources/values-ru/strings.xml
@@ -21,7 +21,7 @@
     <string name="conf_error_value_to_assign_option_set">Правило программы %s пытается присвоить значение %s, которое не принадлежит набору опций. %s</string>
     <string name="field_is_mandatory">Это поле обязательно для заполнения</string>
     <string name="missing_warning_fields_completed_events">У вас есть несколько предупреждающих сообщений.</string>
-    <string name="missing_warning_fields_events">У Вас есть несколько предупреждающих сообщений.\nХотите ли Вы отметить эту форму как завершенную\?</string>
+    <string name="missing_warning_fields_events">У Вас есть несколько предупреждающих сообщений.\nХотите ли Вы отметить эту форму как завершенную?</string>
     <string name="required">Обязательный</string>
     <string name="polygon">Полигон</string>
     <string name="latitude">Широта</string>
@@ -45,9 +45,9 @@
     <string name="complete">Завершить</string>
     <string name="discard_changes">Не сохранять изменения</string>
     <string name="saved">Сохранено!</string>
-    <string name="event_error_on_complete">У Вас есть несколько сообщений об ошибках.\nХотите просмотреть их\?</string>
-    <string name="missing_error_fields_events">В некоторых полях есть ошибки, и они не сохраняются. \nВы хотите просмотреть форму\?</string>
-    <string name="review_message">Некоторые поля требуют Вашего внимания.\nХотите просмотреть форму\?</string>
+    <string name="event_error_on_complete">У Вас есть несколько сообщений об ошибках.\nХотите просмотреть их?</string>
+    <string name="missing_error_fields_events">В некоторых полях есть ошибки, и они не сохраняются. \nВы хотите просмотреть форму?</string>
+    <string name="review_message">Некоторые поля требуют Вашего внимания.\nХотите просмотреть форму?</string>
     <string name="not_now">Не сейчас</string>
     <string name="keep_editing">Продолжить редактирование</string>
     <string name="event_can_be_completed">Хотите ли Вы отметить эту форму как завершенную?</string>

--- a/commonskmm/src/commonMain/composeResources/values-vi/strings.xml
+++ b/commonskmm/src/commonMain/composeResources/values-vi/strings.xml
@@ -23,7 +23,7 @@
     <string name="conf_error_value_option_set">Giá trị của trường %s không thuộc tùy chọn trong %s</string>
     <string name="field_is_mandatory">Trường dữ liệu này bắt buộc</string>
     <string name="missing_warning_fields_completed_events">Bạn có một số tin nhắn cảnh báo.</string>
-    <string name="missing_warning_fields_events">Bạn có một số tin nhắn cảnh báo..\nBạn có muốn đánh dấu biểu nhập này là hoàn tất không\?</string>
+    <string name="missing_warning_fields_events">Bạn có một số tin nhắn cảnh báo..\nBạn có muốn đánh dấu biểu nhập này là hoàn tất không?</string>
     <string name="required">Bắt buộc</string>
     <string name="polygon">Đa giác</string>
     <string name="latitude">Vĩ độ</string>
@@ -47,9 +47,9 @@
     <string name="complete">Hoàn tất</string>
     <string name="discard_changes">Hủy bỏ các thay đổi</string>
     <string name="saved">Đã lưu!</string>
-    <string name="event_error_on_complete">Bạn có một số tin nhắn lỗi.\nBạn có muốn xem không\?</string>
-    <string name="missing_error_fields_events">Một số trường dữ liệu có lỗi và chưa được lưu. \nBạn có muốn xem lại biểu nhập không\?</string>
-    <string name="review_message">Một số trường dữ liệu cần bạn chú ý.\nBạn có muốn xem xét biểu nhập không\?</string>
+    <string name="event_error_on_complete">Bạn có một số tin nhắn lỗi.\nBạn có muốn xem không?</string>
+    <string name="missing_error_fields_events">Một số trường dữ liệu có lỗi và chưa được lưu. \nBạn có muốn xem lại biểu nhập không?</string>
+    <string name="review_message">Một số trường dữ liệu cần bạn chú ý.\nBạn có muốn xem xét biểu nhập không?</string>
     <string name="not_now">Không phải bây giờ</string>
     <string name="keep_editing">Tiếp tục chỉnh sửa</string>
     <string name="event_can_be_completed">Bạn có muốn đánh dấu biểu nhập này là hoàn tất không?</string>


### PR DESCRIPTION
**JIRA:** [ANDROAPP-7721](https://dhis2.atlassian.net/browse/ANDROAPP-7721)

Unescape `\?` → `?` in the 4 `commonskmm` Compose resource files (16 occurrences: cs/es/ru/vi). Transifex escapes `?` as `\?` for these ANDROID-typed KMP resources, which the Compose resource parser can't handle. The rendered text is unchanged — this just gives a clean escaped-character baseline.

Applied on `main`; it reaches `develop` via the regular main→develop merge, so no separate develop PR is needed.


[ANDROAPP-7721]: https://dhis2.atlassian.net/browse/ANDROAPP-7721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ