### PR TITLE
test: [ANDROAPP-7728] automate Events Flow 2

### DIFF
--- a/app/src/androidTest/java/org/dhis2/common/BaseRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/common/BaseRobot.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import android.content.Context.ACTIVITY_SERVICE
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithText
@@ -74,6 +77,18 @@ open class BaseRobot {
     fun waitToDebounce(millis: Long) {
         sleep(millis)
     }
+
+    /** This node's own text entries (does not descend into children). */
+    fun SemanticsNode.texts(): List<String> =
+        config.getOrNull(SemanticsProperties.Text)?.map { it.text } ?: emptyList()
+
+    /**
+     * This node's text plus every descendant's. Needed because an unmerged node
+     * carries only its OWN text, while a field's title sits several levels below
+     * the tagged node.
+     */
+    fun SemanticsNode.subtreeTexts(): List<String> =
+        texts() + children.flatMap { it.subtreeTexts() }
 
     fun getString(stringId: Int): String = getInstrumentation().targetContext.getString(stringId)
 

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventIntents.kt
@@ -3,71 +3,38 @@ package org.dhis2.usescases.event
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import org.dhis2.LazyActivityScenarioRule
-import org.dhis2.commons.Constants
-import org.dhis2.form.model.EventMode
-import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
-import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
 import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
-import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
 import org.hisp.dhis.android.core.D2Manager
 import org.hisp.dhis.android.core.event.EventCreateProjection
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-const val EVENT_UID = "EVENT_UID"
-const val PROGRAM_UID = "PROGRAM_UID"
-const val TEI_UID = "TEI_UID"
-const val ENROLLMENT_UID = "ENROLLMENT_UID"
-const val PROGRAM_STAGE_UID = "PROGRAM_STAGE_UID"
-
-const val PROGRAM_TB_UID = "ur1Edk5Oe2n"
 const val ANTENATAL_CARE_PROGRAM_UID = "lxAQ7Zs9VYR"
-const val ANTENATAL_CARE_EVENT_UID = "ohAH6BXIMad"
-const val EVENT_TO_SHARE_UID = "y0xoVIzBpnL"
-const val TEI_EVENT_TO_DELETE_UID = "foc5zag6gbE"
-const val ENROLLMENT_EVENT_DELETE_UID = "SolDyMgW3oc"
-const val PROGRAM_STAGE_TO_SHARE = "EPEcjy3FWmI"
 
-// ── Flow A: Event Data Entry Form (ANDROAPP-7620) ────────────────────────────
+// ── Flow 1: Event Data Entry Form (ANDROAPP-7620) ────────────────────────────
 // The workflow `@Test` creates a fresh event in every run, so the test
 // does not depend on hardcoded fixture UIDs that drift across DB
-// refreshes. The completed-event sibling test reuses the pre-existing
-// Antenatal Care demo event `ohAH6BXIMad`, which is part of the baseline
-// demo metadata.
+// refreshes.
 const val FLOW_A_PROGRAM_UID = ANTENATAL_CARE_PROGRAM_UID  // lxAQ7Zs9VYR
 const val FLOW_A_STAGE_UID = "dBwrot7S420"                 // Antenatal care visit stage (validationStrategy = ON_COMPLETE)
 const val FLOW_A_ORG_UNIT_UID = "DiszpKrYNg8"              // Ngelehun CHC
 const val FLOW_A_DEFAULT_COC_UID = "HllvX50cXC0"           // default categoryOptionCombo
 
-// Pre-existing demo event used by the read-only / smoke tests.
-const val FLOW_A_EVENT_COMPLETED_UID = ANTENATAL_CARE_EVENT_UID // ohAH6BXIMad — COMPLETED
+// ── Flow 2: create-form mandatory block (ANDROAPP-7728) ──────────────────────
+const val FLOW_D_PROGRAM_UID = "bMcwwoVnbSR"
+const val FLOW_D_ORG_UNIT_NAME = "Ngelehun CHC"
+const val FLOW_D_CATEGORY_NAME = "Implementing Partner"
+const val FLOW_D_VISIT_DATE_LABEL = "Visit date"
+
+const val FLOW_D_GENDER_LABEL = "Gender"
+const val FLOW_D_RDT_LABEL = "RDT test result"
+const val FLOW_D_TREATMENT_LABEL = "Treatment"
+
+fun todayDisplayDate(): String = SimpleDateFormat("dd/MM/yyyy", Locale.US).format(Date())
 
 /**
- * Creates a fresh ACTIVE event in the local SDK database (Antenatal Care
- * program, Ngelehun CHC, today's date, no data values — so the mandatory
- * DE is empty) and launches `EventCaptureActivity` in CHECK mode for it.
- *
- * Returns the UID of the newly-created event so the test can reference it
- * if needed.
- */
-fun createFreshFlowAEventAndLaunchActivity(
-    rule: LazyActivityScenarioRule<EventCaptureActivity>,
-): String {
-    val event = createFreshFlowAEvent()
-    Intent(
-        ApplicationProvider.getApplicationContext(),
-        EventCaptureActivity::class.java,
-    ).apply {
-        putExtra(PROGRAM_UID, FLOW_A_PROGRAM_UID)
-        putExtra(EVENT_UID, event.uid)
-        putExtra(Constants.EVENT_MODE, EventMode.CHECK)
-    }.also { rule.launch(it) }
-    return event.uid
-}
-
-/**
- * One fresh Flow A event, ready for a workflow test that enters via the
+ * One fresh Flow 1 event, ready for a workflow test that enters via the
  * program event list. Returns both the UID and the display date string
  * (`dd/MM/yyyy`) so the test can locate the row in the list and re-tap
  * it later in the journey.
@@ -95,19 +62,6 @@ fun createFreshFlowAEvent(): FreshFlowAEvent {
     return FreshFlowAEvent(uid, displayDate)
 }
 
-fun prepareFlowAEventCompletedAndLaunchActivity(
-    rule: LazyActivityScenarioRule<EventCaptureActivity>,
-) {
-    Intent(
-        ApplicationProvider.getApplicationContext(),
-        EventCaptureActivity::class.java,
-    ).apply {
-        putExtra(PROGRAM_UID, FLOW_A_PROGRAM_UID)
-        putExtra(EVENT_UID, FLOW_A_EVENT_COMPLETED_UID)
-        putExtra(Constants.EVENT_MODE, EventMode.CHECK)
-    }.also { rule.launch(it) }
-}
-
 fun prepareFlowAProgramEventListAndLaunchActivity(
     rule: LazyActivityScenarioRule<ProgramEventDetailActivity>,
 ) {
@@ -119,25 +73,13 @@ fun prepareFlowAProgramEventListAndLaunchActivity(
     }.also { rule.launch(it) }
 }
 
-fun prepareEventDetailsIntentAndLaunchActivity(rule: LazyActivityScenarioRule<EventCaptureActivity>) {
+fun prepareFlowDProgramEventListAndLaunchActivity(
+    rule: LazyActivityScenarioRule<ProgramEventDetailActivity>,
+) {
     Intent(
         ApplicationProvider.getApplicationContext(),
-        EventCaptureActivity::class.java,
+        ProgramEventDetailActivity::class.java,
     ).apply {
-        putExtra(PROGRAM_UID, ANTENATAL_CARE_PROGRAM_UID)
-        putExtra(EVENT_UID, ANTENATAL_CARE_EVENT_UID)
-        putExtra(Constants.EVENT_MODE, EventMode.CHECK)
-
+        putExtra(ProgramEventDetailActivity.EXTRA_PROGRAM_UID, FLOW_D_PROGRAM_UID)
     }.also { rule.launch(it) }
-}
-
-fun prepareEventToShareIntentAndLaunchActivity(ruleEventDetail: LazyActivityScenarioRule<EventInitialActivity>) {
-    Intent(
-        ApplicationProvider.getApplicationContext(),
-        EventInitialActivity::class.java,
-    ).apply {
-        putExtra(PROGRAM_UID, PROGRAM_TB_UID)
-        putExtra(EVENT_UID, EVENT_TO_SHARE_UID)
-        putExtra(PROGRAM_STAGE_UID, PROGRAM_STAGE_TO_SHARE)
-    }.also { ruleEventDetail.launch(it) }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventRegistrationRobot.kt
@@ -1,6 +1,7 @@
 package org.dhis2.usescases.event
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
@@ -8,18 +9,20 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.test.espresso.Espresso.onView
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.dhis2.R
 import org.dhis2.common.BaseRobot
-import org.dhis2.common.matchers.hasCompletedPercentage
+import org.dhis2.commons.dialogs.bottomsheet.MAIN_BUTTON_TAG
+import org.dhis2.commons.dialogs.bottomsheet.SECONDARY_BUTTON_TAG
 
 fun eventRegistrationRobot(
     composeTestRule: ComposeTestRule,
@@ -32,12 +35,7 @@ fun eventRegistrationRobot(
 
 class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot() {
 
-    fun checkEventDataEntryIsOpened(completion: Int, orgUnit: String) {
-        onView(withId(R.id.completion)).check(matches(hasCompletedPercentage(completion)))
-        composeTestRule.onNodeWithText(orgUnit).performScrollTo().assertIsDisplayed()
-    }
-
-    // ── Flow A: form-lifecycle helpers (ANDROAPP-7620) ────────────────────────
+    // ── Flow 1: form-lifecycle helpers (ANDROAPP-7620) ────────────────────────
 
     fun checkSaveButtonIsDisplayed() {
         waitForView(withId(R.id.actionButton)).check(matches(isDisplayed()))
@@ -93,7 +91,7 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
 
     /**
      * Clicks the "No" option of the form's first visible Yes/No radio
-     * group. Used by Flow A's workflow to fill the mandatory WHOMCH
+     * group. Used by Flow 1's workflow to fill the mandatory WHOMCH
      * Smoking DE so the event can be completed.
      *
      * Form renders BOOLEAN DEs via `ProvideYesNoRadioButtonInput` which
@@ -107,5 +105,97 @@ class EventRegistrationRobot(val composeTestRule: ComposeTestRule) : BaseRobot()
         composeTestRule.onAllNodesWithTag("RADIO_BUTTON_false")[0]
             .performScrollTo()
             .performClick()
+    }
+
+    // ── Flow 2: create-form checks (ANDROAPP-7728) ────────────────────────────
+
+    /** Asserts the stage's custom event-date label is shown (ANDROAPP-899). */
+    fun checkEventDateLabelIsDisplayed(label: String) {
+        checkFormFieldLabelIsDisplayed(label)
+    }
+
+    /** Asserts the non-default category-combo field is shown (ANDROAPP-844). */
+    fun checkCategoryFieldIsDisplayed(categoryName: String) {
+        checkFormFieldLabelIsDisplayed(categoryName)
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun checkFormFieldLabelIsDisplayed(label: String) {
+        val labelMatcher = hasText(label, substring = true)
+        composeTestRule.waitUntilAtLeastOneExists(labelMatcher, TIMEOUT)
+        scrollFormTo(labelMatcher)
+        composeTestRule.onAllNodesWithText(label, substring = true, useUnmergedTree = true)
+            .onFirst()
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Under `ON_UPDATE_AND_INSERT` an empty mandatory DE blocks the save
+     * outright: the sheet offers only "Review" (MAIN_BUTTON_TAG) with no
+     * "Not now" escape hatch (SECONDARY_BUTTON_TAG absent).
+     */
+    @OptIn(ExperimentalTestApi::class)
+    fun checkImmediateMandatoryBlock() {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MANDATORY"), TIMEOUT)
+        composeTestRule.onAllNodesWithTag("MANDATORY").onFirst().assertIsDisplayed()
+        composeTestRule.onNodeWithTag(MAIN_BUTTON_TAG).assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag(SECONDARY_BUTTON_TAG).assertCountEquals(0)
+    }
+
+    /** Taps the mandatory sheet's only action ("Review") to return to the form. */
+    fun dismissMandatoryBlockSheet() {
+        composeTestRule.onNodeWithTag(MAIN_BUTTON_TAG).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * Opens the dropdown whose field title contains [label] and picks its first
+     * option. Identified by content rather than structure: several
+     * `INPUT_DROPDOWN` nodes may coexist and the title is not a semantics
+     * sibling of the field, so match on which node's subtree carries the label.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    fun selectFirstDropdownOption(label: String) {
+        scrollFormTo(hasText(label, substring = true))
+        val dropdowns =
+            composeTestRule
+                .onAllNodesWithTag("INPUT_DROPDOWN", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+        val index =
+            dropdowns.indexOfFirst { node ->
+                node.subtreeTexts().any { it.contains(label, ignoreCase = true) }
+            }
+        if (index < 0) {
+            throw AssertionError(
+                "No dropdown field titled '$label'. Dropdowns on screen carried: " +
+                    dropdowns.map { it.subtreeTexts() },
+            )
+        }
+        composeTestRule
+            .onAllNodesWithTag("INPUT_DROPDOWN", useUnmergedTree = true)[index]
+            .performClick()
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag(FIRST_DROPDOWN_ITEM_TAG), TIMEOUT)
+        composeTestRule.onNodeWithTag(FIRST_DROPDOWN_ITEM_TAG).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    fun waitForSaveBottomSheet() {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag(SECONDARY_BUTTON_TAG), TIMEOUT)
+    }
+
+    /**
+     * Scrolls the form's `LazyColumn` (tagged `FORM_VIEW`) to [target]. Fields
+     * below the initial viewport are not composed at all, so a plain
+     * `performScrollTo()` cannot reach them — that requires the node to exist.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    private fun scrollFormTo(target: SemanticsMatcher) {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("FORM_VIEW"), TIMEOUT)
+        composeTestRule.onNodeWithTag("FORM_VIEW", useUnmergedTree = true).performScrollToNode(target)
+    }
+
+    companion object {
+        private const val FIRST_DROPDOWN_ITEM_TAG = "INPUT_DROPDOWN_MENU_ITEM_0"
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/event/EventTest.kt
@@ -11,10 +11,12 @@ import org.dhis2.lazyActivityScenarioRule
 import org.dhis2.usescases.BaseTest
 import org.dhis2.usescases.eventsWithoutRegistration.eventCapture.EventCaptureActivity
 import org.dhis2.usescases.eventsWithoutRegistration.eventInitial.EventInitialActivity
+import org.dhis2.usescases.orgunitselector.orgUnitSelectorRobot
 import org.dhis2.usescases.programEventDetail.ProgramEventDetailActivity
 import org.dhis2.usescases.programevent.robot.programEventsRobot
 import org.dhis2.usescases.teiDashboard.TeiDashboardMobileActivity
 import org.dhis2.usescases.teidashboard.robot.eventRobot
+import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -147,6 +149,62 @@ class EventTest : BaseTest() {
         }
         eventRegistrationRobot(composeTestRule) {
             checkSaveButtonIsDisplayed()
+        }
+    }
+
+    // Flow 2 — create an event via "+" under ON_UPDATE_AND_INSERT.
+    @Test
+    fun shouldBlockSaveOnEmptyMandatory() {
+        prepareFlowDProgramEventListAndLaunchActivity(eventListRule)
+
+        programEventsRobot(composeTestRule) {
+            clickOnAddEvent()
+        }
+        orgUnitSelectorRobot(composeTestRule) {
+            selectTreeOrgUnit(FLOW_D_ORG_UNIT_NAME)
+        }
+        composeTestRule.waitForIdle()
+
+        eventRegistrationRobot(composeTestRule) {
+            // [ANDROAPP-899] Custom event-date label from the stage.
+            checkEventDateLabelIsDisplayed(FLOW_D_VISIT_DATE_LABEL)
+            // [ANDROAPP-844] Non-default attribute category-combo field.
+            checkCategoryFieldIsDisplayed(FLOW_D_CATEGORY_NAME)
+        }
+
+        // ON_UPDATE_AND_INSERT: empty mandatory blocks the save outright.
+        eventRobot(composeTestRule) {
+            clickOnFormFabButton()
+        }
+        eventRegistrationRobot(composeTestRule) {
+            checkImmediateMandatoryBlock()
+        }
+
+        // Fill every rendered field, then the same save must succeed.
+        eventRegistrationRobot(composeTestRule) {
+            dismissMandatoryBlockSheet()
+            selectFirstDropdownOption(FLOW_D_CATEGORY_NAME)
+            selectFirstDropdownOption(FLOW_D_GENDER_LABEL)
+            selectFirstDropdownOption(FLOW_D_RDT_LABEL)
+            selectFirstDropdownOption(FLOW_D_TREATMENT_LABEL)
+        }
+
+        eventRobot(composeTestRule) {
+            clickOnFormFabButton()
+        }
+        eventRegistrationRobot(composeTestRule) {
+            waitForSaveBottomSheet()
+        }
+        // Complete (not "Not now") — creates the event as COMPLETED.
+        eventRobot(composeTestRule) {
+            clickOnCompleteButton()
+        }
+        composeTestRule.waitForIdle()
+
+        // [ANDROAPP-910] New card, dated today, marked "Event completed" in green.
+        programEventsRobot(composeTestRule) {
+            waitForEventDisplayed(todayDisplayDate())
+            checkEventCardStatusColor(todayDisplayDate(), "Event completed", SurfaceColor.CustomGreen)
         }
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/programevent/robot/ProgramEventsRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/programevent/robot/ProgramEventsRobot.kt
@@ -1,9 +1,10 @@
 package org.dhis2.usescases.programevent.robot
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasAnyDescendant
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -34,25 +35,58 @@ class ProgramEventsRobot(val composeTestRule: ComposeContentTestRule) : BaseRobo
         composeTestRule.onNodeWithTag("ADD_EVENT_BUTTON").performClick()
     }
 
-    fun clickOnMap() {
-        composeTestRule.onNodeWithTag("NAVIGATION_BAR_ITEM_Map").performClick()
+    @OptIn(ExperimentalTestApi::class)
+    fun waitForEventDisplayed(eventDate: String) {
+        composeTestRule.waitUntilAtLeastOneExists(hasText(eventDate, substring = true), TIMEOUT)
     }
 
+    /**
+     * Asserts the status row [statusText] on the card dated [eventDate] is rendered
+     * in [expectedColor] (ANDROAPP-910).
+     */
+    fun checkEventCardStatusColor(eventDate: String, statusText: String, expectedColor: Color) {
+        val actualColor = statusRowColor(eventDate, statusText)
+        if (actualColor != expectedColor) {
+            throw AssertionError(
+                "'$statusText' on the event card for '$eventDate' is colored $actualColor, " +
+                    "expected $expectedColor",
+            )
+        }
+    }
+
+    /**
+     * The colour of the span covering [statusText] on the card.
+     *
+     * The colour lives in a `SpanStyle` embedded in the row's own `AnnotatedString`
+     * (`getKeyValueAnnotatedString` wraps the value in `withStyle`), not in any
+     * semantics colour property. Pick the span whose RANGE covers the value's
+     * position: even a keyless status row gets a leading grey KEY span first
+     * (`key` defaults to `""`), so "first span with a colour" grabs the wrong one.
+     */
     @OptIn(ExperimentalTestApi::class)
-    fun checkEventWasCreatedAndClosed() {
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("EVENT_ITEM"))
-        composeTestRule.onNode(
-            hasTestTag("EVENT_ITEM")
-                    and
-                    hasAnyDescendant(
-                        hasText("Event completed", true)
-                    )
-                    and
-                    hasAnyDescendant(
-                        hasText("View only", true)
-                    ),
-            useUnmergedTree = true
-        ).assertIsDisplayed()
+    private fun statusRowColor(eventDate: String, statusText: String): Color? {
+        val card = hasText(eventDate, substring = true)
+        composeTestRule.waitUntilAtLeastOneExists(card, TIMEOUT)
+        val annotatedTexts =
+            composeTestRule.onNode(card).fetchSemanticsNode()
+                .config.getOrNull(SemanticsProperties.Text) ?: emptyList()
+        val statusRow =
+            annotatedTexts.firstOrNull { it.text.contains(statusText, ignoreCase = true) }
+                ?: throw AssertionError(
+                    "Event card for '$eventDate' does not show '$statusText'. Actual card texts: " +
+                        annotatedTexts.map { it.text },
+                )
+        val valueStart = statusRow.text.indexOf(statusText, ignoreCase = true)
+        return statusRow.spanStyles
+            .firstOrNull { span ->
+                span.item.color != Color.Unspecified &&
+                    valueStart >= span.start &&
+                    valueStart < span.end
+            }?.item?.color
+    }
+
+    fun clickOnMap() {
+        composeTestRule.onNodeWithTag("NAVIGATION_BAR_ITEM_Map").performClick()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -71,29 +105,5 @@ class ProgramEventsRobot(val composeTestRule: ComposeContentTestRule) : BaseRobo
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("MAP", true).assertIsDisplayed()
         composeTestRule.onNodeWithTag("MAP_CAROUSEL",true).assertIsDisplayed()
-    }
-
-    /**
-     * Asserts the event card whose displayed date is [eventDate] shows
-     * the "Event completed" status. Date-scoped so it works even when
-     * the program list contains other completed events.
-     */
-    @OptIn(ExperimentalTestApi::class)
-    fun checkEventCardIsComplete(eventDate: String) {
-        // Wait until the card with our date AND the "Event completed" badge
-        // is rendered together — handles the brief lag between the Complete
-        // call returning and the list refreshing its bound model.
-        // EVENT_ITEM is set in the unmerged tree by the design-system ListCard.
-        val cardMatcher =
-            hasTestTag("EVENT_ITEM") and
-                hasAnyDescendant(hasText(eventDate)) and
-                hasAnyDescendant(hasText("Event completed", substring = true))
-        composeTestRule.waitUntil(timeoutMillis = TIMEOUT) {
-            composeTestRule.onAllNodes(cardMatcher, useUnmergedTree = true)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-        composeTestRule.onNode(cardMatcher, useUnmergedTree = true)
-            .assertIsDisplayed()
     }
 }


### PR DESCRIPTION
Automate Flow 2 covering several events tests
Details in Confluence. Ticket also contains skills file used to develop the tests

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7728).

Please provide a clear definition of the problem and explain your solution.
Automating standard events manual tests. This specific test focuses on on_insert_and_update strategy and includes several other manual tests.