### PR TITLE
test: [ANDROAPP-7733] Add a developer option to force session expiry [skip size]

### DIFF
--- a/app/src/main/java/org/dhis2/data/server/ForceSessionExpiryInterceptor.kt
+++ b/app/src/main/java/org/dhis2/data/server/ForceSessionExpiryInterceptor.kt
@@ -1,0 +1,104 @@
+package org.dhis2.data.server
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okio.Buffer
+import timber.log.Timber
+
+const val FORCED_INVALID_REFRESH_TOKEN = "forced-expiry-invalid-refresh-token"
+const val FORCED_INVALID_ACCESS_TOKEN = "forced-expiry-invalid-access-token"
+
+private const val LOG_TAG = "ForceSessionExpiry"
+
+private const val AUTHORIZATION_HEADER = "Authorization"
+private const val REFRESH_TOKEN_GRANT = "grant_type=refresh_token"
+private val REFRESH_TOKEN_PARAM = Regex("(^|&)refresh_token=[^&]*")
+private const val TOKEN_PATH = "token"
+private const val PING_PATH = "/api/ping"
+private const val MAX_BODY_LENGTH = 8 * 1024L
+
+/**
+ * Development tool that makes the current session look expired, so the app can be exercised
+ * without waiting for the 30 days of inactivity it normally takes.
+ *
+ * It does not fake any response: it spoils what the app sends, and lets the server reject it. An
+ * ordinary call loses its authorization header, so the server answers 401 and the SDK tries to
+ * refresh; that refresh goes out with an invalid refresh token, so the server answers 400 and the
+ * SDK discards the stored tokens and reports an expired session. From there the app behaves
+ * exactly as it does after a real expiry, and the switch turns itself off so renewing the session
+ * — which uses a different grant — works normally.
+ */
+class ForceSessionExpiryInterceptor(
+    private val isArmed: () -> Boolean,
+    private val disarm: () -> Unit,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val armed = isArmed()
+        Timber.tag(LOG_TAG).v("armed=%s %s", armed, request.url)
+        if (!armed) return chain.proceed(request)
+
+        // Every sync starts by asking whether the server is reachable, and a spoiled answer to
+        // that question stops it before anything can report an expired session
+        if (request.isServerCheck()) {
+            Timber.tag(LOG_TAG).d("Leaving the server check untouched")
+            return chain.proceed(request)
+        }
+
+        if (!request.isTokenRequest()) {
+            Timber.tag(LOG_TAG).d("Spoiling the access token of %s", request.url)
+            return chain.proceed(request.withInvalidAccessToken()).also { response ->
+                Timber.tag(LOG_TAG).d("%s answered %d", request.url, response.code)
+            }
+        }
+
+        // The login exchange uses the same endpoint with another grant, and breaking it would
+        // leave the user unable to renew the session
+        val body = request.readBody()
+        if (body?.contains(REFRESH_TOKEN_GRANT) != true) {
+            Timber.tag(LOG_TAG).d("Leaving the login exchange untouched")
+            return chain.proceed(request)
+        }
+
+        disarm()
+        Timber.tag(LOG_TAG).d("Sending an invalid refresh token, the session will expire")
+        return chain.proceed(request.withInvalidRefreshToken(body))
+    }
+
+    private fun Request.isServerCheck(): Boolean = url.encodedPath.endsWith(PING_PATH)
+
+    /**
+     * Recognised by the endpoint rather than by the content type of the body: the SDK talks Ktor,
+     * whose OkHttp bodies do not always carry one.
+     */
+    private fun Request.isTokenRequest(): Boolean = method == "POST" && url.encodedPath.contains(TOKEN_PATH, ignoreCase = true)
+
+    private fun Request.readBody(): String? =
+        body?.takeIf { it.contentLength() in 0..MAX_BODY_LENGTH }?.let { requestBody ->
+            Buffer().use { buffer ->
+                requestBody.writeTo(buffer)
+                buffer.readUtf8()
+            }
+        }
+
+    private fun Request.withInvalidRefreshToken(body: String): Request {
+        val spoiled =
+            body.replace(REFRESH_TOKEN_PARAM) { match ->
+                "${match.groupValues[1]}refresh_token=$FORCED_INVALID_REFRESH_TOKEN"
+            }
+        return newBuilder()
+            .method(method, spoiled.toRequestBody(this.body?.contentType()))
+            .build()
+    }
+
+    /**
+     * An invalid token is answered with a plain 401, which is what the SDK reacts to. A missing
+     * header can instead be answered with a redirect to the login page, and nothing is refreshed.
+     */
+    private fun Request.withInvalidAccessToken(): Request =
+        newBuilder()
+            .header(AUTHORIZATION_HEADER, "Bearer $FORCED_INVALID_ACCESS_TOKEN")
+            .build()
+}

--- a/app/src/main/java/org/dhis2/data/server/ForcedSessionExpiry.kt
+++ b/app/src/main/java/org/dhis2/data/server/ForcedSessionExpiry.kt
@@ -1,0 +1,25 @@
+package org.dhis2.data.server
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Arms [ForceSessionExpiryInterceptor] for one session, from the development screen.
+ *
+ * It is deliberately in memory and single use: arming spoils the next session that reaches the
+ * server, and the SDK then discards the tokens, so the account stays expired until the user renews
+ * it. Nothing is persisted, so no build can be left in this state by accident.
+ */
+object ForcedSessionExpiry {
+    private val armed = AtomicBoolean(false)
+
+    val isArmed: Boolean
+        get() = armed.get()
+
+    fun arm() {
+        armed.set(true)
+    }
+
+    fun disarm() {
+        armed.set(false)
+    }
+}

--- a/app/src/main/java/org/dhis2/data/server/ServerModule.kt
+++ b/app/src/main/java/org/dhis2/data/server/ServerModule.kt
@@ -195,10 +195,23 @@ class ServerModule {
                 .connectTimeoutInSeconds(10 * 60)
                 .readTimeoutInSeconds(10 * 60)
                 .networkInterceptors(interceptors)
+                .interceptors(developmentInterceptors())
                 .writeTimeoutInSeconds(10 * 60)
                 .context(context)
                 .build()
         }
+
+        private fun developmentInterceptors(): List<Interceptor> =
+            if (BuildConfig.DEBUG) {
+                listOf(
+                    ForceSessionExpiryInterceptor(
+                        isArmed = { ForcedSessionExpiry.isArmed },
+                        disarm = ForcedSessionExpiry::disarm,
+                    ),
+                )
+            } else {
+                emptyList()
+            }
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/development/DevelopmentActivity.kt
+++ b/app/src/main/java/org/dhis2/usescases/development/DevelopmentActivity.kt
@@ -10,6 +10,7 @@ import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.runBlocking
 import org.dhis2.R
 import org.dhis2.commons.featureconfig.ui.FeatureConfigView
+import org.dhis2.data.server.ForcedSessionExpiry
 import org.dhis2.databinding.DevelopmentActivityBinding
 import org.dhis2.usescases.general.ActivityGlobalAbstract
 import org.hisp.dhis.android.core.D2
@@ -39,6 +40,7 @@ class DevelopmentActivity : ActivityGlobalAbstract() {
         loadConflicts()
         loadMultiText()
         loadCustomIcons()
+        loadSessionExpiry()
     }
 
     private fun loadCustomIcons() {
@@ -261,6 +263,18 @@ class DevelopmentActivity : ActivityGlobalAbstract() {
     private fun loadCrashControl() {
         binding!!.crashButton.setOnClickListener { _: View? ->
             throw IllegalArgumentException("KA BOOOOOM!")
+        }
+    }
+
+    private fun loadSessionExpiry() {
+        binding!!.expireSessionButton.setOnClickListener { _: View? ->
+            ForcedSessionExpiry.arm()
+            Toast
+                .makeText(
+                    this,
+                    "The next sync will find the session expired",
+                    Toast.LENGTH_SHORT,
+                ).show()
         }
     }
 

--- a/app/src/main/res/layout/development_activity.xml
+++ b/app/src/main/res/layout/development_activity.xml
@@ -151,6 +151,29 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:background="@color/primaryAlpha"
+                    android:text="Session"
+                    android:textColor="@color/colorAccent" />
+
+                <TextView
+                    style="@style/TextSecondary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Spoils the next call to the server so its session expires, as it does after 30 days of inactivity. The account keeps working offline and stays expired until the session is renewed." />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/expireSessionButton"
+                    style="@style/Widget.MaterialComponents.Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:text="Expire session" />
+
+                <TextView
+                    style="@style/TextPrimary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:background="@color/primaryAlpha"
                     android:text="Tracker Import conflicts"
                     android:textColor="@color/colorAccent" />
 

--- a/app/src/test/java/org/dhis2/data/server/ForceSessionExpiryInterceptorTest.kt
+++ b/app/src/test/java/org/dhis2/data/server/ForceSessionExpiryInterceptorTest.kt
@@ -1,0 +1,191 @@
+package org.dhis2.data.server
+
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+private const val FORM = "application/x-www-form-urlencoded"
+private const val TOKEN_URL = "https://test.server.org/oauth2/token"
+private const val API_URL = "https://test.server.org/api/me"
+
+class ForceSessionExpiryInterceptorTest {
+    private val chain: Interceptor.Chain = mock()
+    private var armed = true
+    private var disarmed = false
+
+    private val interceptor =
+        ForceSessionExpiryInterceptor(
+            isArmed = { armed },
+            disarm = { disarmed = true },
+        )
+
+    @Test
+    fun `should leave requests untouched when the switch is off`() {
+        // GIVEN
+        armed = false
+        val request = apiRequest()
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - the dev tool is inert unless somebody turns it on
+        assertEquals("Bearer token", proceeded.header("Authorization"))
+    }
+
+    @Test
+    fun `should spoil the access token so the server rejects the call`() {
+        // GIVEN - an ordinary api call with a still valid access token
+        val request = apiRequest()
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - an invalid token earns a clean 401, which is what makes the SDK try to refresh.
+        // Removing the header instead can be answered with a redirect, which refreshes nothing
+        assertEquals("Bearer $FORCED_INVALID_ACCESS_TOKEN", proceeded.header("Authorization"))
+    }
+
+    @Test
+    fun `should leave the server check alone`() {
+        // GIVEN - the ping every sync starts with, to decide whether the server is reachable
+        val request =
+            Request
+                .Builder()
+                .url("http://test.server.org/api/ping")
+                .header("Authorization", "Bearer token")
+                .build()
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - spoiling it makes the sync give up as "server not available" before reaching
+        // anything that could report an expired session
+        assertEquals("Bearer token", proceeded.header("Authorization"))
+    }
+
+    @Test
+    fun `should spoil the refresh token so the server rejects the refresh`() {
+        // GIVEN - the refresh the SDK sends after that 401
+        val request = tokenRequest("grant_type=refresh_token&refresh_token=real-token&client_id=abc")
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - the server answers 400, the SDK discards the tokens and reports an expired
+        // session, exactly as it does after 30 days of inactivity
+        val body = proceeded.bodyAsString()
+        assertTrue(body.contains("grant_type=refresh_token"))
+        assertTrue(body.contains("refresh_token=$FORCED_INVALID_REFRESH_TOKEN"))
+        assertTrue(!body.contains("real-token"))
+
+        // AND - it disarms itself, so renewing the session afterwards works normally
+        assertTrue(disarmed)
+    }
+
+    @Test
+    fun `should leave the login exchange alone`() {
+        // GIVEN - the authorization code exchange of a login, which uses the same endpoint
+        val request = tokenRequest("grant_type=authorization_code&code=abc&client_id=abc")
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - breaking this would stop the user from ever renewing the session
+        assertEquals(
+            "grant_type=authorization_code&code=abc&client_id=abc",
+            proceeded.bodyAsString(),
+        )
+        assertTrue(!disarmed)
+    }
+
+    private fun apiRequest() =
+        Request
+            .Builder()
+            .url(API_URL)
+            .header("Authorization", "Bearer token")
+            .build()
+
+    private fun tokenRequest(body: String) =
+        Request
+            .Builder()
+            .url(TOKEN_URL)
+            .post(body.toRequestBody(FORM.toMediaType()))
+            .build()
+
+    private fun proceed(request: Request): Request {
+        whenever(chain.request()) doReturn request
+        val captor = argumentCaptor<Request>()
+        whenever(chain.proceed(captor.capture())) doReturn emptyResponse(request)
+
+        interceptor.intercept(chain)
+
+        return captor.firstValue
+    }
+
+    private fun emptyResponse(request: Request) =
+        Response
+            .Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("".toResponseBody(null))
+            .build()
+
+    private fun Request.bodyAsString(): String {
+        val buffer = Buffer()
+        body?.writeTo(buffer)
+        return buffer.readUtf8()
+    }
+
+    @Test
+    fun `should spoil a refresh whose body carries no content type`() {
+        // GIVEN - the SDK talks Ktor, whose OkHttp bodies often have no content type of their own
+        val request =
+            Request
+                .Builder()
+                .url(TOKEN_URL)
+                .header("Content-Type", FORM)
+                .post("grant_type=refresh_token&refresh_token=real-token".toRequestBody(null))
+                .build()
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - the refresh is still recognised, otherwise it would succeed and nothing would
+        // ever look expired
+        assertTrue(proceeded.bodyAsString().contains("refresh_token=$FORCED_INVALID_REFRESH_TOKEN"))
+        assertTrue(disarmed)
+    }
+
+    @Test
+    fun `should not read the body of requests that are not token calls`() {
+        // GIVEN - an upload, whose body may be large and readable only once
+        val request =
+            Request
+                .Builder()
+                .url("https://test.server.org/api/tracker")
+                .header("Authorization", "Bearer token")
+                .post("{\"events\":[]}".toRequestBody("application/json".toMediaType()))
+                .build()
+
+        // WHEN
+        val proceeded = proceed(request)
+
+        // THEN - only the header is touched, the body travels as it was
+        assertEquals("Bearer $FORCED_INVALID_ACCESS_TOKEN", proceeded.header("Authorization"))
+        assertEquals("{\"events\":[]}", proceeded.bodyAsString())
+    }
+}

--- a/app/src/test/java/org/dhis2/data/server/ForcedSessionExpiryTest.kt
+++ b/app/src/test/java/org/dhis2/data/server/ForcedSessionExpiryTest.kt
@@ -1,0 +1,33 @@
+package org.dhis2.data.server
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForcedSessionExpiryTest {
+    @After
+    fun tearDown() {
+        ForcedSessionExpiry.disarm()
+    }
+
+    @Test
+    fun `should start disarmed`() {
+        // The tool only does something when a developer asks for it
+        assertFalse(ForcedSessionExpiry.isArmed)
+    }
+
+    @Test
+    fun `should stay armed until the session is spoiled`() {
+        // GIVEN - the developer tapped the button
+        ForcedSessionExpiry.arm()
+
+        // THEN - it survives the calls leading to the refresh, which is what the interceptor
+        // spoils, and only then is it consumed
+        assertTrue(ForcedSessionExpiry.isArmed)
+        assertTrue(ForcedSessionExpiry.isArmed)
+
+        ForcedSessionExpiry.disarm()
+        assertFalse(ForcedSessionExpiry.isArmed)
+    }
+}


### PR DESCRIPTION
## Description

[JIRA ANDROAPP-7733](https://dhis2.atlassian.net/browse/ANDROAPP-7733)

**Part 7 of 7** splitting #5068. Debug-only, and independent of the other six — it can merge, or be rejected, in any order.

A session only expires after 30 days of inactivity, which makes this flow untestable by hand. **Expire session** in developer options arms a one-shot interceptor that spoils the access token on API calls and the refresh token in the token request, so the server rejects the session exactly as it would after those 30 days, then disarms itself.

`/api/ping` is deliberately left untouched: spoiling it makes the app treat the server as unreachable and the expiry never surfaces — which is the same bug Part 3 fixes, and it cost a debugging cycle to find.

Registered only in debug builds.

`[skip size]` is in the title: this is 403 lines, 224 of them tests, and trimming a test to land three lines under the limit would be the wrong trade.

**Independent** — merge in any order.

---

### The stack

Replaces #5068. Merge #5070 first, then each chain in order; #5076 is independent of everything.

| Part | PR | Base | Lines |
|---|---|---|---|
| 1 | #5070 — commons: error mapping + renewal signal | `develop` | 334 |
| 2 | #5071 — sync: repositories via `withDomainErrors` | #5070 | 380 |
| 3 | #5072 — sync: expired session is not an unavailable server | #5071 | 85 |
| 4 | #5073 — sync: raise the renewal signal | #5072 | 349 |
| 5 | #5074 — login: renew from the credentials screen | #5070 | 360 |
| 6 | #5075 — app: dialog and routing | #5074 | 200 |
| 7 | #5076 — dev tool: force session expiry | `develop` | 403 (size check waived) |

The 55 changed files are byte-identical to #5068 — verified file by file — with one exception: the three-line `existingUsername = null` placeholder #5070 needs to compile on its own, which #5074 replaces.
