### PR TITLE
fix: [ANDROAPP-7692] Custom Tab survives when app is sent to backgroundf

### DIFF
--- a/login/src/androidMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.android.kt
+++ b/login/src/androidMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.android.kt
@@ -1,7 +1,6 @@
 package org.dhis2.mobile.login.main.ui.screen
 
 import android.app.Activity
-import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.auth.AuthTabIntent
@@ -28,9 +27,6 @@ actual fun WebAuthenticator(
             AuthTabIntent
                 .Builder()
                 .build()
-        // Custom Tab is not kept in the activity history stack and it's removed from memory.
-        // It won't appear in the "Recent Apps" list
-        authTabIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
 
         val intent =
             authTabIntent.intent.apply {


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7692).

Please provide a clear definition of the problem and explain your solution.