### PR TITLE
fix: stabilise TeiDashboardTest.shouldHandleNotesWorkflow

### DIFF
--- a/app/src/androidTest/java/org/dhis2/common/BaseRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/common/BaseRobot.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Context.ACTIVITY_SERVICE
+import android.os.SystemClock
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.compose.ui.semantics.SemanticsNode
@@ -20,6 +21,7 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.base.DefaultFailureHandler
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.util.TreeIterables
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
@@ -76,6 +78,42 @@ open class BaseRobot {
 
     fun waitToDebounce(millis: Long) {
         sleep(millis)
+    }
+
+    /**
+     * Waits until the view matched by [viewMatcher] has stopped moving on screen.
+     *
+     * Use before clicking a view that an animation may still be repositioning, such as one
+     * next to a keyboard that is opening or closing.
+     */
+    fun waitUntilViewIsStable(viewMatcher: Matcher<View>, waitMillis: Long = TIMEOUT) {
+        waitForView(viewMatcher, waitMillis.toInt()).perform(waitForStablePosition(waitMillis))
+    }
+
+    private fun waitForStablePosition(timeoutMillis: Long): ViewAction = object : ViewAction {
+
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "wait until the view stops moving on screen"
+
+        override fun perform(uiController: UiController, view: View) {
+            val deadline = SystemClock.uptimeMillis() + timeoutMillis
+            val current = IntArray(2)
+            val previous = IntArray(2)
+            view.getLocationOnScreen(previous)
+            var stableSamples = 0
+            while (SystemClock.uptimeMillis() < deadline) {
+                uiController.loopMainThreadForAtLeast(STABILITY_POLL_INTERVAL)
+                view.getLocationOnScreen(current)
+                if (current.contentEquals(previous)) {
+                    stableSamples++
+                    if (stableSamples >= REQUIRED_STABLE_SAMPLES) return
+                } else {
+                    stableSamples = 0
+                    current.copyInto(previous)
+                }
+            }
+        }
     }
 
     /** This node's own text entries (does not descend into children). */
@@ -206,5 +244,7 @@ open class BaseRobot {
     companion object {
         const val TIMEOUT = 5000L
         const val CONDITION_CHECK_INTERVAL = 200L
+        private const val STABILITY_POLL_INTERVAL = 50L
+        private const val REQUIRED_STABLE_SAMPLES = 2
     }
 }

--- a/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/NoteRobot.kt
+++ b/app/src/androidTest/java/org/dhis2/usescases/teidashboard/robot/NoteRobot.kt
@@ -1,9 +1,9 @@
 package org.dhis2.usescases.teidashboard.robot
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.action.TypeTextAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.espresso.intent.Intents
@@ -39,13 +39,19 @@ class NoteRobot : BaseRobot() {
         Intents.intended(allOf(hasComponent(NoteDetailActivity::class.java.name)))
     }
 
+    /**
+     * Sets the note text. Uses `replaceText` rather than typing, which in landscape would go
+     * to the keyboard's own editor instead of the field.
+     */
     fun typeNote(text: String) {
-        waitForView(withId(R.id.noteText)).perform(TypeTextAction(text))
+        waitForView(withId(R.id.noteText)).perform(replaceText(text))
         closeKeyboard()
     }
 
     fun clickOnSaveButton() {
-        waitForView(allOf(withId(R.id.saveButton), withText(R.string.save)),5000)
+        val saveButton = allOf(withId(R.id.saveButton), withText(R.string.save))
+        waitUntilViewIsStable(saveButton)
+        waitForView(saveButton, NOTES_WAIT_TIMEOUT_MS)
             .check(matches(allOf(isDisplayed(), isEnabled())))
             .perform(click())
     }
@@ -89,11 +95,8 @@ class NoteRobot : BaseRobot() {
         waitForView(withText(R.string.clear))
             .check(matches(allOf(isDisplayed(), isEnabled())))
             .perform(closeSoftKeyboard())
-        // Hiding the IME starts an animated window-inset transition that Espresso's
-        // main-thread idle check doesn't reliably wait out on every OS version. Clicking
-        // in the same perform() can resolve the button's coordinates mid-animation and
-        // miss it entirely, so give the transition time to settle before re-resolving.
-        waitToDebounce(300)
+        // The button moves while the keyboard closes; wait for it to settle before clicking.
+        waitUntilViewIsStable(withText(R.string.clear))
         waitForView(withText(R.string.clear))
             .check(matches(allOf(isDisplayed(), isEnabled())))
             .perform(click())


### PR DESCRIPTION
`TeiDashboardTest.shouldHandleNotesWorkflow` failed intermittently on the BrowserStack
matrix, in landscape, and passed on re-run with no code change. Two assumptions about the
soft keyboard, both landscape-specific.

## Typing

`typeNote` used `TypeTextAction`, which needs the IME. In landscape most devices open the
keyboard in fullscreen **extract mode**, which replaces the field under test with the IME's
own editor — the keystrokes never reach `noteText`.

It now uses `replaceText`, which fires the same text watchers without depending on the
keyboard at all.

## Clicking

Hiding the IME starts an animated window-inset transition. A click issued while that
animation is still running resolves the target's coordinates mid-flight and lands where the
button used to be — usually on the keyboard. `isDisplayed()` does not know a view is
obscured by the IME window, so nothing caught this.

New `BaseRobot.waitUntilViewIsStable(matcher)` polls a view's on-screen position until it
stops moving. It replaces a `waitToDebounce(300)` sleep in `clickOnClearButton` — a
hard-coded delay, which this repo forbids — and is added to `clickOnSaveButton`, which had
no protection at all.

## Verification

Passed in portrait and landscape on a full 41-test run and has not failed since. These
tests run only on BrowserStack via CI and cannot be executed locally;
`:app:assembleDhis2DebugAndroidTest` builds and ktlint passes.