### PR TITLE
feat: [ANDROAPP-7733] Show the session renewal dialog and route to login

### DIFF
--- a/app/src/main/java/org/dhis2/data/server/OpenIdSession.kt
+++ b/app/src/main/java/org/dhis2/data/server/OpenIdSession.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
-import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import org.dhis2.commons.schedulers.SchedulerProvider
 import org.dhis2.commons.schedulers.defaultSubscribe
@@ -23,7 +22,6 @@ class OpenIdSession(
     private var sessionCallback: (LogOutReason) -> Unit = { Timber.log(1, EMPTY_CALLBACK) }
 
     enum class LogOutReason {
-        OPEN_ID,
         DISABLED_ACCOUNT,
     }
 
@@ -38,20 +36,13 @@ class OpenIdSession(
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun onCreate() {
         disposable.add(
-            Observable
-                .merge(
-                    d2
-                        .userModule()
-                        .openIdHandler()
-                        .logOutObservable()
-                        .map { LogOutReason.OPEN_ID },
-                    d2
-                        .userModule()
-                        .accountManager()
-                        .accountDeletionObservable()
-                        .filter { it == AccountDeletionReason.ACCOUNT_DISABLED }
-                        .map { LogOutReason.DISABLED_ACCOUNT },
-                ).defaultSubscribe(
+            d2
+                .userModule()
+                .accountManager()
+                .accountDeletionObservable()
+                .filter { it == AccountDeletionReason.ACCOUNT_DISABLED }
+                .map { LogOutReason.DISABLED_ACCOUNT }
+                .defaultSubscribe(
                     schedulerProvider,
                     { sessionCallback(it) },
                     { Timber.e(it) },

--- a/app/src/main/java/org/dhis2/usescases/general/SessionManagerActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/general/SessionManagerActivity.kt
@@ -6,7 +6,9 @@ import android.os.Bundle
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import io.reactivex.subjects.BehaviorSubject
 import kotlinx.coroutines.launch
 import org.dhis2.App
@@ -20,9 +22,11 @@ import org.dhis2.commons.service.SessionManagerServiceImpl
 import org.dhis2.commons.ui.extensions.handleInsets
 import org.dhis2.data.server.OpenIdSession.LogOutReason
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.mobile.commons.session.SessionRenewalNotifier
 import org.dhis2.mobile.login.pin.addPinBottomSheet
 import org.dhis2.mobile.login.pin.domain.model.PinMode
 import org.dhis2.mobile.sync.domain.SyncStatusController
+import org.dhis2.usescases.general.ui.SessionRenewalDialog
 import org.dhis2.usescases.login.LoginActivity
 import org.dhis2.usescases.login.LoginActivity.Companion.bundle
 import org.dhis2.usescases.main.MainActivity
@@ -56,6 +60,8 @@ abstract class SessionManagerActivity :
         BehaviorSubject.create()
 
     val syncStatusController: SyncStatusController by inject()
+
+    private val sessionRenewalNotifier: SessionRenewalNotifier by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val serverComponent = (applicationContext as App).serverComponent
@@ -107,6 +113,8 @@ abstract class SessionManagerActivity :
         if (handleEdgeToEdge) handleInsets()
 
         super.onCreate(savedInstanceState)
+
+        observeSessionRenewalRequests()
     }
 
     override fun onUserInteraction() {
@@ -202,6 +210,35 @@ abstract class SessionManagerActivity :
             activityResultObserver = null
         }
         super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun observeSessionRenewalRequests() {
+        if (this is LoginActivity || this is SplashActivity) return
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                sessionRenewalNotifier.renewalRequired.collect {
+                    showSessionRenewalDialog()
+                }
+            }
+        }
+    }
+
+    private fun showSessionRenewalDialog() {
+        SessionRenewalDialog(
+            onNotNow = {
+                sessionRenewalNotifier.consume()
+            },
+            onLogInAgain = {
+                sessionRenewalNotifier.consume()
+                startActivity(
+                    LoginActivity::class.java,
+                    bundle(renewSession = true),
+                    true,
+                    true,
+                    null,
+                )
+            },
+        ).show(supportFragmentManager)
     }
 
     private fun checkSessionTimeout() {

--- a/app/src/main/java/org/dhis2/usescases/general/ui/SessionRenewalDialog.kt
+++ b/app/src/main/java/org/dhis2/usescases/general/ui/SessionRenewalDialog.kt
@@ -1,0 +1,110 @@
+package org.dhis2.usescases.general.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import org.dhis2.R
+import org.hisp.dhis.mobile.ui.designsystem.component.Button
+import org.hisp.dhis.mobile.ui.designsystem.theme.DHIS2Theme
+
+const val SESSION_RENEWAL_DIALOG_TAG = "SessionRenewalDialog"
+const val SESSION_RENEWAL_CONFIRM_BUTTON_TAG = "SESSION_RENEWAL_CONFIRM_BUTTON_TAG"
+
+class SessionRenewalDialog(
+    private val onNotNow: () -> Unit,
+    private val onLogInAgain: () -> Unit,
+) : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        dialog.window!!.requestFeature(Window.FEATURE_NO_TITLE)
+        dialog.window!!.setBackgroundDrawableResource(android.R.color.transparent)
+        isCancelable = false
+        return dialog
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View =
+        ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnDetachedFromWindow,
+            )
+            setContent {
+                DHIS2Theme {
+                    SessionRenewalDialogUi(
+                        onNotNow = {
+                            dismiss()
+                            onNotNow()
+                        },
+                        onLogInAgain = {
+                            dismiss()
+                            onLogInAgain()
+                        },
+                    )
+                }
+            }
+        }
+
+    fun show(manager: FragmentManager) {
+        if (manager.findFragmentByTag(SESSION_RENEWAL_DIALOG_TAG) != null) return
+        super.show(manager, SESSION_RENEWAL_DIALOG_TAG)
+    }
+}
+
+@Composable
+private fun SessionRenewalDialogUi(
+    onNotNow: () -> Unit,
+    onLogInAgain: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onNotNow,
+        title = {
+            Text(
+                text = stringResource(R.string.session_renewal_title),
+                textAlign = TextAlign.Center,
+            )
+        },
+        text = {
+            Text(text = stringResource(R.string.session_renewal_message))
+        },
+        icon = {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_lock_inactive),
+                tint = MaterialTheme.colorScheme.primary,
+                contentDescription = "session expired alert",
+            )
+        },
+        confirmButton = {
+            Button(
+                text = stringResource(R.string.session_renewal_action),
+                modifier = Modifier.testTag(SESSION_RENEWAL_CONFIRM_BUTTON_TAG),
+                onClick = onLogInAgain,
+            )
+        },
+        dismissButton = {
+            Button(
+                text = stringResource(R.string.sync_dialog_action_not_now),
+                onClick = onNotNow,
+            )
+        },
+    )
+}

--- a/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/login/LoginActivity.kt
@@ -29,8 +29,8 @@ import javax.inject.Inject
 import kotlin.getValue
 
 const val EXTRA_SKIP_SYNC = "SKIP_SYNC"
-const val EXTRA_SESSION_EXPIRED = "EXTRA_SESSION_EXPIRED"
 const val EXTRA_ACCOUNT_DISABLED = "EXTRA_ACCOUNT_DISABLED"
+const val EXTRA_RENEW_SESSION = "EXTRA_RENEW_SESSION"
 const val IS_DELETION = "IS_DELETION"
 const val ACCOUNTS_COUNT = "ACCOUNTS_COUNT"
 const val FROM_SPLASH = "FROM_SPLASH"
@@ -55,14 +55,15 @@ class LoginActivity : ActivityGlobalAbstract() {
             isDeletion: Boolean = false,
             logOutReason: OpenIdSession.LogOutReason? = null,
             fromSplash: Boolean = false,
+            renewSession: Boolean = false,
         ): Bundle =
             Bundle().apply {
                 putBoolean(EXTRA_SKIP_SYNC, skipSync)
                 putBoolean(IS_DELETION, isDeletion)
                 putInt(ACCOUNTS_COUNT, accountsCount)
                 putBoolean(FROM_SPLASH, fromSplash)
+                putBoolean(EXTRA_RENEW_SESSION, renewSession)
                 when (logOutReason) {
-                    OpenIdSession.LogOutReason.OPEN_ID -> putBoolean(EXTRA_SESSION_EXPIRED, true)
                     OpenIdSession.LogOutReason.DISABLED_ACCOUNT ->
                         putBoolean(
                             EXTRA_ACCOUNT_DISABLED,
@@ -109,6 +110,7 @@ class LoginActivity : ActivityGlobalAbstract() {
                     onFinish = {
                         finish()
                     },
+                    renewSession = intent.getBooleanExtra(EXTRA_RENEW_SESSION, false),
                 )
             }
         }
@@ -145,26 +147,9 @@ class LoginActivity : ActivityGlobalAbstract() {
     }
 
     private fun checkMessage() {
-        if (intent.getBooleanExtra(EXTRA_SESSION_EXPIRED, false)) {
-            showSessionExpired()
-        } else if (intent.getBooleanExtra(EXTRA_ACCOUNT_DISABLED, false)) {
+        if (intent.getBooleanExtra(EXTRA_ACCOUNT_DISABLED, false)) {
             showAccountDisabled()
         }
-    }
-
-    private fun showSessionExpired() {
-        val sessionDialog =
-            CustomDialog(
-                this,
-                getString(R.string.openid_session_expired),
-                getString(R.string.openid_session_expired_message),
-                getString(R.string.action_accept),
-                null,
-                SESSION_DIALOG_RQ,
-                null,
-            )
-        sessionDialog.setCancelable(false)
-        sessionDialog.show()
     }
 
     private fun showAccountDisabled() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,8 +481,6 @@
     <string name="take_photo">Take Photo</string>
     <string name="break_glass_dialog_title">This program is protected</string>
     <string name="break_glass_hint">Describe the reason here</string>
-    <string name="openid_session_expired">The session has expired</string>
-    <string name="openid_session_expired_message">Your current session has expired. For security reasons you will need to provide your credentials again</string>
     <string name="period_span_default_label" translatable="false">%s - %s</string>
     <string name="week_period_span_default_label">Week %d %s to %s</string>
     <string name="biweek_period_span_default_label" translatable="false">%d %s - %d %s</string>
@@ -556,6 +554,9 @@
     <string name="sync_dialog_action_send">Send</string>
     <string name="sync_dialog_action_refresh">Refresh</string>
     <string name="sync_dialog_action_not_now">Not now</string>
+    <string name="session_renewal_title">Your session has expired</string>
+    <string name="session_renewal_message">Log in again to sync with the server. You can keep working offline and log in later.</string>
+    <string name="session_renewal_action">Log in again</string>
     <string name="tap_to_explore_action">Tap here to explore</string>
     <string name="new_version_message">App version <b>%s</b> is now available. Do you want to download it?</string>
     <string name="software_update">Software update</string>


### PR DESCRIPTION
## Description

[JIRA ANDROAPP-7733](https://dhis2.atlassian.net/browse/ANDROAPP-7733)

**Part 6 of 7** splitting #5068. The user-visible end.

Every session-managed activity observes `SessionRenewalNotifier` while resumed and interrupts with a dialog: **Not now** keeps the user working offline, **Log in again** opens the login with `renewSession = true` so the renewal starts without another tap. Login and splash are excluded — the login screen reports this itself. The dialog follows `NewVersionDialog`.

The dead OpenID `LogOutReason.OPEN_ID` path goes with it, along with its two `values/strings.xml` entries: that observable forced a logout on an expired token, which is the behaviour this feature replaces.

The `openid_session_expired*` keys survive in the translated `values-*` files; the Transifex sync reaps those.

### Not in this PR
- The dialog copy does not yet match the wording the acceptance criteria ask for ("Connection expired" / "Reconnect" / "Continue offline"). Flagged, not fixed here.

**Depends on #5074** — merge after it.

---

### The stack

Replaces #5068. Merge #5070 first, then each chain in order; #5076 is independent of everything.

| Part | PR | Base | Lines |
|---|---|---|---|
| 1 | #5070 — commons: error mapping + renewal signal | `develop` | 334 |
| 2 | #5071 — sync: repositories via `withDomainErrors` | #5070 | 380 |
| 3 | #5072 — sync: expired session is not an unavailable server | #5071 | 85 |
| 4 | #5073 — sync: raise the renewal signal | #5072 | 349 |
| 5 | #5074 — login: renew from the credentials screen | #5070 | 360 |
| 6 | #5075 — app: dialog and routing | #5074 | 200 |
| 7 | #5076 — dev tool: force session expiry | `develop` | 403 (size check waived) |

The 55 changed files are byte-identical to #5068 — verified file by file — with one exception: the three-line `existingUsername = null` placeholder #5070 needs to compile on its own, which #5074 replaces.


---

### About the red Jenkins check

`continuous-integration/jenkins/pr-head` reports *"This commit cannot be built"*. That is structural, not a failure of this code: the `android-multibranch-PR` job only builds pull requests whose base is a long-lived branch, and this one is based on another PR's branch. Precedent: #5038 got the identical error and was merged.

Every GitHub Actions check is green here — lint, unit tests, build-test-apks, form tests, portrait and landscape UI tests, code-quality, SonarCloud. Jenkins goes green on its own once the parent merges and GitHub retargets this PR to `develop`.
