### PR TITLE
fix: [ANDROAPP-7772] Show original file name in file resource fields [skip size]

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/programEventDetail/ProgramEventMapper.kt
@@ -1,5 +1,6 @@
 package org.dhis2.usescases.programEventDetail
 
+import org.dhis2.bindings.fileResourceNameOf
 import org.dhis2.bindings.userFriendlyValue
 import org.dhis2.commons.data.EventModel
 import org.dhis2.commons.data.EventViewModelType
@@ -212,7 +213,13 @@ class ProgramEventMapper(
                             } else {
                                 dataElement.uid()
                             }
-                        val value = it.userFriendlyValue(d2) ?: ""
+                        val friendlyValue = it.userFriendlyValue(d2) ?: ""
+                        val value =
+                            if (dataElement.valueType()?.isFile == true) {
+                                d2.fileResourceNameOf(friendlyValue) ?: friendlyValue
+                            } else {
+                                friendlyValue
+                            }
                         if (displayName != null) {
                             data.add(Pair(displayName, value))
                         }

--- a/app/src/test/java/org/dhis2/usescases/programEventDetail/ProgramEventMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/programEventDetail/ProgramEventMapperTest.kt
@@ -5,14 +5,26 @@ import org.dhis2.commons.resources.DhisPeriodUtils
 import org.dhis2.commons.resources.MetadataIconProvider
 import org.dhis2.mobile.commons.model.MetadataIconData
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyOneObjectRepositoryFinalImpl
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
 import org.hisp.dhis.android.core.common.ObjectStyle
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.common.State
+import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventStatus
+import org.hisp.dhis.android.core.fileresource.FileResource
+import org.hisp.dhis.android.core.fileresource.FileResourceCollectionRepository
+import org.hisp.dhis.android.core.fileresource.FileResourceObjectRepository
 import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.ProgramStage
+import org.hisp.dhis.android.core.program.ProgramStageDataElement
+import org.hisp.dhis.android.core.program.ProgramStageDataElementCollectionRepository
+import org.hisp.dhis.android.core.program.ProgramStageSectionsCollectionRepository
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -115,6 +127,123 @@ class ProgramEventMapperTest {
         val result = mapper.eventToEventViewModel(event)
 
         assert(result.displayDate.isNullOrEmpty())
+    }
+
+    @Test
+    fun `Should show the original file name instead of the file path for file data elements`() {
+        val fileUid = "afl3jai2i4u"
+        val filePath = "/sdk_resources/db/afl3jai2i4u.pdf"
+
+        mockOrgUnitName()
+        mockProgram()
+        mockCategoryOptionCombo()
+        mockStageSections()
+        mockFileDataElementInReports(fileUid, filePath)
+
+        val event =
+            dummyEvent()
+                .toBuilder()
+                .trackedEntityDataValues(
+                    listOf(
+                        TrackedEntityDataValue
+                            .builder()
+                            .event("eventUid")
+                            .dataElement("fileDataElement")
+                            .value(fileUid)
+                            .build(),
+                    ),
+                ).build()
+
+        val result = mapper.eventToProgramEvent(event)
+
+        assertEquals(listOf("File" to "report.pdf"), result.eventDisplayData)
+    }
+
+    /**
+     * The filter connectors cannot be reached through deep stubs, because `eq()` erases to its
+     * `BaseRepository` upper bound, so every step of the chain is mocked explicitly.
+     */
+    private fun mockStageSections() {
+        val byProgramStageUid: StringFilterConnector<ProgramStageSectionsCollectionRepository> = mock()
+        val filtered: ProgramStageSectionsCollectionRepository = mock()
+        val withDataElements: ProgramStageSectionsCollectionRepository = mock()
+        val ordered: ProgramStageSectionsCollectionRepository = mock()
+
+        whenever(d2.programModule().programStageSections().byProgramStageUid()) doReturn byProgramStageUid
+        whenever(byProgramStageUid.eq("programStage")) doReturn filtered
+        whenever(filtered.withDataElements()) doReturn withDataElements
+        whenever(withDataElements.orderBySortOrder(any())) doReturn ordered
+        whenever(ordered.blockingGet()) doReturn emptyList()
+    }
+
+    private fun mockFileDataElementInReports(
+        fileUid: String,
+        filePath: String,
+    ) {
+        val fileDataElement: DataElement =
+            mock {
+                on { uid() } doReturn "fileDataElement"
+                on { displayFormName() } doReturn "File"
+                on { valueType() } doReturn ValueType.FILE_RESOURCE
+            }
+        val stageDataElement: ProgramStageDataElement =
+            mock {
+                on { uid() } doReturn "programStageDataElement"
+                on { displayInReports() } doReturn true
+                on { dataElement() } doReturn ObjectWithUid.create("fileDataElement")
+            }
+        val fileResource: FileResource =
+            mock {
+                on { uid() } doReturn fileUid
+                on { path() } doReturn filePath
+                on { name() } doReturn "report.pdf"
+            }
+
+        val byProgramStage: StringFilterConnector<ProgramStageDataElementCollectionRepository> = mock()
+        val stageDataElements: ProgramStageDataElementCollectionRepository = mock()
+        val orderedStageDataElements: ProgramStageDataElementCollectionRepository = mock()
+
+        whenever(d2.programModule().programStageDataElements().byProgramStage()) doReturn byProgramStage
+        whenever(byProgramStage.eq("programStage")) doReturn stageDataElements
+        whenever(stageDataElements.orderBySortOrder(any())) doReturn orderedStageDataElements
+        whenever(orderedStageDataElements.blockingGet()) doReturn listOf(stageDataElement)
+        whenever(
+            d2
+                .dataElementModule()
+                .dataElements()
+                .uid("fileDataElement")
+                .blockingGet(),
+        ) doReturn fileDataElement
+
+        val fileResources: FileResourceCollectionRepository = mock()
+        val byUid: StringFilterConnector<FileResourceCollectionRepository> = mock()
+        val byPath: StringFilterConnector<FileResourceCollectionRepository> = mock()
+        val byUidEqUid: FileResourceCollectionRepository = mock()
+        val byUidEqPath: FileResourceCollectionRepository = mock()
+        val byPathEqPath: FileResourceCollectionRepository = mock()
+        val oneByUidEqUid: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+        val oneByUidEqPath: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+        val oneByPathEqPath: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+        val byUidObjectRepository: FileResourceObjectRepository = mock()
+
+        whenever(d2.fileResourceModule().fileResources()) doReturn fileResources
+        whenever(fileResources.byUid()) doReturn byUid
+        whenever(fileResources.byPath()) doReturn byPath
+        whenever(byUid.eq(fileUid)) doReturn byUidEqUid
+        whenever(byUid.eq(filePath)) doReturn byUidEqPath
+        whenever(byPath.eq(filePath)) doReturn byPathEqPath
+        whenever(byUidEqUid.one()) doReturn oneByUidEqUid
+        whenever(byUidEqPath.one()) doReturn oneByUidEqPath
+        whenever(byPathEqPath.one()) doReturn oneByPathEqPath
+
+        // check() and checkValueTypeValue() resolve the value to the path of the file on disk
+        whenever(oneByUidEqUid.blockingExists()) doReturn true
+        whenever(fileResources.uid(fileUid)) doReturn byUidObjectRepository
+        whenever(byUidObjectRepository.blockingGet()) doReturn fileResource
+
+        // fileResourceNameOf() resolves the path back to the original file name
+        whenever(oneByUidEqPath.blockingGet()) doReturn null
+        whenever(oneByPathEqPath.blockingGet()) doReturn fileResource
     }
 
     private fun mockOrgUnitName() {

--- a/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
+++ b/commons/src/main/java/org/dhis2/commons/bindings/ValueExtensions.kt
@@ -150,6 +150,22 @@ fun checkValueTypeValue(
         else -> value
     }
 
+fun D2.fileResourceNameOf(uidOrPath: String): String? =
+    fileResourceModule()
+        .fileResources()
+        .byUid()
+        .eq(uidOrPath)
+        .one()
+        .blockingGet()
+        ?.name()
+        ?: fileResourceModule()
+            .fileResources()
+            .byPath()
+            .eq(uidOrPath)
+            .one()
+            .blockingGet()
+            ?.name()
+
 fun TrackedEntityAttributeValueObjectRepository.blockingSetCheck(
     d2: D2,
     attrUid: String,

--- a/form/src/androidTest/kotlin/org/dhis2/form/ui/provider/inputfield/InputFileProviderTest.kt
+++ b/form/src/androidTest/kotlin/org/dhis2/form/ui/provider/inputfield/InputFileProviderTest.kt
@@ -1,0 +1,96 @@
+package org.dhis2.form.ui.provider.inputfield
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import org.hisp.dhis.android.core.common.ValueType
+import org.junit.Rule
+import org.junit.Test
+
+class InputFileProviderTest {
+
+    companion object {
+        const val FIELD_UI_MODEL_UID = "FieldUIModelUid"
+        const val FILE_RESOURCE_UID = "afl3jai2i4u"
+        const val FILE_PATH = "/data/user/0/org.dhis2/files/sdk_resources/db/afl3jai2i4u.pdf"
+        const val ORIGINAL_FILE_NAME = "report.pdf"
+        const val INPUT_FILE_TEST_TAG = "INPUT_FILE"
+        const val FILE_NAME_TEST_TAG = "INPUT_FILE_RESOURCE_UPLOAD_TEXT_FILE_NAME"
+        const val ADD_BUTTON_TEST_TAG = "INPUT_FILE_RESOURCE_ADD_BUTTON"
+    }
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun shouldDisplayTheOriginalFileNameWhenTheModelHasOne() {
+        val fieldUiModel =
+            generateFieldUiModel(
+                uid = FIELD_UI_MODEL_UID,
+                value = FILE_RESOURCE_UID,
+                displayName = FILE_PATH,
+                valueType = ValueType.FILE_RESOURCE,
+                fileName = ORIGINAL_FILE_NAME,
+            )
+
+        composeTestRule.setContent {
+            ProvideInputFileResource(
+                modifier = Modifier.testTag(INPUT_FILE_TEST_TAG),
+                fieldUiModel = fieldUiModel,
+                onFileSelected = {},
+                uiEventHandler = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag(FILE_NAME_TEST_TAG).assertTextEquals(ORIGINAL_FILE_NAME)
+    }
+
+    @Test
+    fun shouldFallBackToThePathFileNameWhenTheModelHasNoFileName() {
+        val fieldUiModel =
+            generateFieldUiModel(
+                uid = FIELD_UI_MODEL_UID,
+                value = FILE_RESOURCE_UID,
+                displayName = FILE_PATH,
+                valueType = ValueType.FILE_RESOURCE,
+                fileName = null,
+            )
+
+        composeTestRule.setContent {
+            ProvideInputFileResource(
+                modifier = Modifier.testTag(INPUT_FILE_TEST_TAG),
+                fieldUiModel = fieldUiModel,
+                onFileSelected = {},
+                uiEventHandler = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag(FILE_NAME_TEST_TAG).assertTextEquals("$FILE_RESOURCE_UID.pdf")
+    }
+
+    @Test
+    fun shouldDisplayTheAddButtonWhenThereIsNoValue() {
+        val fieldUiModel =
+            generateFieldUiModel(
+                uid = FIELD_UI_MODEL_UID,
+                value = "",
+                displayName = null,
+                valueType = ValueType.FILE_RESOURCE,
+                fileName = null,
+            )
+
+        composeTestRule.setContent {
+            ProvideInputFileResource(
+                modifier = Modifier.testTag(INPUT_FILE_TEST_TAG),
+                fieldUiModel = fieldUiModel,
+                onFileSelected = {},
+                uiEventHandler = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag(ADD_BUTTON_TEST_TAG).assertIsDisplayed()
+    }
+}

--- a/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/FormRepositoryImpl.kt
@@ -8,6 +8,7 @@ import org.dhis2.commons.periods.model.Period
 import org.dhis2.commons.prefs.Preference
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.form.data.EnrollmentRepository.Companion.ENROLLMENT_DATE_UID
+import org.dhis2.form.extensions.withDisplayValues
 import org.dhis2.form.model.ActionType
 import org.dhis2.form.model.FieldUiModel
 import org.dhis2.form.model.OptionSetConfiguration
@@ -671,14 +672,8 @@ class FormRepositoryImpl(
                             list.indexOf(item),
                             item
                                 .setValue(value)
-                                .setDisplayName(
-                                    displayNameProvider.provideDisplayName(
-                                        valueType,
-                                        value,
-                                        item.optionSet,
-                                        item.periodSelector?.type,
-                                    ),
-                                ).setLegend(
+                                .withDisplayValues(displayNameProvider, value, valueType)
+                                .setLegend(
                                     legendValueProvider.provideLegendValue(
                                         item.uid,
                                         value,
@@ -709,7 +704,7 @@ class FormRepositoryImpl(
     override fun removeAllValues() {
         itemList =
             itemList.map { fieldUiModel ->
-                fieldUiModel.setValue(null).setDisplayName(null)
+                fieldUiModel.setValue(null).setDisplayName(null).setFileName(null)
             }
     }
 
@@ -764,14 +759,7 @@ class FormRepositoryImpl(
                     item
                         .setValue(action.value)
                         .setError(error)
-                        .setDisplayName(
-                            displayNameProvider.provideDisplayName(
-                                action.valueType,
-                                action.value,
-                                item.optionSet,
-                                item.periodSelector?.type,
-                            ),
-                        )
+                        .withDisplayValues(displayNameProvider, action.value, action.valueType)
                 } ?: item
             }
         return mergedList

--- a/form/src/main/java/org/dhis2/form/data/RulesUtilsProviderImpl.kt
+++ b/form/src/main/java/org/dhis2/form/data/RulesUtilsProviderImpl.kt
@@ -362,7 +362,8 @@ class RulesUtilsProviderImpl(
                                 field.valueType,
                                 field.optionSet,
                             ),
-                        )?.setEditable(false)
+                        )?.setFileName(null)
+                        ?.setEditable(false)
 
                 updatedField?.let {
                     fieldViewModels[fieldUid] = it

--- a/form/src/main/java/org/dhis2/form/data/metadata/FileResourceConfiguration.kt
+++ b/form/src/main/java/org/dhis2/form/data/metadata/FileResourceConfiguration.kt
@@ -1,5 +1,6 @@
 package org.dhis2.form.data.metadata
 
+import org.dhis2.bindings.fileResourceNameOf
 import org.hisp.dhis.android.core.D2
 
 class FileResourceConfiguration(
@@ -21,4 +22,6 @@ class FileResourceConfiguration(
         } else {
             null
         }
+
+    fun getFileName(uidOrPath: String): String? = d2.fileResourceNameOf(uidOrPath)
 }

--- a/form/src/main/java/org/dhis2/form/extensions/FieldUiModelExtensions.kt
+++ b/form/src/main/java/org/dhis2/form/extensions/FieldUiModelExtensions.kt
@@ -3,6 +3,8 @@ package org.dhis2.form.extensions
 import androidx.compose.ui.graphics.Color
 import org.dhis2.form.model.FieldUiModel
 import org.dhis2.form.model.UiRenderType
+import org.dhis2.form.ui.provider.DisplayNameProvider
+import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.mobile.ui.designsystem.component.InputShellState
 import org.hisp.dhis.mobile.ui.designsystem.component.LegendData
 import org.hisp.dhis.mobile.ui.designsystem.component.Orientation
@@ -72,3 +74,17 @@ fun FieldUiModel.autocompleteList() =
         }
         else -> null
     }
+
+fun FieldUiModel.withDisplayValues(
+    displayNameProvider: DisplayNameProvider,
+    value: String?,
+    valueType: ValueType?,
+): FieldUiModel =
+    setDisplayName(
+        displayNameProvider.provideDisplayName(
+            valueType,
+            value,
+            optionSet,
+            periodSelector?.type,
+        ),
+    ).setFileName(displayNameProvider.provideFileName(valueType, value))

--- a/form/src/main/java/org/dhis2/form/model/FieldUiModel.kt
+++ b/form/src/main/java/org/dhis2/form/model/FieldUiModel.kt
@@ -45,6 +45,8 @@ interface FieldUiModel {
 
     val displayName: String?
 
+    val fileName: String?
+
     val renderingType: UiRenderType?
 
     val optionSetConfiguration: OptionSetConfiguration?
@@ -104,6 +106,8 @@ interface FieldUiModel {
     fun setFieldMandatory(): FieldUiModel
 
     fun setDisplayName(displayName: String?): FieldUiModel
+
+    fun setFileName(fileName: String?): FieldUiModel
 
     fun setKeyBoardActionDone(): FieldUiModel
 

--- a/form/src/main/java/org/dhis2/form/model/FieldUiModelImpl.kt
+++ b/form/src/main/java/org/dhis2/form/model/FieldUiModelImpl.kt
@@ -36,6 +36,7 @@ data class FieldUiModelImpl(
     override val eventCategories: List<EventCategory>? = null,
     override val periodSelector: PeriodSelector? = null,
     override var customIntent: CustomIntentModel? = null,
+    override val fileName: String? = null,
 ) : FieldUiModel {
     private var callback: FieldUiModel.Callback? = null
 
@@ -87,6 +88,8 @@ data class FieldUiModelImpl(
     override fun setIsLoadingData(isLoadingData: Boolean) = this.copy(isLoadingData = isLoadingData)
 
     override fun setDisplayName(displayName: String?) = this.copy(displayName = displayName)
+
+    override fun setFileName(fileName: String?) = this.copy(fileName = fileName)
 
     override fun setKeyBoardActionDone() = this.copy(keyboardActionType = KeyboardActionType.DONE)
 

--- a/form/src/main/java/org/dhis2/form/model/SectionUiModelImpl.kt
+++ b/form/src/main/java/org/dhis2/form/model/SectionUiModelImpl.kt
@@ -45,6 +45,7 @@ data class SectionUiModelImpl(
     override val eventCategories: List<EventCategory>? = null,
     override val periodSelector: PeriodSelector? = null,
     override var customIntent: CustomIntentModel? = null,
+    override val fileName: String? = null,
 ) : FieldUiModel {
     private var sectionNumber: Int = 0
     private var showBottomShadow: Boolean = false
@@ -109,6 +110,8 @@ data class SectionUiModelImpl(
     override fun setIsLoadingData(isLoadingData: Boolean) = this.copy(isLoadingData = isLoadingData)
 
     override fun setDisplayName(displayName: String?) = this.copy(displayName = displayName)
+
+    override fun setFileName(fileName: String?) = this.copy(fileName = fileName)
 
     override fun setKeyBoardActionDone() = this.copy(keyboardActionType = KeyboardActionType.DONE)
 

--- a/form/src/main/java/org/dhis2/form/ui/FieldViewModelFactoryImpl.kt
+++ b/form/src/main/java/org/dhis2/form/ui/FieldViewModelFactoryImpl.kt
@@ -91,6 +91,7 @@ class FieldViewModelFactoryImpl(
                     optionSet,
                     periodSelector?.type,
                 ),
+            fileName = displayNameProvider.provideFileName(valueType, value),
             renderingType =
                 uiEventTypesProvider.provideUiRenderType(
                     featureType,

--- a/form/src/main/java/org/dhis2/form/ui/provider/DisplayNameProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/DisplayNameProvider.kt
@@ -10,4 +10,9 @@ interface DisplayNameProvider {
         optionSet: String? = null,
         periodType: PeriodType? = null,
     ): String?
+
+    fun provideFileName(
+        valueType: ValueType?,
+        value: String?,
+    ): String?
 }

--- a/form/src/main/java/org/dhis2/form/ui/provider/DisplayNameProviderImpl.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/DisplayNameProviderImpl.kt
@@ -28,6 +28,14 @@ class DisplayNameProviderImpl(
         }
     }
 
+    override fun provideFileName(
+        valueType: ValueType?,
+        value: String?,
+    ): String? =
+        value
+            ?.takeIf { it.isNotEmpty() && valueType?.isFile == true }
+            ?.let { fileResourceConfiguration.getFileName(it) }
+
     private fun getOptionSetValue(
         value: String,
         optionSet: String,

--- a/form/src/main/java/org/dhis2/form/ui/provider/inputfield/InputFileProvider.kt
+++ b/form/src/main/java/org/dhis2/form/ui/provider/inputfield/InputFileProvider.kt
@@ -46,7 +46,7 @@ internal fun ProvideInputFileResource(
         supportingText = fieldUiModel.supportingText(),
         buttonText = stringResource(R.string.add_file),
         uploadFileState = uploadState,
-        fileName = file?.name,
+        fileName = fieldUiModel.fileName ?: file?.name,
         fileWeight = file?.length()?.let { fileSizeLabel(it) },
         onSelectFile = {
             uploadState = getFileUploadState(fieldUiModel.displayName, true)

--- a/form/src/test/java/org/dhis2/form/data/FormRepositoryImplTest.kt
+++ b/form/src/test/java/org/dhis2/form/data/FormRepositoryImplTest.kt
@@ -155,7 +155,44 @@ class FormRepositoryImplTest {
         runBlocking {
             repository.removeAllValues()
             val list = repository.composeList()
-            assertTrue(list.all { it.value == null && it.displayName == null })
+            assertTrue(list.all { it.value == null && it.displayName == null && it.fileName == null })
+        }
+
+    @Test
+    fun `Should set the original file name when a file resource value is saved`() =
+        runBlocking {
+            whenever(
+                displayNameProvider.provideDisplayName(
+                    ValueType.FILE_RESOURCE,
+                    "fileUid",
+                    null,
+                    null,
+                ),
+            ) doReturn "/sdk_resources/db/fileUid.pdf"
+            whenever(
+                displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, "fileUid"),
+            ) doReturn "report.pdf"
+
+            repository.updateValueOnList("uid001", "fileUid", ValueType.FILE_RESOURCE)
+
+            val field = repository.composeList().first { it.uid == "uid001" }
+            assertEquals("/sdk_resources/db/fileUid.pdf", field.displayName)
+            assertEquals("report.pdf", field.fileName)
+        }
+
+    @Test
+    fun `Should clear the file name when a file resource value is removed`() =
+        runBlocking {
+            whenever(
+                displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, "fileUid"),
+            ) doReturn "report.pdf"
+            repository.updateValueOnList("uid001", "fileUid", ValueType.FILE_RESOURCE)
+
+            repository.updateValueOnList("uid001", null, ValueType.FILE_RESOURCE)
+
+            val field = repository.composeList().first { it.uid == "uid001" }
+            assertEquals(null, field.displayName)
+            assertEquals(null, field.fileName)
         }
 
     @Test

--- a/form/src/test/java/org/dhis2/form/data/metadata/FileResourceConfigurationTest.kt
+++ b/form/src/test/java/org/dhis2/form/data/metadata/FileResourceConfigurationTest.kt
@@ -1,6 +1,8 @@
 package org.dhis2.form.data.metadata
 
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyOneObjectRepositoryFinalImpl
 import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.FileResourceCollectionRepository
 import org.hisp.dhis.android.core.fileresource.FileResourceModule
@@ -19,6 +21,14 @@ class FileResourceConfigurationTest {
     private val fileResources: FileResourceCollectionRepository = mock()
     private val fileResourceObjectRepository: FileResourceObjectRepository = mock()
     private val fileResource = mock<FileResource>()
+
+    private val byUidConnector: StringFilterConnector<FileResourceCollectionRepository> = mock()
+    private val byPathConnector: StringFilterConnector<FileResourceCollectionRepository> = mock()
+    private val byUidFiltered: FileResourceCollectionRepository = mock()
+    private val byPathFiltered: FileResourceCollectionRepository = mock()
+    private val byUidOne: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+    private val byPathOne: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+
     private lateinit var fileResourceConfiguration: FileResourceConfiguration
 
     @Before
@@ -28,6 +38,13 @@ class FileResourceConfigurationTest {
         whenever(d2.fileResourceModule()).thenReturn(fileResourceModule)
         whenever(fileResourceModule.fileResources()).thenReturn(fileResources)
         whenever(fileResources.uid(anyString())).thenReturn(fileResourceObjectRepository)
+
+        whenever(fileResources.byUid()).thenReturn(byUidConnector)
+        whenever(fileResources.byPath()).thenReturn(byPathConnector)
+        whenever(byUidConnector.eq(anyString())).thenReturn(byUidFiltered)
+        whenever(byPathConnector.eq(anyString())).thenReturn(byPathFiltered)
+        whenever(byUidFiltered.one()).thenReturn(byUidOne)
+        whenever(byPathFiltered.one()).thenReturn(byPathOne)
     }
 
     @Test
@@ -51,6 +68,48 @@ class FileResourceConfigurationTest {
         whenever(fileResourceObjectRepository.blockingExists()).thenReturn(false)
 
         val result = fileResourceConfiguration.getFilePath(uid)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should return the original file name when the value is the file resource uid`() {
+        whenever(byUidOne.blockingGet()).thenReturn(fileResource)
+        whenever(fileResource.name()).thenReturn("report.pdf")
+
+        val result = fileResourceConfiguration.getFileName("existing_uid")
+
+        assertEquals("report.pdf", result)
+    }
+
+    @Test
+    fun `should return the original file name when the value is the file path`() {
+        whenever(byUidOne.blockingGet()).thenReturn(null)
+        whenever(byPathOne.blockingGet()).thenReturn(fileResource)
+        whenever(fileResource.name()).thenReturn("report.pdf")
+
+        val result = fileResourceConfiguration.getFileName("/sdk_resources/db/existing_uid.pdf")
+
+        assertEquals("report.pdf", result)
+    }
+
+    @Test
+    fun `should return null when there is no file resource for the value`() {
+        whenever(byUidOne.blockingGet()).thenReturn(null)
+        whenever(byPathOne.blockingGet()).thenReturn(null)
+
+        val result = fileResourceConfiguration.getFileName("missing")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should return null when the file resource has no name`() {
+        whenever(byUidOne.blockingGet()).thenReturn(fileResource)
+        whenever(byPathOne.blockingGet()).thenReturn(fileResource)
+        whenever(fileResource.name()).thenReturn(null)
+
+        val result = fileResourceConfiguration.getFileName("existing_uid")
 
         assertNull(result)
     }

--- a/form/src/test/java/org/dhis2/form/ui/FieldViewModelFactoryImplTest.kt
+++ b/form/src/test/java/org/dhis2/form/ui/FieldViewModelFactoryImplTest.kt
@@ -11,12 +11,14 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
 import org.hisp.dhis.android.core.program.SectionRenderingType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class FieldViewModelFactoryImplTest {
     private val valueTypeHintMap = HashMap<ValueType, String>()
@@ -73,5 +75,37 @@ class FieldViewModelFactoryImplTest {
         )
         verify(trackedEntityAttribute).displayFormName()
         verify(programTrackedEntityAttribute, never()).displayName()
+    }
+
+    @Test
+    fun `should populate the original file name for file resource fields`() {
+        val filePath = "/sdk_resources/db/fileUid.pdf"
+        whenever(
+            displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, filePath),
+        ) doReturn "report.pdf"
+
+        val field =
+            fieldViewModelFactoryImpl.create(
+                id = "fileDataElement",
+                label = "File",
+                valueType = ValueType.FILE_RESOURCE,
+                mandatory = false,
+                optionSet = null,
+                value = filePath,
+                programStageSection = null,
+                allowFutureDates = true,
+                editable = true,
+                renderingType = SectionRenderingType.LISTING,
+                description = null,
+                fieldRendering = null,
+                objectStyle = ObjectStyle.builder().build(),
+                fieldMask = null,
+                optionSetConfiguration = null,
+                featureType = null,
+                autoCompleteList = null,
+                orgUnitSelectorScope = null,
+            )
+
+        assertEquals("report.pdf", field.fileName)
     }
 }

--- a/form/src/test/java/org/dhis2/form/ui/provider/DisplayNameProviderImplTest.kt
+++ b/form/src/test/java/org/dhis2/form/ui/provider/DisplayNameProviderImplTest.kt
@@ -9,10 +9,14 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.option.Option
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class DisplayNameProviderImplTest {
@@ -143,6 +147,40 @@ class DisplayNameProviderImplTest {
                 optionSet = null,
             )
         assertEquals(filePath, result)
+    }
+
+    @Test
+    fun `Should return the original file name for valueType FILE_RESOURCE when value is the file uid`() {
+        val value = "fileUid"
+        whenever(fileResourceConfiguration.getFileName(value)) doReturn "report.pdf"
+
+        val result = displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, value)
+
+        assertEquals("report.pdf", result)
+    }
+
+    @Test
+    fun `Should return the original file name for valueType FILE_RESOURCE when value is the file path`() {
+        val value = "/sdk_resources/db/fileUid.pdf"
+        whenever(fileResourceConfiguration.getFileName(value)) doReturn "report.pdf"
+
+        val result = displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, value)
+
+        assertEquals("report.pdf", result)
+    }
+
+    @Test
+    fun `Should return null file name when value is null or empty`() {
+        assertNull(displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, null))
+        assertNull(displayNameProvider.provideFileName(ValueType.FILE_RESOURCE, ""))
+        verify(fileResourceConfiguration, never()).getFileName(any())
+    }
+
+    @Test
+    fun `Should not look for a file name for non file value types`() {
+        assertNull(displayNameProvider.provideFileName(ValueType.TEXT, "value"))
+        assertNull(displayNameProvider.provideFileName(null, "value"))
+        verify(fileResourceConfiguration, never()).getFileName(any())
     }
 
     @Test

--- a/tracker/src/androidHostTest/kotlin/org/dhis2/tracker/relationships/data/RelationshipsRepositoryFileValuesTest.kt
+++ b/tracker/src/androidHostTest/kotlin/org/dhis2/tracker/relationships/data/RelationshipsRepositoryFileValuesTest.kt
@@ -1,0 +1,236 @@
+package org.dhis2.tracker.relationships.data
+
+import kotlinx.coroutines.test.runTest
+import org.dhis2.commons.resources.ResourceManager
+import org.dhis2.tracker.relationships.model.RelationshipConstraintSide
+import org.dhis2.tracker.relationships.model.RelationshipModel
+import org.dhis2.tracker.relationships.model.RelationshipSection
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyOneObjectRepositoryFinalImpl
+import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.dataelement.DataElement
+import org.hisp.dhis.android.core.event.Event
+import org.hisp.dhis.android.core.fileresource.FileResource
+import org.hisp.dhis.android.core.fileresource.FileResourceCollectionRepository
+import org.hisp.dhis.android.core.fileresource.FileResourceObjectRepository
+import org.hisp.dhis.android.core.relationship.Relationship
+import org.hisp.dhis.android.core.relationship.RelationshipConstraint
+import org.hisp.dhis.android.core.relationship.TrackerDataView
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Covers that a file based value is rendered on a relationship card with the original file name,
+ * instead of the absolute path of the file on disk.
+ */
+class RelationshipsRepositoryFileValuesTest {
+    private val d2: D2 = mock(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
+    private val resources: ResourceManager = mock()
+    private val repository = TestRelationshipsRepository(d2, resources)
+
+    private val teiUid = "teiUid"
+    private val eventUid = "eventUid"
+    private val fileUid = "afl3jai2i4u"
+    private val filePath = "/sdk_resources/db/afl3jai2i4u.pdf"
+    private val originalName = "report.pdf"
+
+    @Test
+    fun `should show the original file name for a file attribute`() =
+        runTest {
+            val attributeUid = "attributeUid"
+            // Mocks are built up front: creating one inside whenever() leaves Mockito mid-stubbing
+            val attribute = fileAttribute(attributeUid)
+            mockFileResource()
+            whenever(
+                d2
+                    .trackedEntityModule()
+                    .trackedEntityAttributes()
+                    .uid(attributeUid)
+                    .blockingGet(),
+            ) doReturn attribute
+            whenever(
+                d2
+                    .trackedEntityModule()
+                    .trackedEntityAttributeValues()
+                    .value(attributeUid, teiUid)
+                    .blockingGet(),
+            ) doReturn
+                TrackedEntityAttributeValue
+                    .builder()
+                    .trackedEntityAttribute(attributeUid)
+                    .trackedEntityInstance(teiUid)
+                    .value(fileUid)
+                    .build()
+
+            val result =
+                repository.teiAttributes(
+                    teiUid = teiUid,
+                    relationshipConstraint = constraintWithAttribute(attributeUid),
+                )
+
+            assertEquals(listOf("File" to originalName), result)
+        }
+
+    @Test
+    fun `should show the original file name for a file data element`() =
+        runTest {
+            val dataElementUid = "dataElementUid"
+            // Mocks are built up front: creating one inside whenever() leaves Mockito mid-stubbing
+            val dataElement = fileDataElement(dataElementUid)
+            mockFileResource()
+            whenever(
+                d2
+                    .dataElementModule()
+                    .dataElements()
+                    .uid(dataElementUid)
+                    .blockingGet(),
+            ) doReturn dataElement
+            whenever(
+                d2
+                    .eventModule()
+                    .events()
+                    .withTrackedEntityDataValues()
+                    .uid(eventUid)
+                    .blockingGet(),
+            ) doReturn eventWithFileValue(dataElementUid)
+
+            val result =
+                repository.eventValues(
+                    eventUid = eventUid,
+                    relationshipConstraint = constraintWithDataElement(dataElementUid),
+                )
+
+            assertEquals(listOf("File" to originalName), result)
+        }
+
+    /**
+     * The filter connectors cannot be reached through deep stubs, because `eq()` erases to its
+     * `BaseRepository` upper bound, so every step of the chain is mocked explicitly.
+     */
+    private fun mockFileResource() {
+        val fileResource = fileResource()
+        val fileResources: FileResourceCollectionRepository = mock()
+        val byUid: StringFilterConnector<FileResourceCollectionRepository> = mock()
+        val byPath: StringFilterConnector<FileResourceCollectionRepository> = mock()
+        val byUidEqUid: FileResourceCollectionRepository = mock()
+        val byUidEqPath: FileResourceCollectionRepository = mock()
+        val byPathEqPath: FileResourceCollectionRepository = mock()
+        val oneByUidEqUid: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+        val oneByUidEqPath: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+        val oneByPathEqPath: ReadOnlyOneObjectRepositoryFinalImpl<FileResource> = mock()
+        val byUidObjectRepository: FileResourceObjectRepository = mock()
+
+        whenever(d2.fileResourceModule().fileResources()) doReturn fileResources
+        whenever(fileResources.byUid()) doReturn byUid
+        whenever(fileResources.byPath()) doReturn byPath
+        whenever(byUid.eq(fileUid)) doReturn byUidEqUid
+        whenever(byUid.eq(filePath)) doReturn byUidEqPath
+        whenever(byPath.eq(filePath)) doReturn byPathEqPath
+        whenever(byUidEqUid.one()) doReturn oneByUidEqUid
+        whenever(byUidEqPath.one()) doReturn oneByUidEqPath
+        whenever(byPathEqPath.one()) doReturn oneByPathEqPath
+
+        // check() and checkValueTypeValue() resolve the value to the path of the file on disk
+        whenever(oneByUidEqUid.blockingExists()) doReturn true
+        whenever(fileResources.uid(fileUid)) doReturn byUidObjectRepository
+        whenever(byUidObjectRepository.blockingGet()) doReturn fileResource
+
+        // fileResourceNameOf() resolves the path back to the original file name
+        whenever(oneByUidEqPath.blockingGet()) doReturn null
+        whenever(oneByPathEqPath.blockingGet()) doReturn fileResource
+    }
+
+    private fun fileResource(): FileResource =
+        mock {
+            on { uid() } doReturn fileUid
+            on { path() } doReturn filePath
+            on { name() } doReturn originalName
+        }
+
+    private fun fileAttribute(uid: String): TrackedEntityAttribute =
+        mock {
+            on { uid() } doReturn uid
+            on { displayFormName() } doReturn "File"
+            on { valueType() } doReturn ValueType.FILE_RESOURCE
+        }
+
+    private fun fileDataElement(uid: String): DataElement =
+        mock {
+            on { uid() } doReturn uid
+            on { displayName() } doReturn "File"
+            on { valueType() } doReturn ValueType.FILE_RESOURCE
+        }
+
+    private fun eventWithFileValue(dataElementUid: String): Event =
+        Event
+            .builder()
+            .uid(eventUid)
+            .trackedEntityDataValues(
+                listOf(
+                    TrackedEntityDataValue
+                        .builder()
+                        .event(eventUid)
+                        .dataElement(dataElementUid)
+                        .value(fileUid)
+                        .build(),
+                ),
+            ).build()
+
+    private fun constraintWithAttribute(attributeUid: String): RelationshipConstraint =
+        RelationshipConstraint
+            .builder()
+            .trackerDataView(
+                TrackerDataView
+                    .builder()
+                    .attributes(listOf(attributeUid))
+                    .dataElements(emptyList())
+                    .build(),
+            ).build()
+
+    private fun constraintWithDataElement(dataElementUid: String): RelationshipConstraint =
+        RelationshipConstraint
+            .builder()
+            .trackerDataView(
+                TrackerDataView
+                    .builder()
+                    .attributes(emptyList())
+                    .dataElements(listOf(dataElementUid))
+                    .build(),
+            ).build()
+}
+
+private class TestRelationshipsRepository(
+    d2: D2,
+    resources: ResourceManager,
+) : RelationshipsRepository(d2, resources) {
+    suspend fun teiAttributes(
+        teiUid: String,
+        relationshipConstraint: RelationshipConstraint,
+    ) = getTeiAttributesForRelationship(teiUid, relationshipConstraint, null)
+
+    suspend fun eventValues(
+        eventUid: String,
+        relationshipConstraint: RelationshipConstraint,
+    ) = getEventValuesForRelationship(eventUid, relationshipConstraint, null)
+
+    override suspend fun getRelationshipTypes(): List<RelationshipSection> = emptyList()
+
+    override suspend fun getRelationshipsGroupedByTypeAndSide(relationshipSection: RelationshipSection): RelationshipSection =
+        relationshipSection
+
+    override suspend fun getRelationships(): List<RelationshipModel> = emptyList()
+
+    override fun createRelationship(
+        selectedTeiUid: String,
+        relationshipTypeUid: String,
+        relationshipSide: RelationshipConstraintSide,
+    ): Relationship = throw UnsupportedOperationException()
+}

--- a/tracker/src/androidMain/kotlin/org/dhis2/tracker/relationships/data/RelationshipsRepository.kt
+++ b/tracker/src/androidMain/kotlin/org/dhis2/tracker/relationships/data/RelationshipsRepository.kt
@@ -1,5 +1,6 @@
 package org.dhis2.tracker.relationships.data
 
+import org.dhis2.bindings.fileResourceNameOf
 import org.dhis2.bindings.userFriendlyValue
 import org.dhis2.commons.date.toUi
 import org.dhis2.commons.resources.ResourceManager
@@ -13,6 +14,7 @@ import org.dhis2.tracker.relationships.model.RelationshipOwnerType
 import org.dhis2.tracker.relationships.model.RelationshipSection
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.common.ObjectStyle
+import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
@@ -45,6 +47,13 @@ abstract class RelationshipsRepository(
         relationshipTypeUid: String,
         relationshipSide: RelationshipConstraintSide,
     ): Relationship
+
+    private fun String.resolveFileName(valueType: ValueType?): String =
+        if (valueType?.isFile == true) {
+            d2.fileResourceNameOf(this) ?: this
+        } else {
+            this
+        }
 
     protected fun orgUnitInScope(orgUnitUid: String?): Boolean =
         orgUnitUid?.let {
@@ -103,13 +112,13 @@ abstract class RelationshipsRepository(
         // Get a list of Pair<label, value>
         val attributes =
             trackedEntityAttributesUids?.mapNotNull { attributeUid ->
-                val fieldName =
+                val attribute =
                     d2
                         .trackedEntityModule()
                         .trackedEntityAttributes()
                         .uid(attributeUid)
                         .blockingGet()
-                        ?.displayFormName()
+                val fieldName = attribute?.displayFormName()
 
                 val value =
                     d2
@@ -118,6 +127,7 @@ abstract class RelationshipsRepository(
                         .value(attributeUid, teiUid!!)
                         .blockingGet()
                         ?.userFriendlyValue(d2)
+                        ?.resolveFileName(attribute?.valueType())
                 if (fieldName != null && value != null) {
                     Pair(fieldName, value)
                 } else {
@@ -185,18 +195,19 @@ abstract class RelationshipsRepository(
 
         val dataElements =
             dataElementUids?.mapNotNull { dataElementUid ->
-                val formName =
+                val dataElement =
                     d2
                         .dataElementModule()
                         .dataElements()
                         .uid(dataElementUid)
                         .blockingGet()
-                        ?.displayName()
+                val formName = dataElement?.displayName()
                 val value =
                     event
                         ?.trackedEntityDataValues()
                         ?.find { it.dataElement() == dataElementUid }
                         .userFriendlyValue(d2)
+                        ?.resolveFileName(dataElement?.valueType())
                 if (formName != null && value != null) {
                     Pair(formName, value)
                 } else {


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7772).

A `FILE_RESOURCE` field showed the file resource uid with its extension (`afl3jai2i4u.pdf`) instead of the original file name (`report.pdf`).

This is not an SDK bug: the SDK keeps the original name in `FileResource.name` from end to end, and deliberately renames only the file **on disk** to `<uid>.<ext>`. The app was reading the basename of `FileResource.path()` and never reading `name()`.

### Solution

A new `fileName` property on `FieldUiModel`, populated alongside `displayName`, which keeps holding the path. `displayName` is consumed as a path by `FormView.openFile`, the file weight, the image preview and the signature field, so its semantics are left untouched — if a recomputation site were ever missed, the field simply falls back to the current behaviour instead of breaking downloads or previews.

- `D2.fileResourceNameOf(uidOrPath)` resolves the name by uid and, failing that, by path. Both are needed: a form field holds the uid right after picking a file, and the path once the form is composed again — the latter is the case that was broken.
- Routed through `DisplayNameProvider`, the only collaborator already present at every recomputation site, so no constructor signature or DI wiring changes.
- Event and relationship cards had the same root cause and were leaking the absolute path to the user (`ProgramEventMapper.getData()`, `RelationshipsRepository`). They now show the name too.

### Testing

Unit tests cover name resolution by uid, by path, a missing file resource and a null name, plus the recomputation sites and both card mappers. A new instrumented test covers the input field showing the original name, falling back to `<uid>.<ext>` when there is none, and the empty state.

Manually verified on device: picking a file, reopening the form, files downloaded from the server, enrollment forms, clearing the value, opening/downloading the file, rotation, image and signature fields, aggregate data set file fields, and both card types.

### Known gap

`FormView.downloadFile` still copies the file to Downloads under its `<uid>.<ext>` name. Out of scope here; `fileResourceNameOf()` is available if we want to fix that separately.
