### PR TITLE
fix: [ANDROAPP-7732] Checks if server has oAuth enabled to verify if "login with openId" button should be displayed

### DIFF
--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/CredentialsScreen.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/CredentialsScreen.kt
@@ -240,6 +240,7 @@ fun CredentialsScreen(
                 onCredentialsAction = { credentialsAction ->
                     handleCredentialAction(viewModel, context, credentialsAction)
                 },
+                hasOAuthEnabled = entryMode == CredentialsEntryMode.EXISTING_OAUTH,
                 hasOtherAccounts = screenState.hasOtherAccounts,
             )
         }
@@ -581,6 +582,7 @@ private fun CredentialActions(
     oidcInfo: OidcInfo?,
     canLogin: Boolean,
     hasOtherAccounts: Boolean,
+    hasOAuthEnabled: Boolean,
     onCredentialsAction: (CredentialsAction) -> Unit,
 ) {
     Column(
@@ -643,7 +645,7 @@ private fun CredentialActions(
                 }
             }
         }
-        if (oidcInfo != null) {
+        if (!hasOAuthEnabled && oidcInfo != null) {
             Row(
                 modifier = Modifier.fillMaxWidth().padding(Spacing.Spacing16),
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7732).

Please provide a clear definition of the problem and explain your solution.