### PR TITLE
fix: [ANDROAPP-7774] main-thread ANR in SplashPresenter from blocking SDK reads

### DIFF
--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -352,7 +352,9 @@ app-repo-only — library base branches are fixed in Step 9b.)
      over one broad one — an unscoped `text ~` search across the whole
      project can return an oversized result.
   2. **Found an existing open issue** covering the same crash → reuse its key
-     as `JIRA_KEY`; do not create a duplicate.
+     as `JIRA_KEY`; do not create a duplicate. Leave its description alone
+     except to append the `## How to test manually` section described in 3 if
+     it has none.
   3. **Nothing found** → create a new `Bug` in `ANDROAPP`. Before creating,
      fetch this issue type's required fields
      (`getJiraIssueTypeMetaWithFields`) — at the time of writing `Bug`
@@ -367,14 +369,22 @@ app-repo-only — library base branches are fixed in Step 9b.)
        for section headers. Do **not** use Jira wiki markup (`h2.`, `{code}`,
        `*bold*`) — it renders literally and makes the ticket harder to read.
      - Aim for three short sections — what breaks, why, and impact — of a
-       couple of sentences each. Prose over bullets-of-bullets.
+       couple of sentences each, then the manual test below. Prose over
+       bullets-of-bullets.
      - **Never paste a stack trace, event payload, or log dump.** Link the
        Sentry issue and let it hold the crash detail — it is always more
        current than a copy, and the dump is what makes these tickets
        unreadable. Name the crash site as `File.kt:line` in prose instead.
      - Include: the Sentry issue link(s) with user/event counts, the
        one-sentence root cause from Step 3, the affected release, and (once
-       known) the PR link. Nothing else.
+       known) the PR link.
+     - Close with a `## How to test manually` section — steps a field tester can
+       run on a release APK, with no adb and no debug build. Derive it from the
+       code you read in Steps 2-5 and follow
+       `.claude/skills/sentry-fix/references/manual-test.md`, including its
+       self-check. A test that a correct build would fail, or a broken build
+       would pass, is worse than no test at all.
+     - Nothing else — no stack traces, no tool transcripts, no fix history.
   4. If the search in 1 (or a `/sentry-triage` report) surfaced a clearly
      related prior ticket — same anti-pattern, adjacent call site or repo —
      link `JIRA_KEY` to it (`createIssueLink`, type `Relates`) and mention the

--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -188,7 +188,14 @@ For **app-owned** fixes follow all rules from `AGENTS.md`:
   - Trailing commas on every multi-line parameter/argument list
   - Expression bodies for single-expression functions
 - **No comments** unless the WHY is non-obvious (hidden constraint, workaround for a
-  specific upstream bug)
+  specific upstream bug). Specifically, **never narrate the fix in the source** —
+  no "moved this here because it caused an ANR", no Sentry issue IDs, no
+  before/after explanation, no multi-line block justifying the change. That
+  history belongs in the PR body and the Jira ticket, which is where a reader
+  goes looking for it. The diff already shows what changed.
+  When a comment *is* warranted, make it one concise line describing what the
+  code does or the constraint it satisfies — stated in the present tense, as if
+  the code had always looked this way.
 
 For **library-owned** fixes the app's conventions do NOT apply (no
 `launchUseCase`, no `DomainErrorMapper`). Follow the target repo's own guidance:
@@ -346,15 +353,28 @@ app-repo-only — library base branches are fixed in Step 9b.)
      project can return an oversized result.
   2. **Found an existing open issue** covering the same crash → reuse its key
      as `JIRA_KEY`; do not create a duplicate.
-  3. **Nothing found** → create a new `Bug` in `ANDROAPP`: summary matching
-     the Sentry issue title, description with the Sentry issue link, a
-     trimmed stack trace, the one-sentence root cause from Step 3, and (once
-     known) the PR link. Before creating, fetch this issue type's required
-     fields (`getJiraIssueTypeMetaWithFields`) — at the time of writing `Bug`
+  3. **Nothing found** → create a new `Bug` in `ANDROAPP`. Before creating,
+     fetch this issue type's required fields
+     (`getJiraIssueTypeMetaWithFields`) — at the time of writing `Bug`
      requires `components` (use `AndroidApp` unless a more specific component
      obviously fits), `environment` (free text — release + platform is
      enough), and `versions` (`Affects versions` — the crashing release, e.g.
      the `release` tag from Step 1). Store the new key as `JIRA_KEY`.
+
+     **Write the description short and scannable** — a developer opening the
+     ticket should grasp the problem in about fifteen seconds:
+     - Pass `contentFormat: "markdown"` and write **real Markdown**. Use `##`
+       for section headers. Do **not** use Jira wiki markup (`h2.`, `{code}`,
+       `*bold*`) — it renders literally and makes the ticket harder to read.
+     - Aim for three short sections — what breaks, why, and impact — of a
+       couple of sentences each. Prose over bullets-of-bullets.
+     - **Never paste a stack trace, event payload, or log dump.** Link the
+       Sentry issue and let it hold the crash detail — it is always more
+       current than a copy, and the dump is what makes these tickets
+       unreadable. Name the crash site as `File.kt:line` in prose instead.
+     - Include: the Sentry issue link(s) with user/event counts, the
+       one-sentence root cause from Step 3, the affected release, and (once
+       known) the PR link. Nothing else.
   4. If the search in 1 (or a `/sentry-triage` report) surfaced a clearly
      related prior ticket — same anti-pattern, adjacent call site or repo —
      link `JIRA_KEY` to it (`createIssueLink`, type `Relates`) and mention the

--- a/app/src/main/java/org/dhis2/usescases/splash/SplashPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/splash/SplashPresenter.kt
@@ -33,10 +33,7 @@ class SplashPresenter internal constructor(
                 userManager.isUserLoggedIn
                     .delay(2000, TimeUnit.MILLISECONDS, schedulerProvider.io())
                     .subscribeOn(schedulerProvider.io())
-                    // Resolve the blocking SDK reads here, upstream of observeOn(ui): if they
-                    // run after the switch to the UI scheduler they block the main thread on
-                    // SQLiteConnectionPool while background sync holds the connection, causing
-                    // an ANR (DHIS2-ANDROID-CAPTURE-83NF / 83P1).
+                    // Must stay upstream of observeOn(ui): these SDK reads block on the database.
                     .map { userLogged -> userLogged to trackingInfoFor(userManager, userLogged) }
                     .observeOn(schedulerProvider.ui())
                     .subscribe(

--- a/app/src/main/java/org/dhis2/usescases/splash/SplashPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/splash/SplashPresenter.kt
@@ -33,18 +33,18 @@ class SplashPresenter internal constructor(
                 userManager.isUserLoggedIn
                     .delay(2000, TimeUnit.MILLISECONDS, schedulerProvider.io())
                     .subscribeOn(schedulerProvider.io())
+                    // Resolve the blocking SDK reads here, upstream of observeOn(ui): if they
+                    // run after the switch to the UI scheduler they block the main thread on
+                    // SQLiteConnectionPool while background sync holds the connection, causing
+                    // an ANR (DHIS2-ANDROID-CAPTURE-83NF / 83P1).
+                    .map { userLogged -> userLogged to trackingInfoFor(userManager, userLogged) }
                     .observeOn(schedulerProvider.ui())
                     .subscribe(
-                        { userLogged ->
-                            if (userLogged && trackingPermissionGranted()) {
-                                val systemInfo =
-                                    userManager.d2
-                                        .systemInfoModule()
-                                        .systemInfo()
-                                        .blockingGet()
+                        { (userLogged, trackingInfo) ->
+                            trackingInfo?.let {
                                 trackUserInfo(
-                                    serverUrl = systemInfo?.contextPath() ?: "",
-                                    serverVersion = systemInfo?.version() ?: "",
+                                    serverUrl = it.serverUrl,
+                                    serverVersion = it.serverVersion,
                                 )
                             }
                             view.goToNextScreen(
@@ -74,13 +74,30 @@ class SplashPresenter internal constructor(
         )
     }
 
-    private fun trackingPermissionGranted(): Boolean =
-        userManager
-            ?.d2
-            ?.dataStoreModule()
-            ?.localDataStore()
-            ?.value(DATA_STORE_ANALYTICS_PERMISSION_KEY)
-            ?.blockingGet()
+    private fun trackingInfoFor(
+        userManager: UserManager,
+        userLogged: Boolean,
+    ): TrackingInfo? =
+        if (userLogged && trackingPermissionGranted(userManager)) {
+            val systemInfo =
+                userManager.d2
+                    .systemInfoModule()
+                    .systemInfo()
+                    .blockingGet()
+            TrackingInfo(
+                serverUrl = systemInfo?.contextPath() ?: "",
+                serverVersion = systemInfo?.version() ?: "",
+            )
+        } else {
+            null
+        }
+
+    private fun trackingPermissionGranted(userManager: UserManager): Boolean =
+        userManager.d2
+            .dataStoreModule()
+            .localDataStore()
+            .value(DATA_STORE_ANALYTICS_PERMISSION_KEY)
+            .blockingGet()
             ?.value() == true.toString()
 
     private fun trackUserInfo(
@@ -97,4 +114,9 @@ class SplashPresenter internal constructor(
             ?.accountManager()
             ?.getAccounts()
             ?.count() ?: 0
+
+    private data class TrackingInfo(
+        val serverUrl: String,
+        val serverVersion: String,
+    )
 }

--- a/app/src/test/java/org/dhis2/usescases/splash/SplashPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/splash/SplashPresenterTest.kt
@@ -1,0 +1,155 @@
+package org.dhis2.usescases.splash
+
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import org.dhis2.commons.prefs.Preference
+import org.dhis2.commons.prefs.PreferenceProvider
+import org.dhis2.data.schedulers.TrampolineSchedulerProvider
+import org.dhis2.data.server.UserManager
+import org.dhis2.mobile.commons.reporting.CrashReportController
+import org.dhis2.utils.analytics.DATA_STORE_ANALYTICS_PERMISSION_KEY
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.datastore.KeyValuePair
+import org.hisp.dhis.android.core.systeminfo.SystemInfo
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SplashPresenterTest {
+    private val view: SplashView = mock()
+    private val userManager: UserManager = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val d2: D2 = Mockito.mock(D2::class.java, RETURNS_DEEP_STUBS)
+    private val schedulerProvider = TrampolineSchedulerProvider()
+    private val preferenceProvider: PreferenceProvider = mock()
+    private val crashReportController: CrashReportController = mock()
+
+    private lateinit var presenter: SplashPresenter
+
+    @Before
+    fun setup() {
+        whenever(userManager.d2) doReturn d2
+        presenter =
+            SplashPresenter(
+                view,
+                userManager,
+                schedulerProvider,
+                preferenceProvider,
+                crashReportController,
+            )
+    }
+
+    @Test
+    fun `Should go to next screen when user is not logged in without touching the SDK`() {
+        whenever(userManager.isUserLoggedIn) doReturn Observable.just(false)
+
+        presenter.init()
+
+        verify(view).goToNextScreen(
+            false,
+            preferenceProvider.getBoolean(Preference.SESSION_LOCKED, false),
+            preferenceProvider.getBoolean(Preference.INITIAL_METADATA_SYNC_DONE, false),
+            preferenceProvider.getBoolean(Preference.INITIAL_DATA_SYNC_DONE, false),
+        )
+        verify(d2, never()).systemInfoModule()
+        verify(crashReportController, never()).trackServer(any(), any())
+    }
+
+    @Test
+    fun `Should track user info and go to next screen when user is logged in and tracking permission is granted`() {
+        whenever(userManager.isUserLoggedIn) doReturn Observable.just(true)
+        val permissionGranted =
+            KeyValuePair
+                .builder()
+                .key(DATA_STORE_ANALYTICS_PERMISSION_KEY)
+                .value(true.toString())
+                .build()
+        whenever(
+            d2
+                .dataStoreModule()
+                .localDataStore()
+                .value(DATA_STORE_ANALYTICS_PERMISSION_KEY)
+                .blockingGet(),
+        ) doReturn permissionGranted
+        val systemInfo =
+            SystemInfo
+                .builder()
+                .contextPath("https://play.dhis2.org")
+                .version("2.40")
+                .build()
+        whenever(d2.systemInfoModule().systemInfo().blockingGet()) doReturn systemInfo
+
+        presenter.init()
+
+        verify(crashReportController).trackServer("https://play.dhis2.org", "2.40")
+        verify(view).goToNextScreen(
+            true,
+            preferenceProvider.getBoolean(Preference.SESSION_LOCKED, false),
+            preferenceProvider.getBoolean(Preference.INITIAL_METADATA_SYNC_DONE, false),
+            preferenceProvider.getBoolean(Preference.INITIAL_DATA_SYNC_DONE, false),
+        )
+    }
+
+    @Test
+    fun `Should not track user info when user is logged in but tracking permission is not granted`() {
+        whenever(userManager.isUserLoggedIn) doReturn Observable.just(true)
+        val permissionDenied =
+            KeyValuePair
+                .builder()
+                .key(DATA_STORE_ANALYTICS_PERMISSION_KEY)
+                .value(false.toString())
+                .build()
+        whenever(
+            d2
+                .dataStoreModule()
+                .localDataStore()
+                .value(DATA_STORE_ANALYTICS_PERMISSION_KEY)
+                .blockingGet(),
+        ) doReturn permissionDenied
+
+        presenter.init()
+
+        verify(crashReportController, never()).trackServer(any(), any())
+        verify(view).goToNextScreen(
+            true,
+            preferenceProvider.getBoolean(Preference.SESSION_LOCKED, false),
+            preferenceProvider.getBoolean(Preference.INITIAL_METADATA_SYNC_DONE, false),
+            preferenceProvider.getBoolean(Preference.INITIAL_DATA_SYNC_DONE, false),
+        )
+    }
+
+    @Test
+    fun `Should go to next screen when there is no user manager`() {
+        val presenterWithoutUserManager =
+            SplashPresenter(
+                view,
+                null,
+                schedulerProvider,
+                preferenceProvider,
+                crashReportController,
+            )
+
+        presenterWithoutUserManager.init()
+
+        verify(view).goToNextScreen(
+            false,
+            sessionLocked = false,
+            initialSyncDone = false,
+            initialDataSyncDone = false,
+        )
+    }
+
+    @Test
+    fun `Should clear disposable on destroy`() {
+        presenter.compositeDisposable = CompositeDisposable()
+        presenter.destroy()
+
+        assert(presenter.compositeDisposable.size() == 0)
+    }
+}


### PR DESCRIPTION
## Summary

`SplashPresenter.isUserLoggedIn()` runs its Rx chain on `io()` and then
switches to `ui()` via `observeOn`. The `onNext` callback — now on the main
thread — performed two blocking SDK/Room reads:

- `trackingPermissionGranted()` → `localDataStore().value(...).blockingGet()`
- `systemInfoModule().systemInfo().blockingGet()`

When background sync held the SQLite connection, the main thread parked in
`SQLiteConnectionPool.waitForConnection`, producing an ANR right at app
startup (`SplashActivity`).

## Fix

Both blocking reads are moved into a `map` operator placed **before**
`observeOn(schedulerProvider.ui())`, so they still run on the IO scheduler
established by `subscribeOn(schedulerProvider.io())`. The UI thread now only
receives the already-computed `Boolean` / `TrackingInfo?` pair — no SDK or
database access happens on the main thread. The rest of the Rx chain and the
presenter's public API are unchanged; this keeps the fix scoped to the
existing RxJava chain rather than introducing new operators or migrating the
presenter to coroutines.

## Sentry issue
Fixes DHIS2-ANDROID-CAPTURE-83NF
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-83NF/

Also fixes the same defect at the same line, grouped separately by
foreground/background state:
Fixes DHIS2-ANDROID-CAPTURE-83P1
https://dhis2.sentry.io/issues/DHIS2-ANDROID-CAPTURE-83P1/

Related task: [ANDROAPP-7774](https://dhis2.atlassian.net/browse/ANDROAPP-7774)

## Test plan
- Added `app/src/test/java/org/dhis2/usescases/splash/SplashPresenterTest.kt`
  covering: user not logged in (SDK untouched), logged in with tracking
  permission granted (`trackServer` called with the resolved system info),
  logged in without tracking permission (no `trackServer` call), no
  `UserManager`, and disposable cleanup on `destroy()`.
- `./gradlew ktlintFormat && ./gradlew ktlintCheck` — clean
- `./gradlew :app:testDhis2DebugUnitTest --tests "org.dhis2.usescases.splash.SplashPresenterTest"` — 5/5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ANDROAPP-7774]: https://dhis2.atlassian.net/browse/ANDROAPP-7774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ