### PR TITLE
docs: [ANDROAPP-7744] document contributing conventions and verification gaps in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,71 @@ For patterns, examples, and common mistakes load the **android-testing** skill.
 
 ---
 
+## Contributing Conventions
+
+### Jira
+
+Work is tracked in the **ANDROAPP** project on `https://dhis2.atlassian.net`. Two fields are
+**required** when creating an issue — the API rejects the request without them:
+
+- **Components** — use `AndroidApp` for capture-app work (others: `datasets`, `LMIS`,
+  `login`, `Mobile-UI`, `UX`)
+- **Internal feature** — `General interest`, or `Internal to system` for refactors and
+  dependency work users won't notice
+
+### Branches
+
+- Ticketed work: `ANDROAPP-<key>` or `ANDROAPP-<key>-<short-description>`
+- Repo tooling, docs and dependency chores without a ticket: `<type>/<short-description>`,
+  e.g. `chore/upgrade-gradle-9.5.0-agp-9.3.0`
+
+**Name the branch correctly before opening the PR.** Renaming afterwards is not possible:
+the GitHub rename API returns 403 (`Must have organization admin access to rename branches
+protected by organization rulesets`), and GitHub cannot retarget an open PR's head branch —
+so the only fix is a new branch and a new PR.
+
+### Commits and PR titles
+
+`<type>: [ANDROAPP-<key>] <subject>` for ticketed work, otherwise `<type>: <subject>`.
+Types in use: `feat`, `fix`, `chore`, `test`, `build`, `deps`, `style`.
+
+### PR size
+
+`scripts/check_pr_size.sh` fails the `setup` job above **`MAX_LINES=400`** changed lines.
+To bypass it deliberately, include `[skip size]` in the PR **title or body**.
+
+---
+
+## Verification Beyond the Standard Tasks
+
+`./run_tests.sh` (ktlint + unit tests) does not cover everything CI does. Two gaps worth
+knowing:
+
+**compileSdk / AGP / SDK-surface changes** — also run what CI's `build-test-apks` job runs:
+
+```bash
+./gradlew :app:assembleDhis2Debug :app:assembleDhis2DebugAndroidTest :form:assembleAndroidTest
+```
+
+Raising `compileSdk` turns newly `@Nullable`-annotated platform APIs into hard Kotlin
+nullables, and the breakage often lands only in `androidTest`, which neither
+`assembleDhis2Debug` nor the unit tests compile. `app/build.gradle.kts` sets
+`lint { abortOnError = false }`, so Android lint will not catch these either — only
+compilation does. Takes ~17 min locally.
+
+**Release/R8 changes** — `:app:assembleDhis2Release` cannot complete locally, because
+`signingConfigs` reads `SIGNING_KEY_ALIAS`, `SIGNING_KEYSTORE_PATH` and friends from
+`System.getenv()` and those are CI-only secrets; the build dies at signing for reasons
+unrelated to your change. Use **`./gradlew :app:minifyDhis2ReleaseWithR8`** instead — R8 runs
+before signing, so it exercises minification and keep rules without a keystore. This matters
+because `.github/workflows/verify-dependency-metadata.yml` builds the three release variants.
+
+> That workflow also **regenerates and auto-commits** `gradle/verification-metadata.xml` for
+> same-repo PRs, so adding or bumping a dependency needs no manual checksum work. Locally the
+> equivalent is `./gradlew --write-verification-metadata sha256 help`.
+
+---
+
 ## Sentry Skills
 
 Two custom skills for Sentry error triage and remediation. They are **multi-repo**:


### PR DESCRIPTION
Jira: [ANDROAPP-7744](https://dhis2.atlassian.net/browse/ANDROAPP-7744)

## Why

`AGENTS.md` documents build commands, project structure, architecture and testing — but nothing about **process**. Working through the Glide removal (#5026) and the compileSdk 37 bump (#5019), two things had to be learned the hard way rather than read:

- The branch and commit conventions aren't written down, so they get inferred from `gh pr list` — and inferred wrong. A branch named `chore/remove-glide` had to be recreated as `ANDROAPP-7743-remove-glide`, because a branch **cannot be renamed after the PR exists** (the GitHub rename API is blocked by organization rulesets, and an open PR's head branch can't be retargeted).
- Creating an ANDROAPP issue fails with a 400 unless **Components** and **Internal feature** are set. That's only discoverable by trying.

And one real CI failure: the compileSdk 37 bump passed `ktlintCheck`, `:app:assembleDhis2Debug` and the full unit-test suite locally, then broke `build-test-apks` — because `getTaskInfo()` became `@Nullable` in API 37 and the only affected code was in `androidTest`, which none of those tasks compile. `lint { abortOnError = false }` means lint won't flag it either.

## What this adds

**Contributing Conventions** — the ANDROAPP project and its two required fields; branch naming for ticketed (`ANDROAPP-<key>`) vs chore (`<type>/<desc>`) work; commit/PR title format; the 400-line size limit and `[skip size]`.

**Verification Beyond the Standard Tasks** — run `:app:assembleDhis2DebugAndroidTest` for compileSdk/AGP changes, and use `:app:minifyDhis2ReleaseWithR8` for R8 since release variants can't be signed locally. Plus a note that `verify-dependency-metadata.yml` auto-commits `verification-metadata.xml`, so no manual checksum work is needed.

## Accuracy

Docs-only, 65 lines added, no code touched. Every figure and path was read from the current sources on `develop` rather than recalled:

| Claim | Verified against |
|---|---|
| `MAX_LINES=400`, `[skip size]` in title *or* body | `scripts/check_pr_size.sh:3`, `ci.yml` Check PR Size step |
| Size check runs in the `setup` job | `ci.yml` job structure |
| `build-test-apks` task list | `ci.yml` Build Test APKs step |
| `lint { abortOnError = false }` | `app/build.gradle.kts:271` |
| Release signing reads CI-only env vars | `app/build.gradle.kts` `signingConfigs` |
| Metadata is regenerated and auto-committed | `.github/workflows/verify-dependency-metadata.yml` |
| Jira required fields and component list | ANDROAPP createmeta |

One thing deliberately **left out**: that `compileSdk` and `targetSdk` are separate version-catalog keys. That's true on #5019's branch but not yet on `develop`, so documenting it here would be wrong until that merges. Worth a follow-up once it lands.


[ANDROAPP-7744]: https://dhis2.atlassian.net/browse/ANDROAPP-7744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ