### PR TITLE
fix: [ANDROAPP-7733] Stop reporting an expired session as an unavailable server

### DIFF
--- a/sync/src/androidHostTest/kotlin/org/dhis2/mobile/sync/data/AndroidSyncRepositoryTest.kt
+++ b/sync/src/androidHostTest/kotlin/org/dhis2/mobile/sync/data/AndroidSyncRepositoryTest.kt
@@ -9,12 +9,15 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.dhis2.mobile.commons.coroutine.Dispatcher
+import org.dhis2.mobile.commons.error.DomainError
 import org.dhis2.mobile.commons.error.DomainErrorMapper
 import org.dhis2.mobile.commons.providers.PreferenceProvider
 import org.dhis2.mobile.commons.reporting.AnalyticActions
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.call.BaseD2Progress
 import org.hisp.dhis.android.core.fileresource.FileResourceDomainType
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.settings.GeneralSettings
 import org.junit.After
 import org.junit.Before
@@ -27,6 +30,8 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class AndroidSyncRepositoryTest {
     private val d2: D2 = Mockito.mock(D2::class.java, Mockito.RETURNS_DEEP_STUBS)
@@ -36,7 +41,7 @@ class AndroidSyncRepositoryTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
-    val repository =
+    internal val repository =
         AndroidSyncRepository(
             d2 = d2,
             preferences = preferences,
@@ -165,5 +170,44 @@ class AndroidSyncRepositoryTest {
 
             verify(analyticsHelper, times(0)).updateMatomoSecondaryTracker(any(), any())
             verify(analyticsHelper).clearMatomoSecondaryTracker()
+        }
+
+    @Test
+    fun `Should report an expired session instead of an unavailable server`() =
+        runTest {
+            // GIVEN - once the tokens are discarded the SDK rejects every call, the ping included
+            val d2Error =
+                D2Error
+                    .builder()
+                    .errorCode(D2ErrorCode.OAUTH2_NO_VALID_TOKEN)
+                    .errorDescription("There is no access token")
+                    .build()
+            val renewalRequired = DomainError.SessionRenewalRequiredError("Your session has expired")
+            // RxJava rewraps the checked D2Error before it reaches the repository
+            whenever(d2.systemInfoModule().ping().blockingGet())
+                .thenAnswer { throw RuntimeException(d2Error) }
+            whenever(domainErrorMapper.mapToDomainError(d2Error)) doReturn renewalRequired
+
+            // WHEN & THEN - swallowing it as unavailability would hide the one problem only the
+            // user can fix, so it travels on to the sync use case
+            val thrown =
+                try {
+                    repository.isServerAvailable("SYNC_DATA")
+                    null
+                } catch (error: DomainError) {
+                    error
+                }
+            assertEquals(renewalRequired, thrown)
+        }
+
+    @Test
+    fun `Should report an unreachable server as unavailable`() =
+        runTest {
+            // GIVEN - a plain connectivity failure, which a later sync can retry
+            whenever(d2.systemInfoModule().ping().blockingGet())
+                .thenAnswer { throw RuntimeException("unreachable") }
+
+            // WHEN & THEN
+            assertFalse(repository.isServerAvailable("SYNC_DATA"))
         }
 }

--- a/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/AndroidSyncRepository.kt
+++ b/sync/src/androidMain/kotlin/org/dhis2/mobile/sync/data/AndroidSyncRepository.kt
@@ -7,7 +7,10 @@ import kotlinx.datetime.format
 import kotlinx.datetime.toLocalDateTime
 import org.dhis2.mobile.commons.coroutine.Dispatcher
 import org.dhis2.mobile.commons.dates.dateTimeFormat
+import org.dhis2.mobile.commons.error.DomainError
 import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.asD2Error
+import org.dhis2.mobile.commons.error.withDomainErrorsAsResult
 import org.dhis2.mobile.commons.providers.EVENT_MAX
 import org.dhis2.mobile.commons.providers.EVENT_MAX_DEFAULT
 import org.dhis2.mobile.commons.providers.LAST_DATA_SYNC
@@ -32,14 +35,13 @@ import org.hisp.dhis.android.core.arch.call.D2ProgressStatus
 import org.hisp.dhis.android.core.arch.call.D2ProgressSyncStatus
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.fileresource.FileResourceDomainType
-import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.program.ProgramType
 import org.hisp.dhis.android.core.settings.LimitScope
 import kotlin.math.ceil
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-class AndroidSyncRepository(
+internal class AndroidSyncRepository(
     private val d2: D2,
     private val preferences: PreferenceProvider,
     private val analyticsHelper: AnalyticActions,
@@ -48,19 +50,10 @@ class AndroidSyncRepository(
 ) : SyncRepository {
     private suspend fun <T> execute(block: suspend () -> Result<T>): Result<T> =
         withContext(dispatcher.io) {
-            try {
-                block()
-            } catch (d2Error: D2Error) {
-                Result.failure(domainErrorMapper.mapToDomainError(d2Error))
-            }
+            run(block)
         }
 
-    private suspend fun <T> run(block: suspend () -> Result<T>): Result<T> =
-        try {
-            block()
-        } catch (d2Error: D2Error) {
-            Result.failure(domainErrorMapper.mapToDomainError(d2Error))
-        }
+    private suspend fun <T> run(block: suspend () -> Result<T>): Result<T> = domainErrorMapper.withDomainErrorsAsResult(block)
 
     override suspend fun currentMetadataSyncPeriod() =
         withContext(dispatcher.io) {
@@ -197,17 +190,17 @@ class AndroidSyncRepository(
 
     override suspend fun isLoggedIn() = D2Manager.isD2Instantiated() && d2.userModule().blockingIsLogged()
 
-    override suspend fun isServerAvailable(syncJobName: String): Boolean {
-        val isServerAvailable =
-            try {
-                d2.systemInfoModule().ping().blockingGet()
-                true
-            } catch (e: Exception) {
-                false
+    override suspend fun isServerAvailable(syncJobName: String): Boolean =
+        try {
+            d2.systemInfoModule().ping().blockingGet()
+            true
+        } catch (error: Exception) {
+            val domainError = error.asD2Error()?.let { domainErrorMapper.mapToDomainError(it) }
+            if (domainError is DomainError.SessionRenewalRequiredError) {
+                throw domainError
             }
-
-        return isServerAvailable
-    }
+            false
+        }
 
     override suspend fun setUnnavailableFlag(syncJobName: String) {
         d2


### PR DESCRIPTION
## Description

[JIRA ANDROAPP-7733](https://dhis2.atlassian.net/browse/ANDROAPP-7733)

**Part 3 of 7** splitting #5068. Small, behavioural, test-backed — the first of the two product bugs the original PR buried.

`isServerAvailable` caught every exception from `/api/ping` and returned `false`. An expired token therefore looked exactly like a network failure: the sync was skipped as "server unavailable", nothing was reported, and the user was never told the session needed renewing.

It now rethrows a mapped `SessionRenewalRequiredError` and keeps returning `false` for everything else. The duplicated `execute`/`run` pair collapses onto `withDomainErrorsAsResult`, and the class becomes `internal`.

### Not in this PR
- Anything that reacts to the rethrown error — that is Part 4.

**Depends on #5071** — merge after it.

---

### The stack

Replaces #5068. Merge #5070 first, then each chain in order; #5076 is independent of everything.

| Part | PR | Base | Lines |
|---|---|---|---|
| 1 | #5070 — commons: error mapping + renewal signal | `develop` | 334 |
| 2 | #5071 — sync: repositories via `withDomainErrors` | #5070 | 380 |
| 3 | #5072 — sync: expired session is not an unavailable server | #5071 | 85 |
| 4 | #5073 — sync: raise the renewal signal | #5072 | 349 |
| 5 | #5074 — login: renew from the credentials screen | #5070 | 360 |
| 6 | #5075 — app: dialog and routing | #5074 | 200 |
| 7 | #5076 — dev tool: force session expiry | `develop` | 403 (size check waived) |

The 55 changed files are byte-identical to #5068 — verified file by file — with one exception: the three-line `existingUsername = null` placeholder #5070 needs to compile on its own, which #5074 replaces.


---

### About the red Jenkins check

`continuous-integration/jenkins/pr-head` reports *"This commit cannot be built"*. That is structural, not a failure of this code: the `android-multibranch-PR` job only builds pull requests whose base is a long-lived branch, and this one is based on another PR's branch. Precedent: #5038 got the identical error and was merged.

Every GitHub Actions check is green here — lint, unit tests, build-test-apks, form tests, portrait and landscape UI tests, code-quality, SonarCloud. Jenkins goes green on its own once the parent merges and GitHub retargets this PR to `develop`.
