### PR TITLE
chore: [ANDROAPP-7745] drop redundant testOptions.targetSdk from library modules

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -17,7 +17,6 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        testOptions.targetSdk = libs.versions.sdk.get().toInt()
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/compose-table/build.gradle.kts
+++ b/compose-table/build.gradle.kts
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        testOptions.targetSdk = libs.versions.sdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/dhis2_android_maps/build.gradle.kts
+++ b/dhis2_android_maps/build.gradle.kts
@@ -15,7 +15,6 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        testOptions.targetSdk = libs.versions.sdk.get().toInt()
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/dhis_android_analytics/build.gradle.kts
+++ b/dhis_android_analytics/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        testOptions.targetSdk = libs.versions.sdk.get().toInt()
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/form/build.gradle.kts
+++ b/form/build.gradle.kts
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        testOptions.targetSdk = libs.versions.sdk.get().toInt()
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/stock-usecase/build.gradle.kts
+++ b/stock-usecase/build.gradle.kts
@@ -18,7 +18,6 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        testOptions.targetSdk = libs.versions.sdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
Jira: [ANDROAPP-7745](https://dhis2.atlassian.net/browse/ANDROAPP-7745)

## Why

Six library modules set `testOptions.targetSdk` inside their `defaultConfig` block:

```kotlin
defaultConfig {
    minSdk = libs.versions.minSdk.get().toInt()
    testOptions.targetSdk = libs.versions.sdk.get().toInt()   // not a defaultConfig property
```

Two problems with that.

**It isn't a `defaultConfig` property.** It resolves to `android.testOptions.targetSdk` through the enclosing `android { }` scope, so the code reads as though library modules have a `defaultConfig` targetSdk. They don't — AGP removed it because the consuming app's `targetSdk` governs. Confirmed: the library merged manifests carry only `android:minSdkVersion="23"`, no `targetSdkVersion` at all. It dates from `1f5681b35` ("Update gradle and kotlin version"), so it looks like a mechanical fix when AGP deprecated `defaultConfig.targetSdk` for libraries.

**It's redundant and inconsistent.** The property only ever reaches *instrumented-test* manifests — across the whole build output it materialises in exactly one file, `form/build/intermediates/packaged_manifests/debugAndroidTest/.../AndroidManifest.xml`. Nothing shipped is affected. And six other Android modules already omit it entirely and build and test fine: `aggregates`, `commonskmm`, `dhis2-mobile-program-rules`, `login`, `sync`, `tracker`.

## Behaviour

Removing the property lets the value fall back to AGP's default, which follows **`compileSdk`**.

On `develop` that is a genuine no-op, because `compileSdk` and `targetSdk` are both 36 — verified by rebuilding and re-reading the manifest, which still resolves to `targetSdkVersion="36"`.

> [!NOTE]
> This stops being a no-op once #5019 lands. That PR splits `compileSdk` (37) from `targetSdk` (36), so instrumented-test `targetSdk` would then follow `compileSdk` and read **37** rather than 36. Only `form` and `commons` have instrumented tests, so the blast radius is small — but it's a real consequence and reviewers should decide whether they're happy with instrumented tests running at the compile level. If not, the alternative is to keep the property and merely move it out of `defaultConfig` into a proper `testOptions { }` block.

## Verification

- `./gradlew ktlintCheck` ✅
- `./gradlew testDebugUnitTest testDhis2DebugUnitTest testAndroidHostTest` ✅
- `./gradlew :app:assembleDhis2Debug :app:assembleDhis2DebugAndroidTest :form:assembleAndroidTest` ✅ — the `build-test-apks` task list, included deliberately because this change affects androidTest manifests
- `form`'s `debugAndroidTest` manifest still resolves to `targetSdkVersion="36"` ✅

6 files, 6 deletions, one line each.


[ANDROAPP-7745]: https://dhis2.atlassian.net/browse/ANDROAPP-7745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ