### PR TITLE
fix: [ANDROAPP-7759] Report DomainError as a failed Result in the PIN use cases

### DIFF
--- a/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/domain/ResultOf.kt
+++ b/commonskmm/src/commonMain/kotlin/org/dhis2/mobile/commons/domain/ResultOf.kt
@@ -1,0 +1,21 @@
+package org.dhis2.mobile.commons.domain
+
+import kotlinx.coroutines.CancellationException
+import org.dhis2.mobile.commons.error.DomainError
+
+/**
+ * Runs a use case body, reporting any failure as [Result.failure] -- including a [DomainError],
+ * which `catch (e: Exception)` does not catch because [DomainError] extends Throwable.
+ *
+ * Cancellation is not a failure, so it propagates instead of being reported as one. That is also
+ * why the stdlib `runCatching` is not a substitute: it does catch [Throwable], but it swallows
+ * [CancellationException] and so must not be used inside a coroutine.
+ */
+suspend fun <T> resultOf(block: suspend () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (error: Throwable) {
+        Result.failure(error)
+    }

--- a/commonskmm/src/commonTest/kotlin/org/dhis2/mobile/commons/domain/ResultOfTest.kt
+++ b/commonskmm/src/commonTest/kotlin/org/dhis2/mobile/commons/domain/ResultOfTest.kt
@@ -1,0 +1,63 @@
+package org.dhis2.mobile.commons.domain
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.dhis2.mobile.commons.error.DomainError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ResultOfTest {
+    @Test
+    fun `GIVEN a body that returns a value WHEN it is run THEN the value is reported as a success`() =
+        runTest {
+            // WHEN
+            val result = resultOf { "1234" }
+
+            // THEN
+            assertTrue(result.isSuccess)
+            assertEquals("1234", result.getOrNull())
+        }
+
+    @Test
+    fun `GIVEN a body that throws a DomainError WHEN it is run THEN the same error is reported as a failure`() =
+        runTest {
+            // GIVEN - DomainError extends Throwable, so catch (e: Exception) would let it escape
+            val error = DomainError.DatabaseError("The PIN could not be saved")
+
+            // WHEN
+            val result = resultOf { throw error }
+
+            // THEN - the same instance, so the caller can still tell the errors apart
+            assertTrue(result.isFailure)
+            assertSame(error, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `GIVEN a body that throws an Exception WHEN it is run THEN the same error is reported as a failure`() =
+        runTest {
+            // GIVEN
+            val error = IllegalStateException("not a domain error")
+
+            // WHEN
+            val result = resultOf { throw error }
+
+            // THEN
+            assertTrue(result.isFailure)
+            assertSame(error, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `GIVEN a body that is cancelled WHEN it is run THEN the cancellation propagates`() =
+        runTest {
+            // GIVEN - cancellation is not a failure, so it must not be swallowed into a Result
+            val cancellation = CancellationException("the screen was closed")
+
+            // WHEN & THEN
+            val thrown =
+                assertFailsWith<CancellationException> { resultOf { throw cancellation } }
+            assertSame(cancellation, thrown)
+        }
+}

--- a/login/src/androidHostTest/kotlin/org/dhis2/mobile/login/pin/data/SessionRepositoryImplTest.kt
+++ b/login/src/androidHostTest/kotlin/org/dhis2/mobile/login/pin/data/SessionRepositoryImplTest.kt
@@ -1,0 +1,146 @@
+package org.dhis2.mobile.login.pin.data
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.dhis2.mobile.commons.coroutine.Dispatcher
+import org.dhis2.mobile.commons.error.DomainError
+import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.providers.PreferenceProvider
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.mockito.Mockito
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.fail
+
+class SessionRepositoryImplTest {
+    private val d2: D2 = Mockito.mock(D2::class.java, Mockito.RETURNS_DEEP_STUBS)
+    private val domainErrorMapper: DomainErrorMapper = mock()
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val pin = "1234"
+
+    private val d2Error =
+        D2Error
+            .builder()
+            .errorCode(D2ErrorCode.OAUTH2_NO_VALID_TOKEN)
+            .errorDescription("There is no access token")
+            .build()
+
+    private val mappedError = DomainError.SessionRenewalRequiredError("Your session has expired")
+
+    // Resolved eagerly: navigating the deep stubs inside a doAnswer().whenever(...) argument
+    // would run while Mockito is already stubbing, which it rejects
+    private val pinValue = d2.dataStoreModule().localDataStore().value("pin")
+    private val userModule = d2.userModule()
+
+    private val repository =
+        SessionRepositoryImpl(
+            d2 = d2,
+            preferenceProvider = mock<PreferenceProvider>(),
+            domainErrorMapper = domainErrorMapper,
+            dispatcher = Dispatcher(testDispatcher, testDispatcher, testDispatcher),
+        )
+
+    @BeforeTest
+    fun setUp() {
+        // runTest reuses the scheduler of the main dispatcher, so the repository and the test
+        // share one clock
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `GIVEN an SDK error on saving WHEN the PIN is saved THEN the mapped domain error is thrown`() =
+        runTest {
+            // GIVEN
+            whenever(domainErrorMapper.mapToDomainError(d2Error)) doReturn mappedError
+            doAnswer { throw d2Error }.whenever(pinValue).blockingSet(pin)
+
+            // WHEN & THEN
+            assertEquals(mappedError, thrownBy { repository.savePin(pin) })
+        }
+
+    @Test
+    fun `GIVEN an SDK error rewrapped by RxJava on saving WHEN the PIN is saved THEN it is mapped as well`() =
+        runTest {
+            // GIVEN - D2Error is a checked exception, so the blocking operators the SDK exposes
+            // rewrap it; the inline catch (d2Error: D2Error) this replaced never saw those
+            whenever(domainErrorMapper.mapToDomainError(d2Error)) doReturn mappedError
+            doAnswer { throw RuntimeException(d2Error) }.whenever(pinValue).blockingSet(pin)
+
+            // WHEN & THEN
+            assertEquals(mappedError, thrownBy { repository.savePin(pin) })
+        }
+
+    @Test
+    fun `GIVEN an SDK error rewrapped by RxJava on deleting WHEN the PIN is deleted THEN it is mapped as well`() =
+        runTest {
+            // GIVEN
+            whenever(domainErrorMapper.mapToDomainError(d2Error)) doReturn mappedError
+            doAnswer { throw RuntimeException(d2Error) }.whenever(pinValue).blockingDeleteIfExist()
+
+            // WHEN & THEN
+            assertEquals(mappedError, thrownBy { repository.deletePin() })
+        }
+
+    @Test
+    fun `GIVEN an SDK error rewrapped by RxJava on reading WHEN the PIN is read THEN it is mapped as well`() =
+        runTest {
+            // GIVEN
+            whenever(domainErrorMapper.mapToDomainError(d2Error)) doReturn mappedError
+            doAnswer { throw RuntimeException(d2Error) }.whenever(pinValue).blockingGet()
+
+            // WHEN & THEN
+            assertEquals(mappedError, thrownBy { repository.getStoredPin() })
+        }
+
+    @Test
+    fun `GIVEN an expired session on logout WHEN the user is logged out THEN the renewal error is thrown`() =
+        runTest {
+            // GIVEN - this is the path "Forgot PIN" takes, so the renewal error has to survive it
+            whenever(domainErrorMapper.mapToDomainError(d2Error)) doReturn mappedError
+            doAnswer { throw RuntimeException(d2Error) }.whenever(userModule).blockingLogOut()
+
+            // WHEN & THEN
+            assertEquals(mappedError, thrownBy { repository.logout() })
+        }
+
+    @Test
+    fun `GIVEN an unrelated failure WHEN the PIN is saved THEN it travels on untouched`() =
+        runTest {
+            // GIVEN - nothing to map, so nothing should be invented
+            val failure = IllegalStateException("not an SDK error")
+            doAnswer { throw failure }.whenever(pinValue).blockingSet(pin)
+
+            // WHEN & THEN - the type and message survive; coroutine stack-trace recovery
+            // may hand the caller a copy rather than the very same instance
+            val thrown = thrownBy { repository.savePin(pin) }
+            assertIs<IllegalStateException>(thrown)
+            assertEquals(failure.message, thrown.message)
+        }
+
+    private inline fun thrownBy(block: () -> Unit): Throwable {
+        try {
+            block()
+        } catch (error: Throwable) {
+            return error
+        }
+        fail("Expected the call to fail")
+    }
+}

--- a/login/src/androidMain/kotlin/org/dhis2/mobile/login/pin/data/SessionRepositoryImpl.kt
+++ b/login/src/androidMain/kotlin/org/dhis2/mobile/login/pin/data/SessionRepositoryImpl.kt
@@ -3,9 +3,9 @@ package org.dhis2.mobile.login.pin.data
 import kotlinx.coroutines.withContext
 import org.dhis2.mobile.commons.coroutine.Dispatcher
 import org.dhis2.mobile.commons.error.DomainErrorMapper
+import org.dhis2.mobile.commons.error.withDomainErrors
 import org.dhis2.mobile.commons.providers.PreferenceProvider
 import org.hisp.dhis.android.core.D2
-import org.hisp.dhis.android.core.maintenance.D2Error
 
 /**
  * Android implementation of SessionRepository using DHIS2 SDK.
@@ -22,54 +22,47 @@ class SessionRepositoryImpl(
         private const val PREF_SESSION_LOCKED = "SessionLocked"
     }
 
-    override suspend fun savePin(pin: String) =
+    override suspend fun savePin(pin: String) {
         withContext(dispatcher.io) {
-            try {
+            domainErrorMapper.withDomainErrors {
                 d2
                     .dataStoreModule()
                     .localDataStore()
                     .value(PIN_KEY)
                     .blockingSet(pin)
-            } catch (d2Error: D2Error) {
-                throw domainErrorMapper.mapToDomainError(d2Error)
             }
         }
+    }
 
     override suspend fun getStoredPin(): String? =
         withContext(dispatcher.io) {
-            try {
+            domainErrorMapper.withDomainErrors {
                 d2
                     .dataStoreModule()
                     .localDataStore()
                     .value(PIN_KEY)
                     .blockingGet()
                     ?.value()
-            } catch (d2Error: D2Error) {
-                throw domainErrorMapper.mapToDomainError(d2Error)
             }
         }
 
-    override suspend fun deletePin() =
+    override suspend fun deletePin() {
         withContext(dispatcher.io) {
-            try {
+            domainErrorMapper.withDomainErrors {
                 d2
                     .dataStoreModule()
                     .localDataStore()
                     .value(PIN_KEY)
                     .blockingDeleteIfExist()
-            } catch (d2Error: D2Error) {
-                throw domainErrorMapper.mapToDomainError(d2Error)
             }
         }
+    }
 
-    override suspend fun setSessionLocked(locked: Boolean) =
+    override suspend fun setSessionLocked(locked: Boolean) {
         withContext(dispatcher.io) {
-            try {
-                preferenceProvider.setValue(PREF_SESSION_LOCKED, locked)
-            } catch (e: Exception) {
-                throw e
-            }
+            preferenceProvider.setValue(PREF_SESSION_LOCKED, locked)
         }
+    }
 
     override suspend fun isSessionLocked(): Boolean =
         withContext(dispatcher.io) {
@@ -84,12 +77,11 @@ class SessionRepositoryImpl(
             }
         }
 
-    override suspend fun logout() =
+    override suspend fun logout() {
         withContext(dispatcher.io) {
-            try {
+            domainErrorMapper.withDomainErrors {
                 d2.userModule().blockingLogOut()
-            } catch (d2Error: D2Error) {
-                throw domainErrorMapper.mapToDomainError(d2Error)
             }
         }
+    }
 }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ForgotPinUseCase.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ForgotPinUseCase.kt
@@ -1,6 +1,7 @@
 package org.dhis2.mobile.login.pin.domain.usecase
 
 import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.domain.resultOf
 import org.dhis2.mobile.login.pin.data.SessionRepository
 
 /**
@@ -15,12 +16,9 @@ class ForgotPinUseCase(
      * @return Result indicating success or failure.
      */
     override suspend operator fun invoke(input: Unit): Result<Unit> =
-        try {
+        resultOf {
             sessionRepository.deletePin()
             sessionRepository.logout()
             sessionRepository.setSessionLocked(false)
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
         }
 }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/SavePinUseCase.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/pin/domain/usecase/SavePinUseCase.kt
@@ -1,5 +1,7 @@
 package org.dhis2.mobile.login.pin.domain.usecase
 
+import org.dhis2.mobile.commons.domain.UseCase
+import org.dhis2.mobile.commons.domain.resultOf
 import org.dhis2.mobile.login.pin.data.SessionRepository
 
 /**
@@ -8,18 +10,15 @@ import org.dhis2.mobile.login.pin.data.SessionRepository
  */
 class SavePinUseCase(
     private val sessionRepository: SessionRepository,
-) {
+) : UseCase<String, Unit> {
     /**
      * Saves the provided PIN and configures session settings.
-     * @param pin The PIN to save.
+     * @param input The PIN to save.
      * @return Result indicating success or failure.
      */
-    suspend operator fun invoke(pin: String): Result<Unit> =
-        try {
-            sessionRepository.savePin(pin)
+    override suspend operator fun invoke(input: String): Result<Unit> =
+        resultOf {
+            sessionRepository.savePin(input)
             sessionRepository.setSessionLocked(true)
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
         }
 }

--- a/login/src/commonTest/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ForgotPinUseCaseTest.kt
+++ b/login/src/commonTest/kotlin/org/dhis2/mobile/login/pin/domain/usecase/ForgotPinUseCaseTest.kt
@@ -1,12 +1,16 @@
 package org.dhis2.mobile.login.pin.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import org.dhis2.mobile.commons.error.DomainError
 import org.dhis2.mobile.login.pin.data.SessionRepository
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class ForgotPinUseCaseTest {
@@ -51,5 +55,48 @@ class ForgotPinUseCaseTest {
             assertTrue(result.isFailure)
             verify(repository).deletePin()
             verify(repository).logout()
+        }
+
+    @Test
+    fun `GIVEN a repository failing with a DomainError WHEN the PIN is forgotten THEN the same error is reported as a failure`() =
+        runTest {
+            // Given - DomainError extends Throwable, so it used to escape the use case and crash
+            // the ViewModel scope instead of failing the Result.
+            // Note: mockito's doThrow rejects a DomainError as a "checked exception", hence thenAnswer.
+            val error = DomainError.DatabaseError("The PIN could not be deleted")
+            whenever(repository.deletePin()).thenAnswer { throw error }
+
+            // When
+            val result = useCase(Unit)
+
+            // Then
+            assertTrue(result.isFailure)
+            assertSame(error, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `GIVEN a logout failing with an expired session WHEN the PIN is forgotten THEN the renewal error survives`() =
+        runTest {
+            // Given - anything less than the same instance and the session renewal dialog never fires
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.deletePin()).then { }
+            whenever(repository.logout()).thenAnswer { throw error }
+
+            // When
+            val result = useCase(Unit)
+
+            // Then
+            assertSame(error, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `GIVEN a PIN operation in flight WHEN the coroutine is cancelled THEN the cancellation propagates`() =
+        runTest {
+            // Given - cancellation is not a failure, so it must not become a failed Result
+            val cancellation = CancellationException("the screen was closed")
+            whenever(repository.deletePin()).thenAnswer { throw cancellation }
+
+            // When & Then
+            assertSame(cancellation, assertFailsWith<CancellationException> { useCase(Unit) })
         }
 }

--- a/login/src/commonTest/kotlin/org/dhis2/mobile/login/pin/domain/usecase/SavePinUseCaseTest.kt
+++ b/login/src/commonTest/kotlin/org/dhis2/mobile/login/pin/domain/usecase/SavePinUseCaseTest.kt
@@ -1,12 +1,16 @@
 package org.dhis2.mobile.login.pin.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import org.dhis2.mobile.commons.error.DomainError
 import org.dhis2.mobile.login.pin.data.SessionRepository
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SavePinUseCaseTest {
@@ -49,5 +53,50 @@ class SavePinUseCaseTest {
             // Then
             assertTrue(result.isFailure)
             verify(repository).savePin(pin)
+        }
+
+    @Test
+    fun `GIVEN a repository failing with a DomainError WHEN the PIN is saved THEN the same error is reported as a failure`() =
+        runTest {
+            // Given - DomainError extends Throwable, so it used to escape the use case and crash
+            // the ViewModel scope instead of failing the Result.
+            // Note: mockito's doThrow rejects a DomainError as a "checked exception", hence thenAnswer.
+            val pin = "1234"
+            val error = DomainError.DatabaseError("The PIN could not be saved")
+            whenever(repository.savePin(pin)).thenAnswer { throw error }
+
+            // When
+            val result = useCase(pin)
+
+            // Then
+            assertTrue(result.isFailure)
+            assertSame(error, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `GIVEN a save failing with an expired session WHEN the PIN is saved THEN the renewal error survives`() =
+        runTest {
+            // Given - anything less than the same instance and the session renewal dialog never fires
+            val pin = "1234"
+            val error = DomainError.SessionRenewalRequiredError("Your session has expired")
+            whenever(repository.savePin(pin)).thenAnswer { throw error }
+
+            // When
+            val result = useCase(pin)
+
+            // Then
+            assertSame(error, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `GIVEN a PIN operation in flight WHEN the coroutine is cancelled THEN the cancellation propagates`() =
+        runTest {
+            // Given - cancellation is not a failure, so it must not become a failed Result
+            val pin = "1234"
+            val cancellation = CancellationException("the screen was closed")
+            whenever(repository.savePin(pin)).thenAnswer { throw cancellation }
+
+            // When & Then
+            assertSame(cancellation, assertFailsWith<CancellationException> { useCase(pin) })
         }
 }


### PR DESCRIPTION
Fixes [ANDROAPP-7759](https://dhis2.atlassian.net/browse/ANDROAPP-7759)

## Problem

`DomainError` is `sealed class DomainError : Throwable()`, so the `catch (e: Exception)` in
`ForgotPinUseCase` and `SavePinUseCase` never matched. A mapped SDK error propagated out of the
use case instead of becoming `Result.failure(...)` as the `UseCase` contract promises — and since
`PinViewModel` calls them inside `viewModelScope.launch` and only handles `onSuccess` / `onFailure`,
**"Forgot PIN" against a failing SDK crashed the app** instead of showing a message, leaving the
spinner up.

Independently, `CancellationException` *is* an `Exception`, so both use cases were swallowing
cancellation and reporting it as a failed `Result`.

## Changes

- **New `resultOf { }` helper** in `commonskmm/commonMain` (`org.dhis2.mobile.commons.domain`),
  mirroring the existing `withDomainErrors`: catches `Throwable` so a `DomainError` is reported as
  a failure, and rethrows `CancellationException` so cancellation is never a failure. The stdlib
  `runCatching` is not a substitute — it swallows cancellation, which is why the idiom was already
  hand-rolled in `FetchOrgUnits.kt` and `LoginRepositoryImpl.kt`.
- **Both PIN use cases** run on that helper. `SavePinUseCase` now implements `UseCase<String, Unit>`
  as AGENTS.md requires; the signature already matched, so callers are unaffected.
- **`SessionRepositoryImpl`** moves its four inline `catch (d2Error: D2Error)` blocks onto
  `withDomainErrors`. This closes a live gap in the same file: those inline catches only saw a bare
  `D2Error`, so any failure the SDK's blocking RxJava operators rewrapped in a `RuntimeException`
  escaped `savePin` / `deletePin` / `logout` completely unmapped — the same bug class fixed for
  `sync` in #5071. The no-op `catch (e: Exception) { throw e }` in `setSessionLocked` goes with it.

## Tests

`ResultOfTest` (commonskmm `commonTest`), extended `ForgotPinUseCaseTest` / `SavePinUseCaseTest`
(login `commonTest`) and a new `SessionRepositoryImplTest` (login `androidHostTest`) prove that:

- a `DomainError` thrown by the repository comes back as `Result.failure` carrying **the same instance**;
- a `SessionRenewalRequiredError` from `logout()` survives as itself, so the session renewal dialog can still fire from this path;
- `CancellationException` propagates instead of becoming a failed `Result`;
- at the repository level, `RuntimeException(d2Error)` maps as well as a bare `D2Error`, and an unrelated failure travels on untouched.

`./gradlew :commonskmm:testAndroidHostTest :login:testAndroidHostTest` → 201 passed, 0 failed.
`./gradlew ktlintCheck` → clean. `:app:compileDhis2DebugKotlin` → clean.

## Deliberately out of scope

Two follow-ups the ticket calls out, each wanting its own ticket:

- Making `DomainError` extend `Exception` would repair every site at once, but has a measured blast
  radius of **42** `catch (…: Exception)` sites in the KMP modules; `LoginRepositoryImpl.kt:136`
  and `:154` would silently downgrade a precise error such as `SessionRenewalRequiredError` to a
  generic `ConfigurationError`.
- `PinViewModel` uses `viewModelScope.launch` instead of `launchUseCase`, so its coroutines are not
  tracked by the Espresso idling resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ANDROAPP-7759]: https://dhis2.atlassian.net/browse/ANDROAPP-7759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ