### PR TITLE
refactor: [ANDROAPP-7733] Map SDK errors in sync repositories with withDomainErrors

### DIFF
--- a/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncDataSetRepositoryImpl.kt
+++ b/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncDataSetRepositoryImpl.kt
@@ -1,39 +1,46 @@
 package org.dhis2.mobile.sync.data
 
+import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.withDomainErrors
 import org.dhis2.mobile.sync.domain.DataSetUid
 import org.hisp.dhis.android.core.D2
 
 internal class SyncDataSetRepositoryImpl(
     private val d2: D2,
+    private val domainErrorMapper: DomainErrorMapper,
 ) : SyncDataSetRepository {
     override suspend fun uploadDataSet(dataSetUid: DataSetUid) {
-        d2
-            .dataSetModule()
-            .dataSetInstances()
-            .byDataSetUid()
-            .eq(dataSetUid)
-            .blockingGet()
-            .forEach { dataSetInstance ->
-                d2
-                    .dataValueModule()
-                    .dataValues()
-                    .byOrganisationUnitUid()
-                    .eq(dataSetInstance.organisationUnitUid())
-                    .byPeriod()
-                    .eq(dataSetInstance.period())
-                    .byAttributeOptionComboUid()
-                    .eq(dataSetInstance.attributeOptionComboUid())
-                    .blockingUpload()
-            }
+        domainErrorMapper.withDomainErrors {
+            d2
+                .dataSetModule()
+                .dataSetInstances()
+                .byDataSetUid()
+                .eq(dataSetUid)
+                .blockingGet()
+                .forEach { dataSetInstance ->
+                    d2
+                        .dataValueModule()
+                        .dataValues()
+                        .byOrganisationUnitUid()
+                        .eq(dataSetInstance.organisationUnitUid())
+                        .byPeriod()
+                        .eq(dataSetInstance.period())
+                        .byAttributeOptionComboUid()
+                        .eq(dataSetInstance.attributeOptionComboUid())
+                        .blockingUpload()
+                }
+        }
     }
 
     override suspend fun uploadCompleteRegistration(dataSetUid: DataSetUid) {
-        d2
-            .dataSetModule()
-            .dataSetCompleteRegistrations()
-            .byDataSetUid()
-            .eq(dataSetUid)
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .dataSetModule()
+                .dataSetCompleteRegistrations()
+                .byDataSetUid()
+                .eq(dataSetUid)
+                .blockingUpload()
+        }
     }
 
     // TODO: The sdk does not provide methods to download data values for a given dataset

--- a/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncDataValueRepositoryImpl.kt
+++ b/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncDataValueRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package org.dhis2.mobile.sync.data
 
+import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.withDomainErrors
 import org.dhis2.mobile.sync.domain.DataSetUid
 import org.dhis2.mobile.sync.model.CategoryOptionComboUid
 import org.dhis2.mobile.sync.model.OrgUnitUid
@@ -8,6 +10,7 @@ import org.hisp.dhis.android.core.D2
 
 internal class SyncDataValueRepositoryImpl(
     private val d2: D2,
+    private val domainErrorMapper: DomainErrorMapper,
 ) : SyncDataValueRepository {
     override suspend fun uploadDataValues(
         dataSetUid: DataSetUid,
@@ -16,18 +19,20 @@ internal class SyncDataValueRepositoryImpl(
         attributeOptionComboUid: CategoryOptionComboUid,
         categoryOptionComboUids: List<CategoryOptionComboUid>,
     ) {
-        d2
-            .dataValueModule()
-            .dataValues()
-            .byAttributeOptionComboUid()
-            .eq(attributeOptionComboUid)
-            .byOrganisationUnitUid()
-            .eq(orgUnitUid)
-            .byPeriod()
-            .eq(periodId)
-            .byCategoryOptionComboUid()
-            .`in`(categoryOptionComboUids)
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .dataValueModule()
+                .dataValues()
+                .byAttributeOptionComboUid()
+                .eq(attributeOptionComboUid)
+                .byOrganisationUnitUid()
+                .eq(orgUnitUid)
+                .byPeriod()
+                .eq(periodId)
+                .byCategoryOptionComboUid()
+                .`in`(categoryOptionComboUids)
+                .blockingUpload()
+        }
     }
 
     override suspend fun uploadCompleteRegistrations(
@@ -36,18 +41,20 @@ internal class SyncDataValueRepositoryImpl(
         periodId: PeriodId,
         attributeOptionComboUid: CategoryOptionComboUid,
     ) {
-        d2
-            .dataSetModule()
-            .dataSetCompleteRegistrations()
-            .byDataSetUid()
-            .eq(dataSetUid)
-            .byAttributeOptionComboUid()
-            .eq(attributeOptionComboUid)
-            .byOrganisationUnitUid()
-            .eq(orgUnitUid)
-            .byPeriod()
-            .eq(periodId)
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .dataSetModule()
+                .dataSetCompleteRegistrations()
+                .byDataSetUid()
+                .eq(dataSetUid)
+                .byAttributeOptionComboUid()
+                .eq(attributeOptionComboUid)
+                .byOrganisationUnitUid()
+                .eq(orgUnitUid)
+                .byPeriod()
+                .eq(periodId)
+                .blockingUpload()
+        }
     }
 
     // TODO: The sdk does not provide methods to download data values for a given data set instance

--- a/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncEventRepositoryImpl.kt
+++ b/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncEventRepositoryImpl.kt
@@ -1,34 +1,43 @@
 package org.dhis2.mobile.sync.data
 
+import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.withDomainErrors
 import org.hisp.dhis.android.core.D2
 
 internal class SyncEventRepositoryImpl(
     private val d2: D2,
+    private val domainErrorMapper: DomainErrorMapper,
 ) : SyncEventRepository {
     override suspend fun uploadEvent(eventUid: String) {
-        d2
-            .eventModule()
-            .events()
-            .byUid()
-            .eq(eventUid)
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .eventModule()
+                .events()
+                .byUid()
+                .eq(eventUid)
+                .blockingUpload()
+        }
     }
 
     override suspend fun downloadEvent(eventUid: String) {
-        d2
-            .eventModule()
-            .eventDownloader()
-            .byUid()
-            .eq(eventUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .eventModule()
+                .eventDownloader()
+                .byUid()
+                .eq(eventUid)
+                .blockingDownload()
+        }
     }
 
     override suspend fun downloadFileResources(eventUid: String) {
-        d2
-            .fileResourceModule()
-            .fileResourceDownloader()
-            .byEventUid()
-            .eq(eventUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .fileResourceModule()
+                .fileResourceDownloader()
+                .byEventUid()
+                .eq(eventUid)
+                .blockingDownload()
+        }
     }
 }

--- a/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncProgramRepositoryImpl.kt
+++ b/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncProgramRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package org.dhis2.mobile.sync.data
 
+import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.withDomainErrors
 import org.dhis2.mobile.sync.model.ProgramType
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.common.State
@@ -7,81 +9,98 @@ import org.hisp.dhis.android.core.program.ProgramType as CoreProgramType
 
 internal class SyncProgramRepositoryImpl(
     private val d2: D2,
+    private val domainErrorMapper: DomainErrorMapper,
 ) : SyncProgramRepository {
     override suspend fun getProgramType(programUid: String): ProgramType =
-        when (
-            d2
-                .programModule()
-                .programs()
-                .uid(programUid)
-                .suspendGet()
-                ?.programType
-        ) {
-            CoreProgramType.WITH_REGISTRATION -> ProgramType.Tracker
-            CoreProgramType.WITHOUT_REGISTRATION -> ProgramType.Event
-            null -> ProgramType.None
+        domainErrorMapper.withDomainErrors {
+            when (
+                d2
+                    .programModule()
+                    .programs()
+                    .uid(programUid)
+                    .suspendGet()
+                    ?.programType
+            ) {
+                CoreProgramType.WITH_REGISTRATION -> ProgramType.Tracker
+                CoreProgramType.WITHOUT_REGISTRATION -> ProgramType.Event
+                null -> ProgramType.None
+            }
         }
 
     override suspend fun uploadTrackerProgram(programUid: String) {
-        d2
-            .trackedEntityModule()
-            .trackedEntityInstances()
-            .byProgramUids(listOf(programUid))
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .trackedEntityModule()
+                .trackedEntityInstances()
+                .byProgramUids(listOf(programUid))
+                .blockingUpload()
+        }
     }
 
     override suspend fun downloadTrackerProgram(programUid: String) {
-        d2
-            .trackedEntityModule()
-            .trackedEntityInstanceDownloader()
-            .byProgramUid(programUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .trackedEntityModule()
+                .trackedEntityInstanceDownloader()
+                .byProgramUid(programUid)
+                .blockingDownload()
+        }
     }
 
     override suspend fun uploadEventProgram(programUid: String) {
-        d2
-            .eventModule()
-            .events()
-            .byProgramUid()
-            .eq(programUid)
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .eventModule()
+                .events()
+                .byProgramUid()
+                .eq(programUid)
+                .blockingUpload()
+        }
     }
 
     override suspend fun downloadEventProgram(programUid: String) {
-        d2
-            .eventModule()
-            .eventDownloader()
-            .byProgramUid(programUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .eventModule()
+                .eventDownloader()
+                .byProgramUid(programUid)
+                .blockingDownload()
+        }
     }
 
     override suspend fun downloadFileResources(programUid: String) {
-        d2
-            .fileResourceModule()
-            .fileResourceDownloader()
-            .byProgramUid()
-            .eq(programUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .fileResourceModule()
+                .fileResourceDownloader()
+                .byProgramUid()
+                .eq(programUid)
+                .blockingDownload()
+        }
     }
 
     override suspend fun allTeisAreSynced(programUid: String) =
-        d2
-            .trackedEntityModule()
-            .trackedEntityInstances()
-            .byProgramUids(listOf(programUid))
-            .byAggregatedSyncState()
-            .notIn(State.SYNCED, State.RELATIONSHIP)
-            .blockingGet()
-            .isEmpty()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .trackedEntityModule()
+                .trackedEntityInstances()
+                .byProgramUids(listOf(programUid))
+                .byAggregatedSyncState()
+                .notIn(State.SYNCED, State.RELATIONSHIP)
+                .blockingGet()
+                .isEmpty()
+        }
 
     override suspend fun allEventsAreSynced(programUid: String) =
-        d2
-            .eventModule()
-            .events()
-            .byProgramUid()
-            .eq(programUid)
-            .byAggregatedSyncState()
-            .notIn(State.SYNCED)
-            .blockingGet()
-            .isEmpty()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .eventModule()
+                .events()
+                .byProgramUid()
+                .eq(programUid)
+                .byAggregatedSyncState()
+                .notIn(State.SYNCED)
+                .blockingGet()
+                .isEmpty()
+        }
 }

--- a/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncTeiRepositoryImpl.kt
+++ b/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/SyncTeiRepositoryImpl.kt
@@ -1,64 +1,74 @@
 package org.dhis2.mobile.sync.data
 
+import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.withDomainErrors
 import org.dhis2.mobile.sync.model.EnrollmentInfo
 import org.hisp.dhis.android.core.D2
 
 internal class SyncTeiRepositoryImpl(
     private val d2: D2,
+    private val domainErrorMapper: DomainErrorMapper,
 ) : SyncTeiRepository {
-    override suspend fun getEnrollmentInfo(enrollmentUid: String): EnrollmentInfo {
-        val enrollment =
-            d2
-                .enrollmentModule()
-                .enrollments()
-                .uid(enrollmentUid)
-                .blockingGet() ?: throw IllegalStateException("Enrollment does not exist")
+    override suspend fun getEnrollmentInfo(enrollmentUid: String): EnrollmentInfo =
+        domainErrorMapper.withDomainErrors {
+            val enrollment =
+                d2
+                    .enrollmentModule()
+                    .enrollments()
+                    .uid(enrollmentUid)
+                    .blockingGet() ?: throw IllegalStateException("Enrollment does not exist")
 
-        return EnrollmentInfo(
-            uid = enrollmentUid,
-            teiUid =
-                enrollment.trackedEntityInstance() ?: throw IllegalStateException(
-                    "Missing tei uid for enrollment %s".format(
-                        enrollmentUid,
+            EnrollmentInfo(
+                uid = enrollmentUid,
+                teiUid =
+                    enrollment.trackedEntityInstance() ?: throw IllegalStateException(
+                        "Missing tei uid for enrollment %s".format(
+                            enrollmentUid,
+                        ),
                     ),
-                ),
-            programUid =
-                enrollment.program() ?: throw IllegalStateException(
-                    "Missing program uid for enrollment %s".format(
-                        enrollmentUid,
+                programUid =
+                    enrollment.program() ?: throw IllegalStateException(
+                        "Missing program uid for enrollment %s".format(
+                            enrollmentUid,
+                        ),
                     ),
-                ),
-        )
-    }
+            )
+        }
 
     override suspend fun uploadTei(enrollmentInfo: EnrollmentInfo) {
-        d2
-            .trackedEntityModule()
-            .trackedEntityInstances()
-            .byUid()
-            .eq(enrollmentInfo.teiUid)
-            .byProgramUids(listOf(enrollmentInfo.programUid))
-            .blockingUpload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .trackedEntityModule()
+                .trackedEntityInstances()
+                .byUid()
+                .eq(enrollmentInfo.teiUid)
+                .byProgramUids(listOf(enrollmentInfo.programUid))
+                .blockingUpload()
+        }
     }
 
     override suspend fun downloadTei(enrollmentInfo: EnrollmentInfo) {
-        d2
-            .trackedEntityModule()
-            .trackedEntityInstanceDownloader()
-            .byUid()
-            .eq(enrollmentInfo.teiUid)
-            .byProgramUid(enrollmentInfo.programUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .trackedEntityModule()
+                .trackedEntityInstanceDownloader()
+                .byUid()
+                .eq(enrollmentInfo.teiUid)
+                .byProgramUid(enrollmentInfo.programUid)
+                .blockingDownload()
+        }
     }
 
     override suspend fun downloadFileResources(enrollmentInfo: EnrollmentInfo) {
-        d2
-            .fileResourceModule()
-            .fileResourceDownloader()
-            .byTrackedEntityUid()
-            .eq(enrollmentInfo.teiUid)
-            .byProgramUid()
-            .eq(enrollmentInfo.programUid)
-            .blockingDownload()
+        domainErrorMapper.withDomainErrors {
+            d2
+                .fileResourceModule()
+                .fileResourceDownloader()
+                .byTrackedEntityUid()
+                .eq(enrollmentInfo.teiUid)
+                .byProgramUid()
+                .eq(enrollmentInfo.programUid)
+                .blockingDownload()
+        }
     }
 }


### PR DESCRIPTION
## Description

[JIRA ANDROAPP-7733](https://dhis2.atlassian.net/browse/ANDROAPP-7733)

**Part 2 of 7** splitting #5068. A mechanical refactor, isolated precisely because it is large and boring — so it does not hide the two real bug fixes in Parts 3 and 4.

Every method in these five repositories wrapped its SDK call in the same `catch (d2Error: D2Error) -> mapToDomainError` block. They now use `withDomainErrors` / `withDomainErrorsAsResult` from Part 1.

One behaviour change comes with it, and it is the point: the old inline catch only saw a bare `D2Error`, so every failure the SDK's blocking RxJava operators rewrapped in a `RuntimeException` reached the domain layer unmapped. Those are now mapped.

### Not in this PR
- `AndroidSyncRepository` — Part 3, where it comes with a behavioural fix and tests.
- New tests: the existing `sync` suite covers these paths.

**Depends on #5070** — merge after it.

---

### The stack

Replaces #5068. Merge #5070 first, then each chain in order; #5076 is independent of everything.

| Part | PR | Base | Lines |
|---|---|---|---|
| 1 | #5070 — commons: error mapping + renewal signal | `develop` | 334 |
| 2 | #5071 — sync: repositories via `withDomainErrors` | #5070 | 380 |
| 3 | #5072 — sync: expired session is not an unavailable server | #5071 | 85 |
| 4 | #5073 — sync: raise the renewal signal | #5072 | 349 |
| 5 | #5074 — login: renew from the credentials screen | #5070 | 360 |
| 6 | #5075 — app: dialog and routing | #5074 | 200 |
| 7 | #5076 — dev tool: force session expiry | `develop` | 403 (size check waived) |

The 55 changed files are byte-identical to #5068 — verified file by file — with one exception: the three-line `existingUsername = null` placeholder #5070 needs to compile on its own, which #5074 replaces.


---

### About the red Jenkins check

`continuous-integration/jenkins/pr-head` reports *"This commit cannot be built"*. That is structural, not a failure of this code: the `android-multibranch-PR` job only builds pull requests whose base is a long-lived branch, and this one is based on another PR's branch. Precedent: #5038 got the identical error and was merged.

Every GitHub Actions check is green here — lint, unit tests, build-test-apks, form tests, portrait and landscape UI tests, code-quality, SonarCloud. Jenkins goes green on its own once the parent merges and GitHub retargets this PR to `develop`.
