### PR TITLE
feat: [ANDROAPP-7733] Renew an expired session from the credentials screen

### DIFF
--- a/login/src/androidMain/kotlin/org/dhis2/mobile/login/main/data/LoginRepositoryImpl.kt
+++ b/login/src/androidMain/kotlin/org/dhis2/mobile/login/main/data/LoginRepositoryImpl.kt
@@ -183,13 +183,12 @@ class LoginRepositoryImpl(
         serverUrl: String,
         code: String,
         state: String,
+        expectedUsername: String?,
     ) = withContext(dispatcher.io) {
         try {
             val user =
                 d2.userModule().oauth2Handler().blockingHandleLogInResponse(
-                    // No account to check against yet: the renewal flow threads in the account
-                    // being restored so the SDK can refuse a session another user authorized.
-                    existingUsername = null,
+                    existingUsername = expectedUsername,
                     serverUrl = serverUrl,
                     authorizationCode = code,
                     state = state,

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/data/LoginRepository.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/data/LoginRepository.kt
@@ -74,10 +74,15 @@ interface LoginRepository {
         state: String,
     ): String
 
+    /**
+     * @param expectedUsername the account being restored, so the SDK can refuse a session that was
+     * authorized by a different user. Null when the account does not exist yet.
+     */
     suspend fun loginUserWithOAuth(
         serverUrl: String,
         code: String,
         state: String,
+        expectedUsername: String?,
     ): Result<String?>
 
     suspend fun buildLogoutUrl(serverUrl: String): String

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/di/LoginModule.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/di/LoginModule.kt
@@ -122,6 +122,7 @@ internal val mainLoginModule =
                 importDatabase = get { parametersOf(context) },
                 validateServer = get { parametersOf(context) },
                 networkStatusProvider = get(),
+                renewSession = parameters.getOrNull<Boolean>() ?: false,
             )
         }
         viewModel { parameters ->
@@ -133,6 +134,7 @@ internal val mainLoginModule =
             val context = parameters[5] as PlatformContext
             val entryMode = parameters[6] as CredentialsEntryMode
             val autoPromptLogin = parameters[7] as Boolean
+            val autoStartRenewal = parameters[8] as Boolean
             CredentialsViewModel(
                 navigator = get(),
                 getAvailableUsernames = get { parametersOf(context) },
@@ -163,6 +165,7 @@ internal val mainLoginModule =
                 loginUserOfflineWithCode = get { parametersOf(context) },
                 credentialsResourceProvider = get(),
                 getSessionRenewalUrl = get { parametersOf(context) },
+                autoStartRenewal = autoStartRenewal,
             )
         }
     }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/model/LoginScreenState.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/model/LoginScreenState.kt
@@ -24,6 +24,7 @@ sealed interface LoginScreenState {
         val allowRecovery: Boolean,
         val entryMode: CredentialsEntryMode,
         val autoPromptLogin: Boolean = true,
+        val autoStartRenewal: Boolean = false,
     ) : LoginScreenState
 
     @Serializable

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/GetInitialScreen.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/GetInitialScreen.kt
@@ -10,7 +10,7 @@ class GetInitialScreen(
     private val accountRepository: AccountRepository,
     private val sessionRepository: SessionRepository,
 ) {
-    suspend operator fun invoke(): LoginScreenState {
+    suspend operator fun invoke(renewSession: Boolean = false): LoginScreenState {
         val accounts = accountRepository.getLoggedInAccounts()
 
         return when {
@@ -21,13 +21,16 @@ class GetInitialScreen(
                     hasAccounts = false,
                 )
 
-            accounts.size == 1 -> handleSingleAccount(accounts.first())
-            sessionRepository.isSessionLocked() -> handleLockedSession()
+            accounts.size == 1 -> handleSingleAccount(accounts.first(), renewSession)
+            sessionRepository.isSessionLocked() -> handleLockedSession(renewSession)
             else -> LoginScreenState.Accounts
         }
     }
 
-    private fun handleSingleAccount(account: AccountModel): LoginScreenState =
+    private fun handleSingleAccount(
+        account: AccountModel,
+        renewSession: Boolean,
+    ): LoginScreenState =
         LoginScreenState.LoginCredentials(
             selectedServer = account.serverUrl,
             selectedUsername = account.name,
@@ -36,9 +39,10 @@ class GetInitialScreen(
             allowRecovery = account.allowRecovery,
             entryMode = CredentialsEntryMode.existing(account.authorizationMethod),
             autoPromptLogin = false,
+            autoStartRenewal = renewSession,
         )
 
-    private suspend fun handleLockedSession(): LoginScreenState {
+    private suspend fun handleLockedSession(renewSession: Boolean): LoginScreenState {
         val activeAccount = accountRepository.getActiveAccount() ?: return LoginScreenState.Accounts
         return LoginScreenState.LoginCredentials(
             selectedServer = activeAccount.serverUrl,
@@ -48,6 +52,7 @@ class GetInitialScreen(
             allowRecovery = activeAccount.allowRecovery,
             entryMode = CredentialsEntryMode.existing(activeAccount.authorizationMethod),
             autoPromptLogin = false,
+            autoStartRenewal = renewSession,
         )
     }
 }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/GetOAuthLogoutUrl.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/GetOAuthLogoutUrl.kt
@@ -2,7 +2,6 @@ package org.dhis2.mobile.login.main.domain.usecase
 
 import org.dhis2.mobile.commons.domain.UseCase
 import org.dhis2.mobile.commons.error.DomainError
-import org.dhis2.mobile.commons.logging.logDebug
 import org.dhis2.mobile.login.main.data.LoginRepository
 
 class GetOAuthLogoutUrl(
@@ -10,10 +9,8 @@ class GetOAuthLogoutUrl(
 ) : UseCase<String, String> {
     override suspend fun invoke(input: String): Result<String> =
         try {
-            val hardcodedUrl = "$input/dhis-web-commons-security/logout.action?redirect_uri=$REDIRECT_URI"
             val builtUrl = repository.buildLogoutUrl(input)
-            logDebug("GetOAuthLogoutUrl", "hardcodedUrl: $hardcodedUrl \n builtUrl: $builtUrl")
-            Result.success(hardcodedUrl)
+            Result.success(builtUrl)
         } catch (e: DomainError) {
             Result.failure(e)
         }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/LoginUserWithOAuth.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/LoginUserWithOAuth.kt
@@ -13,8 +13,9 @@ class LoginUserWithOAuth(
         serverUrl: String,
         code: String,
         state: String,
+        expectedUsername: String?,
     ): LoginResult {
-        val result = repository.loginUserWithOAuth(serverUrl, code, state)
+        val result = repository.loginUserWithOAuth(serverUrl, code, state, expectedUsername)
         return when {
             result.isSuccess -> {
                 val username = result.getOrNull()

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/CredentialsScreen.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/CredentialsScreen.kt
@@ -127,6 +127,7 @@ fun CredentialsScreen(
     oidcInfo: OidcInfo?,
     entryMode: CredentialsEntryMode,
     autoPromptLogin: Boolean,
+    autoStartRenewal: Boolean,
 ) {
     val context = LocalPlatformContext.current
 
@@ -141,6 +142,7 @@ fun CredentialsScreen(
                 context,
                 entryMode,
                 autoPromptLogin,
+                autoStartRenewal,
             )
         }
 

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/LoginScreen.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/LoginScreen.kt
@@ -86,9 +86,10 @@ fun LoginScreen(
     onNavigateToHome: () -> Unit,
     onNavigateToPrivacyPolicy: () -> Unit,
     onFinish: () -> Unit,
+    renewSession: Boolean = false,
 ) {
     val context = LocalPlatformContext.current
-    val viewModel = koinViewModel<LoginViewModel> { parametersOf(context) }
+    val viewModel = koinViewModel<LoginViewModel> { parametersOf(context, renewSession) }
     val fixedOidcInfo = koinInject<OidcInfo>()
     var displayMoreActions by remember { mutableStateOf(false) }
     var displayBackArrow by remember { mutableStateOf(false) }
@@ -212,6 +213,7 @@ fun LoginScreen(
                             },
                         entryMode = arg.entryMode,
                         autoPromptLogin = arg.autoPromptLogin,
+                        autoStartRenewal = arg.autoStartRenewal,
                     )
                 }
                 composable<LoginScreenState.OauthAuthentication> {

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/CredentialsViewModel.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/CredentialsViewModel.kt
@@ -80,6 +80,7 @@ class CredentialsViewModel(
     private val loginUserOfflineWithCode: LoginUserOffline,
     private val credentialsResourceProvider: CredentialsResourceProvider,
     private val getSessionRenewalUrl: GetSessionRenewalUrl,
+    private val autoStartRenewal: Boolean,
 ) : ViewModel() {
     companion object {
         private val COUNTDOWN_TICK_INTERVAL = 1.seconds
@@ -120,7 +121,7 @@ class CredentialsViewModel(
     private val isLockoutActive: Boolean
         get() = lockoutJob?.isActive == true
 
-    private var pendingOAuthLoginResult: LoginResult.Success? = null
+    private var pendingOAuthLoginResult: LoginResult? = null
 
     private var appLinkJob: Job? = null
 
@@ -173,6 +174,10 @@ class CredentialsViewModel(
     }
 
     private fun handleExistingOAuthAccount() {
+        if (autoStartRenewal) {
+            onRenewSession()
+            return
+        }
         launchUseCase {
             val biometricInfo = getBiometricInfo(serverUrl)
             _credentialsScreenState.update { current ->
@@ -268,6 +273,8 @@ class CredentialsViewModel(
             )
         }
         launchUseCase {
+            // An expired session is still open, the SDK refuses a new login. Login out before renew
+            logOutUser.invoke()
             getSessionRenewalUrl(
                 SessionRenewalRequest(
                     serverUrl = serverUrl,
@@ -376,35 +383,24 @@ class CredentialsViewModel(
                             serverUrl = serverUrl,
                             code = code,
                             state = state,
-                        )
-                    }
-                when (result) {
-                    is LoginResult.Success -> {
-                        // Defer entering the app until the server session cookie is cleared
-                        pendingOAuthLoginResult = result
-                        getOAuthLogoutUrl(serverUrl).fold(
-                            onSuccess = { logoutUrl ->
-                                navigator.navigate(
-                                    LoginScreenState.OauthAuthentication(
-                                        selectedServer = logoutUrl,
-                                    ),
-                                )
-                            },
-                            onFailure = {
-                                // Best-effort: proceed into the app if the logout URL can't be built
-                                completeOAuthLogin()
-                            },
+                            expectedUsername = username,
                         )
                     }
 
-                    is LoginResult.Error, is LoginResult.LockOut -> {
-                        stopListeningForOAuthCallbacks()
-                        handleLoginResult(result)
-                        _credentialsScreenState.update {
-                            it.copy(loginState = LoginState.Enabled)
-                        }
-                    }
-                }
+                pendingOAuthLoginResult = result
+
+                getOAuthLogoutUrl(serverUrl).fold(
+                    onSuccess = { logoutUrl ->
+                        navigator.navigate(
+                            LoginScreenState.OauthAuthentication(
+                                selectedServer = logoutUrl,
+                            ),
+                        )
+                    },
+                    onFailure = {
+                        completeOAuthLogin()
+                    },
+                )
             }
     }
 
@@ -413,7 +409,10 @@ class CredentialsViewModel(
         pendingOAuthLoginResult = null
         stopListeningForOAuthCallbacks()
         launchUseCase {
-            handleLoginResult(pending, sessionOpenedInBrowser = true)
+            handleLoginResult(
+                result = pending,
+                sessionOpenedInBrowser = pending is LoginResult.Success,
+            )
             _credentialsScreenState.update {
                 it.copy(loginState = LoginState.Enabled)
             }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/LoginViewModel.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/LoginViewModel.kt
@@ -26,6 +26,7 @@ class LoginViewModel(
     private val importDatabase: ImportDatabase,
     private val validateServer: ValidateServer,
     private val networkStatusProvider: NetworkStatusProvider,
+    private val renewSession: Boolean = false,
 ) : ViewModel() {
     private val _serverValidationState = MutableStateFlow(ServerValidationUiState())
     val serverValidationState = _serverValidationState.asStateFlow()
@@ -41,7 +42,7 @@ class LoginViewModel(
 
     private fun goToInitialScreen() {
         launchUseCase {
-            val destination = getInitialScreen()
+            val destination = getInitialScreen(renewSession)
             navigator.navigate(
                 destination = destination,
                 navOptions = {

--- a/login/src/commonTest/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/CredentialsViewModelTest.kt
+++ b/login/src/commonTest/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/CredentialsViewModelTest.kt
@@ -43,8 +43,10 @@ import org.dhis2.mobile.login.main.ui.state.OidcInfo
 import org.dhis2.mobile.login.pin.domain.usecase.ForgotPinUseCase
 import org.dhis2.mobile.login.pin.domain.usecase.GetIsSessionLockedUseCase
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -576,7 +578,7 @@ class CredentialsViewModelTest {
             whenever(getDeviceEnrollmentUrl(any())) doReturn Result.success(enrollmentUrl)
             whenever(getOAuthLogoutUrl(any())) doReturn Result.success(logoutUrl)
             whenever(
-                loginUserWithOAuth.invoke(any(), any(), any()),
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
             ) doReturn LoginResult.Success(initialSyncDone = true, displayTrackingMessage = false)
 
             initViewModel(
@@ -606,6 +608,7 @@ class CredentialsViewModelTest {
                     serverUrl = serverUrl,
                     code = authCode,
                     state = state,
+                    expectedUsername = "testuser",
                 )
 
                 // THEN - the server session is cleared before entering the app:
@@ -655,6 +658,7 @@ class CredentialsViewModelTest {
             val appLinkUrl = "https://test.redirect.org?code=$authCode&state=$state"
             val mockAppLinkFlow = MutableSharedFlow<String>()
             val enrollmentUrl = "https://test.server.org/oauth2/enrollment"
+            val logoutUrl = "$serverUrl/logout"
             val deviceNotRegisteredMessage = "Device not registered"
 
             whenever(getAvailableUsernames()) doReturn emptyList()
@@ -663,8 +667,9 @@ class CredentialsViewModelTest {
             whenever(getIsSessionLockedUseCase(any())) doReturn false
             whenever(appLinkNavigation.appLink) doReturn mockAppLinkFlow
             whenever(getDeviceEnrollmentUrl(any())) doReturn Result.success(enrollmentUrl)
+            whenever(getOAuthLogoutUrl(any())) doReturn Result.success(logoutUrl)
             whenever(
-                loginUserWithOAuth.invoke(any(), any(), any()),
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
             ) doReturn LoginResult.Error(deviceNotRegisteredMessage)
 
             initViewModel(
@@ -687,20 +692,30 @@ class CredentialsViewModelTest {
                     serverUrl = serverUrl,
                     code = authCode,
                     state = state,
+                    expectedUsername = "testuser",
                 )
 
-                // THEN - the device-not-registered message is shown and the user does not enter
-                // the app: no logout hop and no post-login actions
+                // THEN - the browser session is cleared even though the login failed, or the
+                // next attempt would silently reuse the account that just failed
+                verify(navigator).navigate(
+                    eq(LoginScreenState.OauthAuthentication(selectedServer = logoutUrl)),
+                    any(),
+                )
+
+                // WHEN - the logout redirect returns
+                mockAppLinkFlow.emit("https://test.redirect.org?state=$state")
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - the message is shown and the user does not enter the app
                 val errorState = expectMostRecentItem()
                 assertEquals(deviceNotRegisteredMessage, errorState.errorMessage)
                 assertEquals(LoginState.Enabled, errorState.loginState)
                 assertTrue(errorState.afterLoginActions.isEmpty())
-                verify(getOAuthLogoutUrl, never()).invoke(any())
 
                 // AND - the OAuth flow is over, so later app links are ignored
                 mockAppLinkFlow.emit("https://test.redirect.org?code=late_code&state=$state")
                 testDispatcher.scheduler.advanceUntilIdle()
-                verify(loginUserWithOAuth, never()).invoke(any(), eq("late_code"), any())
+                verify(loginUserWithOAuth, never()).invoke(any(), eq("late_code"), any(), anyOrNull())
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -818,7 +833,7 @@ class CredentialsViewModelTest {
                 // AND - the OAuth flow is over, so later app links are ignored
                 mockAppLinkFlow.emit("https://test.redirect.org?code=late_code&state=$state")
                 testDispatcher.scheduler.advanceUntilIdle()
-                verify(loginUserWithOAuth, never()).invoke(any(), any(), any())
+                verify(loginUserWithOAuth, never()).invoke(any(), any(), any(), anyOrNull())
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -863,7 +878,7 @@ class CredentialsViewModelTest {
                 // AND - the OAuth flow is over, so later app links are ignored
                 mockAppLinkFlow.emit("https://test.redirect.org?code=late_code&state=$state")
                 testDispatcher.scheduler.advanceUntilIdle()
-                verify(loginUserWithOAuth, never()).invoke(any(), any(), any())
+                verify(loginUserWithOAuth, never()).invoke(any(), any(), any(), anyOrNull())
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -889,7 +904,7 @@ class CredentialsViewModelTest {
             whenever(getDeviceEnrollmentUrl(any())) doReturn Result.success(enrollmentUrl)
             whenever(getOAuthLogoutUrl(any())) doReturn Result.success(logoutUrl)
             whenever(
-                loginUserWithOAuth.invoke(any(), any(), any()),
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
             ) doReturn LoginResult.Success(initialSyncDone = true, displayTrackingMessage = false)
 
             val staleViewModel =
@@ -923,6 +938,7 @@ class CredentialsViewModelTest {
                     serverUrl = oauthServerUrl,
                     code = authCode,
                     state = state,
+                    expectedUsername = null,
                 )
                 val finalState = expectMostRecentItem()
                 assertEquals(LoginState.Enabled, finalState.loginState)
@@ -934,7 +950,7 @@ class CredentialsViewModelTest {
             }
 
             // AND - the stale view model never consumed the callbacks
-            verify(loginUserWithOAuth, never()).invoke(eq(staleServerUrl), any(), any())
+            verify(loginUserWithOAuth, never()).invoke(eq(staleServerUrl), any(), any(), anyOrNull())
             assertTrue(
                 staleViewModel.credentialsScreenState.value.afterLoginActions
                     .isEmpty(),
@@ -1405,7 +1421,7 @@ class CredentialsViewModelTest {
             whenever(getSessionRenewalUrl(any())) doReturn Result.success(authorizationUrl)
             whenever(getOAuthLogoutUrl(any())) doReturn Result.success("$serverUrl/logout")
             whenever(
-                loginUserWithOAuth.invoke(any(), any(), any()),
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
             ) doReturn LoginResult.Success(initialSyncDone = true, displayTrackingMessage = false)
 
             initViewModel(
@@ -1440,6 +1456,7 @@ class CredentialsViewModelTest {
                     serverUrl = serverUrl,
                     code = authCode,
                     state = state,
+                    expectedUsername = "testuser",
                 )
 
                 cancelAndIgnoreRemainingEvents()
@@ -1503,7 +1520,7 @@ class CredentialsViewModelTest {
             whenever(getSessionRenewalUrl(any())) doReturn Result.success(authorizationUrl)
             whenever(getOAuthLogoutUrl(any())) doReturn Result.success(logoutUrl)
             whenever(
-                loginUserWithOAuth.invoke(any(), any(), any()),
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
             ) doReturn LoginResult.Success(initialSyncDone = true, displayTrackingMessage = false)
 
             initViewModel(
@@ -1683,7 +1700,7 @@ class CredentialsViewModelTest {
             whenever(getSessionRenewalUrl(any())) doReturn Result.success(authorizationUrl)
             whenever(getOAuthLogoutUrl(any())) doReturn Result.success("$serverUrl/logout")
             whenever(
-                loginUserWithOAuth.invoke(any(), any(), any()),
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
             ) doReturn LoginResult.Success(initialSyncDone = true, displayTrackingMessage = false)
             whenever(setOAuthPin("5678")) doReturn
                 Result.failure(DomainError.AuthenticationError(storeErrorMessage))
@@ -1714,11 +1731,223 @@ class CredentialsViewModelTest {
                 // THEN - the account cannot be left without an offline credential, so the session
                 // just renewed is closed and the reason is shown. Note this also gives up the
                 // renewed tokens: the user has to renew again to reach the server
-                verify(loginOutUser).invoke()
+                // Twice: once when the renewal started, once now that it cannot be completed
+                verify(loginOutUser, times(2)).invoke()
                 val failedState = expectMostRecentItem()
                 assertEquals(storeErrorMessage, failedState.errorMessage)
                 assertTrue(failedState.afterLoginActions.isEmpty())
                 assertEquals(LoginState.Enabled, failedState.loginState)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN the screen is opened to renew the session WHEN it loads THEN the browser opens right away`() =
+        runTest {
+            // GIVEN - the user already accepted renewing in the expired-session dialog, so nothing
+            // else should be asked of them here
+            val serverUrl = "https://test.server.org"
+            val authorizationUrl = "$serverUrl/oauth2/authorize"
+
+            whenever(getAvailableUsernames()) doReturn emptyList()
+            whenever(getBiometricInfo(any())) doReturn BiometricsInfo(false, false)
+            whenever(getHasOtherAccounts.invoke()) doReturn false
+            whenever(getIsSessionLockedUseCase(any())) doReturn true
+            whenever(getSessionRenewalUrl(any())) doReturn Result.success(authorizationUrl)
+
+            // WHEN
+            initViewModel(
+                serverUrl = serverUrl,
+                username = "testuser",
+                entryMode = CredentialsEntryMode.EXISTING_OAUTH,
+                autoStartRenewal = true,
+            )
+
+            viewModel.credentialsScreenState.test(timeout = turbineTimeout) {
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - the browser is opened without a tap, and the offline dialog is not left
+                // sitting behind it
+                verify(navigator).navigate(
+                    eq(LoginScreenState.OauthAuthentication(selectedServer = authorizationUrl)),
+                    any(),
+                )
+                assertFalse(expectMostRecentItem().isSessionLocked)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN the screen is opened normally WHEN it loads THEN no renewal is started`() =
+        runTest {
+            // GIVEN - the ordinary landing on an existing OAuth account
+            whenever(getAvailableUsernames()) doReturn emptyList()
+            whenever(getBiometricInfo(any())) doReturn BiometricsInfo(false, false)
+            whenever(getHasOtherAccounts.invoke()) doReturn false
+            whenever(getIsSessionLockedUseCase(any())) doReturn false
+
+            // WHEN
+            initViewModel(
+                entryMode = CredentialsEntryMode.EXISTING_OAUTH,
+                autoPromptLogin = false,
+            )
+
+            viewModel.credentialsScreenState.test(timeout = turbineTimeout) {
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - the user decides when to go through the browser
+                verify(getSessionRenewalUrl, never()).invoke(any())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a new OAuth account WHEN the authorization code arrives THEN no account is expected`() =
+        runTest {
+            // GIVEN - a first login: there is no account on this device to compare the session to
+            val serverUrl = "https://test.server.org"
+            val authCode = "auth_code_123"
+            val state = "test"
+            val mockAppLinkFlow = MutableSharedFlow<String>()
+
+            whenever(getAvailableUsernames()) doReturn emptyList()
+            whenever(getBiometricInfo(any())) doReturn BiometricsInfo(false, false)
+            whenever(getHasOtherAccounts.invoke()) doReturn false
+            whenever(getIsSessionLockedUseCase(any())) doReturn false
+            whenever(appLinkNavigation.appLink) doReturn mockAppLinkFlow
+            whenever(getDeviceEnrollmentUrl(any())) doReturn Result.success("$serverUrl/enroll")
+            whenever(getOAuthLogoutUrl(any())) doReturn Result.success("$serverUrl/logout")
+            whenever(
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
+            ) doReturn LoginResult.Success(initialSyncDone = true, displayTrackingMessage = false)
+
+            initViewModel(
+                serverUrl = serverUrl,
+                username = null,
+                entryMode = CredentialsEntryMode.NEW_ACCOUNT_OAUTH,
+            )
+
+            viewModel.credentialsScreenState.test(timeout = turbineTimeout) {
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // WHEN
+                mockAppLinkFlow.emit("https://test.redirect.org?code=$authCode&state=$state")
+                testDispatcher.scheduler.advanceUntilIdle()
+                testDispatcher.scheduler.advanceTimeBy(4.seconds)
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - no username is sent, so the SDK has no mismatch to reject
+                verify(loginUserWithOAuth).invoke(
+                    serverUrl = serverUrl,
+                    code = authCode,
+                    state = state,
+                    expectedUsername = null,
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a session still open WHEN it is renewed THEN the account is logged out first`() =
+        runTest {
+            // GIVEN - an expired session is still an open session: the SDK refuses to log in again
+            // while credentials are stored, which is what the offline code entry runs into
+            val serverUrl = "https://test.server.org"
+            val authorizationUrl = "$serverUrl/oauth2/authorize"
+
+            whenever(getAvailableUsernames()) doReturn emptyList()
+            whenever(getBiometricInfo(any())) doReturn BiometricsInfo(false, false)
+            whenever(getHasOtherAccounts.invoke()) doReturn false
+            whenever(getIsSessionLockedUseCase(any())) doReturn false
+            whenever(getSessionRenewalUrl(any())) doReturn Result.success(authorizationUrl)
+
+            initViewModel(
+                serverUrl = serverUrl,
+                username = "testuser",
+                entryMode = CredentialsEntryMode.EXISTING_OAUTH,
+                autoPromptLogin = false,
+            )
+
+            viewModel.credentialsScreenState.test(timeout = turbineTimeout) {
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // WHEN
+                viewModel.onRenewSession()
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - the session is closed before the browser opens, so both the renewal and
+                // the offline code are accepted afterwards. The account and its data are kept
+                inOrder(loginOutUser, navigator) {
+                    verify(loginOutUser).invoke()
+                    verify(navigator).navigate(
+                        eq(LoginScreenState.OauthAuthentication(selectedServer = authorizationUrl)),
+                        any(),
+                    )
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a renewal authorized by another user WHEN it fails THEN the browser session is cleared`() =
+        runTest {
+            // GIVEN - the browser held a session for somebody else, so the SDK refuses the login
+            val serverUrl = "https://test.server.org"
+            val authorizationUrl = "$serverUrl/oauth2/authorize"
+            val logoutUrl = "$serverUrl/logout"
+            val state = "test"
+            val mismatchMessage = "You logged in with a different account"
+            val mockAppLinkFlow = MutableSharedFlow<String>()
+
+            whenever(getAvailableUsernames()) doReturn emptyList()
+            whenever(getBiometricInfo(any())) doReturn BiometricsInfo(false, false)
+            whenever(getHasOtherAccounts.invoke()) doReturn false
+            whenever(getIsSessionLockedUseCase(any())) doReturn false
+            whenever(appLinkNavigation.appLink) doReturn mockAppLinkFlow
+            whenever(getSessionRenewalUrl(any())) doReturn Result.success(authorizationUrl)
+            whenever(getOAuthLogoutUrl(any())) doReturn Result.success(logoutUrl)
+            whenever(
+                loginUserWithOAuth.invoke(any(), any(), any(), anyOrNull()),
+            ) doReturn LoginResult.Error(mismatchMessage)
+
+            initViewModel(
+                serverUrl = serverUrl,
+                username = "testuser",
+                entryMode = CredentialsEntryMode.EXISTING_OAUTH,
+                autoPromptLogin = false,
+            )
+
+            viewModel.credentialsScreenState.test(timeout = turbineTimeout) {
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                viewModel.onRenewSession()
+                testDispatcher.scheduler.advanceUntilIdle()
+                mockAppLinkFlow.emit("https://test.redirect.org?code=auth_code_123&state=$state")
+                testDispatcher.scheduler.advanceUntilIdle()
+                testDispatcher.scheduler.advanceTimeBy(4.seconds)
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - the browser is sent through the logout, so the next attempt can ask for
+                // credentials again instead of reusing the account that just failed
+                verify(navigator).navigate(
+                    eq(LoginScreenState.OauthAuthentication(selectedServer = logoutUrl)),
+                    any(),
+                )
+
+                // WHEN - the logout redirect returns
+                mockAppLinkFlow.emit("https://test.redirect.org?state=$state")
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // THEN - and only then the user is told what happened
+                val errorState = expectMostRecentItem()
+                assertEquals(mismatchMessage, errorState.errorMessage)
+                assertEquals(LoginState.Enabled, errorState.loginState)
+                assertTrue(errorState.afterLoginActions.isEmpty())
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -1733,6 +1962,7 @@ class CredentialsViewModelTest {
         autoPromptLogin: Boolean = true,
         oidcInfo: OidcInfo? = null,
         appLinkNavigation: AppLinkNavigation = this.appLinkNavigation,
+        autoStartRenewal: Boolean = false,
     ): CredentialsViewModel {
         viewModel =
             CredentialsViewModel(
@@ -1765,6 +1995,7 @@ class CredentialsViewModelTest {
                 loginUserOfflineWithCode = loginUserOfflineWithCode,
                 credentialsResourceProvider = credentialsResourceProvider,
                 getSessionRenewalUrl = getSessionRenewalUrl,
+                autoStartRenewal = autoStartRenewal,
             )
         return viewModel
     }


### PR DESCRIPTION
## Description

[JIRA ANDROAPP-7733](https://dhis2.atlassian.net/browse/ANDROAPP-7733)

**Part 5 of 7** splitting #5068. The login side of the renewal; 259 of its ~360 lines are `CredentialsViewModelTest`.

A `renewSession` flag travels from the login entry point through `GetInitialScreen` into `CredentialsViewModel`, so the app can land on the credentials screen with the browser renewal already starting — and if the user closes the custom tab, they are left on a normal credentials screen and can keep working offline.

`onRenewSession()` logs out first: the SDK throws `ALREADY_AUTHENTICATED` while credentials exist. It clears the session lock, and takes the logout hop every time, because `buildAuthorizationUrl` has no `prompt` parameter and the browser would otherwise reuse a dead session.

`expectedUsername` is now threaded into the OAuth login, so the SDK can refuse a session that a different user authorized (this replaces the `existingUsername = null` placeholder from Part 1), and `GetOAuthLogoutUrl` drops its hardcoded URL in favour of the one the SDK builds.

### Not in this PR
- The dialog and the routing into this flow — Part 6.
- `EXISTING_OPEN_ID` still uses the old path; moving it onto this flow is ANDROAPP-7756.

**Depends on #5070** — merge after it.

---

### The stack

Replaces #5068. Merge #5070 first, then each chain in order; #5076 is independent of everything.

| Part | PR | Base | Lines |
|---|---|---|---|
| 1 | #5070 — commons: error mapping + renewal signal | `develop` | 334 |
| 2 | #5071 — sync: repositories via `withDomainErrors` | #5070 | 380 |
| 3 | #5072 — sync: expired session is not an unavailable server | #5071 | 85 |
| 4 | #5073 — sync: raise the renewal signal | #5072 | 349 |
| 5 | #5074 — login: renew from the credentials screen | #5070 | 360 |
| 6 | #5075 — app: dialog and routing | #5074 | 200 |
| 7 | #5076 — dev tool: force session expiry | `develop` | 403 (size check waived) |

The 55 changed files are byte-identical to #5068 — verified file by file — with one exception: the three-line `existingUsername = null` placeholder #5070 needs to compile on its own, which #5074 replaces.


---

### About the red Jenkins check

`continuous-integration/jenkins/pr-head` reports *"This commit cannot be built"*. That is structural, not a failure of this code: the `android-multibranch-PR` job only builds pull requests whose base is a long-lived branch, and this one is based on another PR's branch. Precedent: #5038 got the identical error and was merged.

Every GitHub Actions check is green here — lint, unit tests, build-test-apks, form tests, portrait and landscape UI tests, code-quality, SonarCloud. Jenkins goes green on its own once the parent merges and GitHub retargets this PR to `develop`.
