### PR TITLE
feat: [ANDROAPP-7733] Notify session renewal from the sync use cases

### DIFF
--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncData.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncData.kt
@@ -2,6 +2,7 @@ package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
 import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncRepository
 import org.dhis2.mobile.sync.model.DataSyncProgress
 import org.dhis2.mobile.sync.model.DataSyncTask
@@ -11,6 +12,7 @@ private const val SYNC_DATA_NAME = "SYNC_DATA"
 class SyncData(
     private val repository: SyncRepository,
     private val syncStatusController: SyncStatusController,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<(progress: DataSyncProgress) -> Unit, Unit> {
     override suspend fun invoke(input: (progress: DataSyncProgress) -> Unit): Result<Unit> =
         try {
@@ -75,20 +77,36 @@ class SyncData(
                 input(DataSyncProgress(DataSyncTask.SyncReservedValues, progress))
             }
 
-            val isSuccess =
-                uploadEventResult.isSuccess &&
-                    downloadEventResult.isSuccess &&
-                    uploadTEIResult.isSuccess &&
-                    downloadTEIResult.isSuccess &&
-                    uploadDataValueResult.isSuccess &&
-                    downloadDataValueResult.isSuccess
+            val syncResults =
+                listOf(
+                    uploadEventResult,
+                    downloadEventResult,
+                    uploadTEIResult,
+                    downloadTEIResult,
+                    uploadDataValueResult,
+                    downloadDataValueResult,
+                )
+            val isSuccess = syncResults.all { it.isSuccess }
+
+            sessionRenewalNotifier.notifyIfRequired(
+                syncResults.firstNotNullOfOrNull { result ->
+                    result.exceptionOrNull() as? DomainError.SessionRenewalRequiredError
+                },
+            )
 
             repository.saveDataSyncState(isSuccess)
 
             Result.success(Unit)
         } catch (domainError: DomainError) {
-            if (domainError is DomainError.NetworkError) {
-                syncStatusController.onNetworkUnavailable()
+            when (domainError) {
+                is DomainError.NetworkError -> syncStatusController.onNetworkUnavailable()
+
+                is DomainError.SessionRenewalRequiredError ->
+                    sessionRenewalNotifier.notifyRenewalRequired()
+
+                else -> {
+                    // Nothing else to signal
+                }
             }
             Result.failure(domainError)
         } catch (e: Exception) {

--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncDataSet.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncDataSet.kt
@@ -1,12 +1,15 @@
 package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncDataSetRepository
 
 internal typealias DataSetUid = String
 
 internal class SyncDataSet(
     private val syncDataSetRepository: SyncDataSetRepository,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<DataSetUid, Unit> {
     override suspend fun invoke(input: DataSetUid): Result<Unit> =
         try {
@@ -14,6 +17,9 @@ internal class SyncDataSet(
             syncDataSetRepository.uploadCompleteRegistration(input)
             syncDataSetRepository.downloadDataSet(input)
             return Result.success(Unit)
+        } catch (domainError: DomainError) {
+            sessionRenewalNotifier.notifyIfRequired(domainError)
+            Result.failure(domainError)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncDataValue.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncDataValue.kt
@@ -1,11 +1,14 @@
 package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncDataValueRepository
 import org.dhis2.mobile.sync.model.SyncDataValueInput
 
 internal class SyncDataValue(
     private val syncDataValueRepository: SyncDataValueRepository,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<SyncDataValueInput, Unit> {
     override suspend fun invoke(input: SyncDataValueInput): Result<Unit> =
         try {
@@ -29,6 +32,9 @@ internal class SyncDataValue(
                 attributeOptionComboUid = input.attrOptionComboUid,
             )
             Result.success(Unit)
+        } catch (domainError: DomainError) {
+            sessionRenewalNotifier.notifyIfRequired(domainError)
+            Result.failure(domainError)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncEvent.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncEvent.kt
@@ -1,12 +1,15 @@
 package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncEventRepository
 
 internal typealias EventUid = String
 
 internal class SyncEvent(
     private val syncEventRepository: SyncEventRepository,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<EventUid, Unit> {
     override suspend fun invoke(input: EventUid): Result<Unit> =
         try {
@@ -14,6 +17,9 @@ internal class SyncEvent(
             syncEventRepository.downloadEvent(input)
             syncEventRepository.downloadFileResources(input)
             Result.success(Unit)
+        } catch (domainError: DomainError) {
+            sessionRenewalNotifier.notifyIfRequired(domainError)
+            Result.failure(domainError)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncMetadata.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncMetadata.kt
@@ -2,6 +2,7 @@ package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
 import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncBackgroundJobAction
 import org.dhis2.mobile.sync.data.SyncRepository
 import org.dhis2.mobile.sync.model.SMSConfigResult
@@ -12,6 +13,7 @@ private const val SYNC_METADATA_NAME = "SYNC_METADATA"
 class SyncMetadata(
     private val repository: SyncRepository,
     private val syncBackgroundJobAction: SyncBackgroundJobAction,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<(progress: Int) -> Unit, Unit> {
     override suspend fun invoke(input: (progress: Int) -> Unit): Result<Unit> =
         try {
@@ -60,8 +62,12 @@ class SyncMetadata(
                 Result.success(Unit)
             } else {
                 repository.saveMetadataSyncState(false)
+                sessionRenewalNotifier.notifyIfRequired(syncMetadataResult.exceptionOrNull())
                 Result.failure(syncMetadataResult.exceptionOrNull()!!)
             }
+        } catch (domainError: DomainError) {
+            sessionRenewalNotifier.notifyIfRequired(domainError)
+            Result.failure(domainError)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncProgram.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncProgram.kt
@@ -1,6 +1,8 @@
 package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncProgramRepository
 import org.dhis2.mobile.sync.model.ProgramType
 
@@ -9,6 +11,7 @@ internal typealias ProgramUid = String
 internal class SyncProgram(
     private val syncProgramRepository: SyncProgramRepository,
     private val syncStatusController: SyncStatusController,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<ProgramUid, Unit> {
     override suspend fun invoke(input: ProgramUid): Result<Unit> =
         try {
@@ -25,6 +28,9 @@ internal class SyncProgram(
             } else {
                 Result.failure(Exception("Status is not synced"))
             }
+        } catch (domainError: DomainError) {
+            sessionRenewalNotifier.notifyIfRequired(domainError)
+            Result.failure(domainError)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncTei.kt
+++ b/sync/src/commonMain/kotlin/org/dhis2/mobile/sync/domain/SyncTei.kt
@@ -1,12 +1,15 @@
 package org.dhis2.mobile.sync.domain
 
 import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncTeiRepository
 
 internal typealias EnrollmentUid = String
 
 internal class SyncTei(
     private val syncTeiRepository: SyncTeiRepository,
+    private val sessionRenewalNotifier: SessionRenewalNotifier,
 ) : UseCase<String, Unit> {
     override suspend fun invoke(input: EnrollmentUid): Result<Unit> =
         try {
@@ -15,6 +18,9 @@ internal class SyncTei(
             syncTeiRepository.downloadTei(enrollmentInfo)
             syncTeiRepository.downloadFileResources(enrollmentInfo)
             Result.success(Unit)
+        } catch (domainError: DomainError) {
+            sessionRenewalNotifier.notifyIfRequired(domainError)
+            Result.failure(domainError)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncDataSetTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncDataSetTest.kt
@@ -1,16 +1,20 @@
 package org.dhis2.mobile.sync.domain
 
 import kotlinx.coroutines.runBlocking
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncDataSetRepository
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SyncDataSetTest {
     private val repository: SyncDataSetRepository = mock()
-    private val useCase = SyncDataSet(repository)
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
+    private val useCase = SyncDataSet(repository, sessionRenewalNotifier)
 
     @Test
     fun `should return success and call all repository methods in order`() =
@@ -58,5 +62,21 @@ class SyncDataSetTest {
             val result = useCase(dataSetUid)
 
             assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `should request a session renewal when the tokens are no longer valid`() =
+        runBlocking {
+            // GIVEN
+            val dataSetUid = "dataSetUid"
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.uploadDataSet(dataSetUid)).thenAnswer { throw error }
+
+            // WHEN
+            val result = useCase(dataSetUid)
+
+            // THEN
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
         }
 }

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncDataTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncDataTest.kt
@@ -1,0 +1,110 @@
+package org.dhis2.mobile.sync.domain
+
+import kotlinx.coroutines.test.runTest
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
+import org.dhis2.mobile.sync.data.SyncRepository
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncDataTest {
+    private val repository: SyncRepository = mock()
+    private val syncStatusController: SyncStatusController = mock()
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
+
+    private val syncData =
+        SyncData(
+            repository = repository,
+            syncStatusController = syncStatusController,
+            sessionRenewalNotifier = sessionRenewalNotifier,
+        )
+
+    @Test
+    fun `GIVEN the tokens are no longer valid WHEN data is synced THEN a session renewal is requested`() =
+        runTest {
+            // GIVEN - the SDK cannot renew the tokens on its own, so no request reaches the server
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.isServerAvailable(any())).thenAnswer { throw error }
+
+            // WHEN
+            val result = syncData { }
+
+            // THEN - the sync still fails, but the app is told the user has to log in again:
+            // nothing else in the app can recover from this on its own
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyRenewalRequired()
+        }
+
+    @Test
+    fun `GIVEN the server is unavailable WHEN data is synced THEN no session renewal is requested`() =
+        runTest {
+            // GIVEN - a plain connectivity problem, which a later sync can retry
+            whenever(repository.isServerAvailable(any())) doReturn false
+
+            // WHEN
+            val result = syncData { }
+
+            // THEN - the user is not sent through a login they do not need
+            assertTrue(result.isFailure)
+            verify(sessionRenewalNotifier, never()).notifyRenewalRequired()
+        }
+
+    @Test
+    fun `GIVEN an upload fails because the session expired WHEN data is synced THEN a renewal is requested`() =
+        runTest {
+            // GIVEN - the repository reports failures as results rather than throwing them, which
+            // is how an expired session shows up during a data sync
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            stubSyncFlow()
+            whenever(repository.uploadEvents()) doReturn Result.failure(error)
+
+            // WHEN
+            val result = syncData { }
+
+            // THEN - the sync itself completes, and the user is told they have to log in again
+            // instead of the expired session being recorded as a plain sync failure
+            assertTrue(result.isSuccess)
+            verify(repository).saveDataSyncState(false)
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
+        }
+
+    @Test
+    fun `GIVEN every step succeeds WHEN data is synced THEN no renewal is requested`() =
+        runTest {
+            // GIVEN
+            stubSyncFlow()
+
+            // WHEN
+            val result = syncData { }
+
+            // THEN
+            assertTrue(result.isSuccess)
+            verify(repository).saveDataSyncState(true)
+            verify(sessionRenewalNotifier).notifyIfRequired(null)
+            verify(sessionRenewalNotifier, never()).notifyRenewalRequired()
+        }
+
+    private suspend fun stubSyncFlow() {
+        whenever(repository.isServerAvailable(any())) doReturn true
+        whenever(repository.getAllProgramsInitialStatus()) doReturn Result.success(emptyMap())
+        whenever(repository.uploadEvents()) doReturn Result.success(Unit)
+        whenever(repository.downloadEvents(any())) doReturn Result.success(Unit)
+        whenever(repository.getAllEventPrograms()) doReturn Result.success(emptyList())
+        whenever(repository.uploadTEIs()) doReturn Result.success(Unit)
+        whenever(repository.downloadTEIs(any())) doReturn Result.success(Unit)
+        whenever(repository.getAllTrackerPrograms()) doReturn Result.success(emptyList())
+        whenever(repository.uploadDataValues()) doReturn Result.success(Unit)
+        whenever(repository.downloadDataValues(any())) doReturn Result.success(Unit)
+        whenever(repository.getAllDataSets()) doReturn Result.success(emptyList())
+        whenever(repository.downloadDataFileResources(any())) doReturn Result.success(Unit)
+        whenever(repository.downloadReservedValues(any())) doReturn Result.success(Unit)
+        whenever(repository.saveDataSyncState(any())) doReturn Result.success(Unit)
+    }
+}

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncDataValueTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncDataValueTest.kt
@@ -1,17 +1,21 @@
 package org.dhis2.mobile.sync.domain
 
 import kotlinx.coroutines.runBlocking
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncDataValueRepository
 import org.dhis2.mobile.sync.model.SyncDataValueInput
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SyncDataValueTest {
     private val repository: SyncDataValueRepository = mock()
-    private val useCase = SyncDataValue(repository)
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
+    private val useCase = SyncDataValue(repository, sessionRenewalNotifier)
 
     private val input =
         SyncDataValueInput(
@@ -99,5 +103,28 @@ class SyncDataValueTest {
             val result = useCase(input)
 
             assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `should request a session renewal when the tokens are no longer valid`() =
+        runBlocking {
+            // GIVEN
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(
+                repository.uploadDataValues(
+                    dataSetUid = input.dataSetUid,
+                    orgUnitUid = input.orgUnitUid,
+                    periodId = input.periodId,
+                    attributeOptionComboUid = input.attrOptionComboUid,
+                    categoryOptionComboUids = input.categoryOptionComboUid,
+                ),
+            ).thenAnswer { throw error }
+
+            // WHEN
+            val result = useCase(input)
+
+            // THEN
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
         }
 }

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncEventTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncEventTest.kt
@@ -1,16 +1,20 @@
 package org.dhis2.mobile.sync.domain
 
 import kotlinx.coroutines.runBlocking
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncEventRepository
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SyncEventTest {
     private val repository: SyncEventRepository = mock()
-    private val useCase = SyncEvent(repository)
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
+    private val useCase = SyncEvent(repository, sessionRenewalNotifier)
 
     @Test
     fun `should return success and call all repository methods in order`() =
@@ -57,5 +61,22 @@ class SyncEventTest {
             val result = useCase(eventUid)
 
             assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `should request a session renewal when the tokens are no longer valid`() =
+        runBlocking {
+            // GIVEN - the repository reports the expired session as a domain error
+            val eventUid = "eventUid"
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.uploadEvent(eventUid)).thenAnswer { throw error }
+
+            // WHEN
+            val result = useCase(eventUid)
+
+            // THEN - the sync fails and the user is asked to log in again, instead of the error
+            // escaping the use case as a DomainError is not an Exception
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
         }
 }

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncMetadataTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncMetadataTest.kt
@@ -1,6 +1,8 @@
 package org.dhis2.mobile.sync.domain
 
 import kotlinx.coroutines.runBlocking
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncBackgroundJobAction
 import org.dhis2.mobile.sync.data.SyncRepository
 import org.dhis2.mobile.sync.model.SMSConfigResult
@@ -12,15 +14,18 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 
 class SyncMetadataTest {
     private val repository: SyncRepository = mock()
     private val syncBackgroundJobAction: SyncBackgroundJobAction = mock()
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
 
     private val syncMetadata =
         SyncMetadata(
             repository,
             syncBackgroundJobAction,
+            sessionRenewalNotifier,
         )
 
     @Test
@@ -128,5 +133,50 @@ class SyncMetadataTest {
             verify(repository).saveMetadataSyncState(false)
             assert(result.isFailure)
             assert(result.exceptionOrNull() == exception)
+        }
+
+    @Test
+    fun `Should request a session renewal when metadata cannot be synced with an expired session`() =
+        runBlocking {
+            // GIVEN - the tokens can no longer be refreshed, so the metadata call never lands
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.isServerAvailable(any())) doReturn true
+            whenever(repository.currentMetadataSyncPeriod()) doReturn SyncPeriod.Manual
+            whenever(repository.currentDataSyncPeriod()) doReturn SyncPeriod.Manual
+            whenever(repository.syncMetadata(any())) doReturn Result.failure(error)
+
+            val result = syncMetadata.invoke { }
+
+            // THEN - the failure is reported as before and the user is asked to log in again
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
+        }
+
+    @Test
+    fun `Should not request a session renewal when metadata syncs`() =
+        runBlocking {
+            whenever(repository.isServerAvailable(any())) doReturn true
+            whenever(repository.currentMetadataSyncPeriod()) doReturn SyncPeriod.Manual
+            whenever(repository.currentDataSyncPeriod()) doReturn SyncPeriod.Manual
+            whenever(repository.syncMetadata(any())) doReturn Result.success(Unit)
+
+            syncMetadata.invoke { }
+
+            verify(sessionRenewalNotifier, never()).notifyRenewalRequired()
+        }
+
+    @Test
+    fun `Should request a session renewal when the server check reports an expired session`() =
+        runBlocking {
+            // GIVEN - the ping itself fails because the tokens are gone
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.isServerAvailable(any())).thenAnswer { throw error }
+
+            // WHEN
+            val result = syncMetadata.invoke { }
+
+            // THEN - the use case reports it instead of letting it escape into the worker
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
         }
 }

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncProgramTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncProgramTest.kt
@@ -1,6 +1,8 @@
 package org.dhis2.mobile.sync.domain
 
 import kotlinx.coroutines.runBlocking
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncProgramRepository
 import org.dhis2.mobile.sync.model.ProgramType
 import org.junit.Test
@@ -8,12 +10,14 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SyncProgramTest {
     private val repository: SyncProgramRepository = mock()
     private val syncStatusController = SyncStatusController()
-    private val useCase = SyncProgram(repository, syncStatusController)
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
+    private val useCase = SyncProgram(repository, syncStatusController, sessionRenewalNotifier)
 
     @Test
     fun `should sync event program successfully when all events are synced`() =
@@ -95,5 +99,21 @@ class SyncProgramTest {
             val result = useCase(programUid)
 
             assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `should request a session renewal when the tokens are no longer valid`() =
+        runBlocking {
+            // GIVEN
+            val programUid = "programUid"
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.getProgramType(programUid)).thenAnswer { throw error }
+
+            // WHEN
+            val result = useCase(programUid)
+
+            // THEN
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
         }
 }

--- a/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncTeiTest.kt
+++ b/sync/src/commonTest/kotlin/org/dhis2/mobile/sync/domain/SyncTeiTest.kt
@@ -1,17 +1,21 @@
 package org.dhis2.mobile.sync.domain
 
 import kotlinx.coroutines.runBlocking
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.sync.data.SyncTeiRepository
 import org.dhis2.mobile.sync.model.EnrollmentInfo
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SyncTeiTest {
     private val repository: SyncTeiRepository = mock()
-    private val useCase = SyncTei(repository)
+    private val sessionRenewalNotifier: SessionRenewalNotifier = mock()
+    private val useCase = SyncTei(repository, sessionRenewalNotifier)
 
     private val enrollmentUid = "enrollmentUid"
     private val enrollmentInfo =
@@ -78,5 +82,20 @@ class SyncTeiTest {
             val result = useCase(enrollmentUid)
 
             assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `should request a session renewal when the tokens are no longer valid`() =
+        runBlocking {
+            // GIVEN
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.getEnrollmentInfo(enrollmentUid)).thenAnswer { throw error }
+
+            // WHEN
+            val result = useCase(enrollmentUid)
+
+            // THEN
+            assertEquals(error, result.exceptionOrNull())
+            verify(sessionRenewalNotifier).notifyIfRequired(error)
         }
 }


### PR DESCRIPTION
## Description

[JIRA ANDROAPP-7733](https://dhis2.atlassian.net/browse/ANDROAPP-7733)

**Part 4 of 7** splitting #5068. The second product bug.

`SyncData` collapsed its six step results into a single boolean before saving the sync state, so a `SessionRenewalRequiredError` raised by any step was recorded as "sync failed" and thrown away. It now inspects the step results and fires `SessionRenewalNotifier`, as does every other sync use case that can meet an expired session: metadata, dataset, data value, event, program and TEI.

`SyncMetadata` also gained a `DomainError` branch. `DomainError` extends `Throwable`, not `Exception`, so `catch (e: Exception)` was not catching it at all.

Tests cover one failing step at a time — a use case that inspects only its own final `Result` is exactly how the original bug hid.

### Not in this PR
- The UI that shows the dialog — Part 6.
- `SyncData` still returns `Result.success(Unit)` regardless of `isSuccess`. Pre-existing, left alone deliberately, and worth its own ticket.

**Depends on #5072** — merge after it.

---

### The stack

Replaces #5068. Merge #5070 first, then each chain in order; #5076 is independent of everything.

| Part | PR | Base | Lines |
|---|---|---|---|
| 1 | #5070 — commons: error mapping + renewal signal | `develop` | 334 |
| 2 | #5071 — sync: repositories via `withDomainErrors` | #5070 | 380 |
| 3 | #5072 — sync: expired session is not an unavailable server | #5071 | 85 |
| 4 | #5073 — sync: raise the renewal signal | #5072 | 349 |
| 5 | #5074 — login: renew from the credentials screen | #5070 | 360 |
| 6 | #5075 — app: dialog and routing | #5074 | 200 |
| 7 | #5076 — dev tool: force session expiry | `develop` | 403 (size check waived) |

The 55 changed files are byte-identical to #5068 — verified file by file — with one exception: the three-line `existingUsername = null` placeholder #5070 needs to compile on its own, which #5074 replaces.


---

### About the red Jenkins check

`continuous-integration/jenkins/pr-head` reports *"This commit cannot be built"*. That is structural, not a failure of this code: the `android-multibranch-PR` job only builds pull requests whose base is a long-lived branch, and this one is based on another PR's branch. Precedent: #5038 got the identical error and was merged.

Every GitHub Actions check is green here — lint, unit tests, build-test-apks, form tests, portrait and landscape UI tests, code-quality, SonarCloud. Jenkins goes green on its own once the parent merges and GitHub retargets this PR to `develop`.
