### PR TITLE
feat: [ANDROAPP-7687] Add support for Android Auth Tabs and handle duplicate OAuth callbacks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,21 @@
                 android:scheme="smsto" />
         </intent>
 
+        <!--
+             Without these the package manager filters browsers out on Android 11+,
+             so CustomTabsClient cannot resolve a browser or detect Auth Tab support.
+        -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+
+            <category android:name="android.intent.category.BROWSABLE" />
+
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+
     </queries>
 
     <application

--- a/login/src/androidMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.android.kt
+++ b/login/src/androidMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.android.kt
@@ -1,38 +1,83 @@
 package org.dhis2.mobile.login.main.ui.screen
 
-import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+
+private val CUSTOM_TAB_SETTLE_DELAY = 1000.milliseconds
 
 @Composable
 actual fun WebAuthenticator(
     url: String,
+    redirectScheme: String,
+    onAuthCallback: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val customTabLauncher =
-        rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.StartActivityForResult(),
-        ) { result ->
-            if (result.resultCode == Activity.RESULT_CANCELED) {
-                onDismiss()
+    val context = LocalContext.current
+    val currentOnAuthCallback by rememberUpdatedState(onAuthCallback)
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+
+    // Resolve the browser for the support check and the launch.
+    val browserPackage = remember { CustomTabsClient.getPackageName(context, null) }
+    val supportsAuthTab =
+        remember(browserPackage) {
+            browserPackage != null && CustomTabsClient.isAuthTabSupported(context, browserPackage)
+        }
+
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+
+            currentOnDismiss()
+
+            val redirectUri = result.data?.data
+            if (supportsAuthTab && result.resultCode == AuthTabIntent.RESULT_OK && redirectUri != null) {
+                currentOnAuthCallback(redirectUri.toString())
             }
         }
 
-    LaunchedEffect(url) {
-        val authTabIntent =
-            AuthTabIntent
-                .Builder()
-                .build()
+    // returning to this destination or rotating the device does not open a second browser.
+    var launched by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        if (launched) return@LaunchedEffect
+        launched = true
 
-        val intent =
-            authTabIntent.intent.apply {
-                data = url.toUri()
-            }
+        if (!supportsAuthTab) delay(CUSTOM_TAB_SETTLE_DELAY)
 
-        customTabLauncher.launch(intent)
+        val launchSucceeded =
+            runCatching {
+                if (supportsAuthTab) {
+                    AuthTabIntent
+                        .Builder()
+                        .build()
+                        .launch(launcher, url.toUri(), redirectScheme)
+                } else {
+                    val intent =
+                        CustomTabsIntent
+                            .Builder()
+                            .build()
+                            .intent
+                            .apply {
+                                browserPackage?.let(::setPackage)
+                                data = url.toUri()
+                            }
+                    launcher.launch(intent)
+                }
+            }.isSuccess
+
+        if (!launchSucceeded) currentOnDismiss()
     }
 }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/di/LoginModule.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/di/LoginModule.kt
@@ -122,6 +122,7 @@ internal val mainLoginModule =
                 importDatabase = get { parametersOf(context) },
                 validateServer = get { parametersOf(context) },
                 networkStatusProvider = get(),
+                appLinkNavigation = get(),
                 renewSession = parameters.getOrNull<Boolean>() ?: false,
             )
         }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/GetOAuthLogoutUrl.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/domain/usecase/GetOAuthLogoutUrl.kt
@@ -14,8 +14,4 @@ class GetOAuthLogoutUrl(
         } catch (e: DomainError) {
             Result.failure(e)
         }
-
-    companion object {
-        private const val REDIRECT_URI = "dhis2oauth://oauth"
-    }
 }

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/LoginScreen.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/LoginScreen.kt
@@ -78,6 +78,14 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
+/**
+ * The scheme the DHIS2 OAuth2 flow redirects back to.
+ *
+ * Must stay in sync with `OAuth2Config.DEFAULT_REDIRECT_URI` in the DHIS2 Android SDK and with the
+ * `LoginActivity` intent filter that receives it in the app manifest.
+ */
+private const val OAUTH_REDIRECT_SCHEME = "dhis2oauth"
+
 @Composable
 fun LoginScreen(
     navController: NavHostController = rememberNavController(),
@@ -220,6 +228,10 @@ fun LoginScreen(
                     val args = it.toRoute<LoginScreenState.OauthAuthentication>()
                     WebAuthenticator(
                         url = args.selectedServer,
+                        redirectScheme = OAUTH_REDIRECT_SCHEME,
+                        onAuthCallback = { redirectUri ->
+                            viewModel.onOauthRedirect(redirectUri)
+                        },
                         onDismiss = {
                             viewModel.onOauthLoginCancelled()
                         },

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.kt
@@ -2,8 +2,22 @@ package org.dhis2.mobile.login.main.ui.screen
 
 import androidx.compose.runtime.Composable
 
+/**
+ * Opens [url] in a browser for one leg of an OAuth flow.
+ *
+ * @param url the authorization, consent or logout URL to open.
+ * @param redirectScheme the scheme the provider redirects back to. Browsers that support Auth Tab
+ *   intercept that redirect and return it through [onAuthCallback] instead of firing an intent.
+ * @param onAuthCallback invoked with the full redirect URI when the browser reports it directly,
+ *   always after [onDismiss]. Browsers without Auth Tab support never call this: their redirect
+ *   arrives as an app link, which the framework delivers after the tab's activity result.
+ * @param onDismiss invoked when the browser leg ends, whether it redirected or the user backed out.
+ *   It closes the leg's destination; the flow continues from the redirect itself.
+ */
 @Composable
 expect fun WebAuthenticator(
     url: String,
+    redirectScheme: String,
+    onAuthCallback: (String) -> Unit,
     onDismiss: () -> Unit,
 )

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/CredentialsViewModel.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/CredentialsViewModel.kt
@@ -123,6 +123,8 @@ class CredentialsViewModel(
 
     private var pendingOAuthLoginResult: LoginResult? = null
 
+    private var enrollmentJob: Job? = null
+
     private var appLinkJob: Job? = null
 
     private var offlinePin: String = ""
@@ -178,11 +180,10 @@ class CredentialsViewModel(
             return
         }
         launchUseCase {
+            // When biometrics is available it takes over as the unlock challenge.
             val biometricInfo = getBiometricInfo(serverUrl)
-            // When biometrics is available it takes over as the unlock challenge: the
-            // offline-credential dialog stays hidden so only the biometric prompt is shown,
-            // over the bare Credentials screen. It remains reachable manually via "Log in".
             val shouldPromptBiometrics = biometricInfo.canUseBiometrics && autoPromptLogin
+
             _credentialsScreenState.update { current ->
                 current.copy(
                     loginState = LoginState.Enabled,
@@ -339,17 +340,21 @@ class CredentialsViewModel(
         appLinkJob = null
     }
 
+    private fun abortOAuthFlow(errorMessage: String?) {
+        stopListeningForOAuthCallbacks()
+        _credentialsScreenState.update {
+            it.copy(
+                errorMessage = errorMessage,
+                loginState = LoginState.Enabled,
+            )
+        }
+    }
+
     private fun handleOAuthCallbacks(urlString: String) {
         // First check if there is any error
         val error = urlString.substringAfter("error=", "").substringBefore('&')
         if (error.isNotEmpty()) {
-            stopListeningForOAuthCallbacks()
-            _credentialsScreenState.update {
-                it.copy(
-                    errorMessage = error,
-                    loginState = LoginState.Enabled,
-                )
-            }
+            abortOAuthFlow(errorMessage = error)
             return
         }
 
@@ -374,18 +379,16 @@ class CredentialsViewModel(
             return
         }
 
-        stopListeningForOAuthCallbacks()
-        _credentialsScreenState.update {
-            it.copy(
-                loginState = LoginState.Enabled,
-            )
-        }
+        abortOAuthFlow(errorMessage = null)
     }
 
     private fun loginWithOAuthCode(
         code: String,
         state: String,
     ) {
+        // An authorization code is single use, so refuse to exchange twice.
+        if (loginJob?.isActive == true) return
+
         _credentialsScreenState.update {
             it.copy(
                 loginState = LoginState.Running,
@@ -440,37 +443,35 @@ class CredentialsViewModel(
         enrollmentIat: String,
         state: String,
     ) {
-        launchUseCase {
-            _credentialsScreenState.update {
-                it.copy(loginState = LoginState.Running)
-            }
+        // An enrollment token is single use.
+        if (enrollmentJob?.isActive == true) return
 
-            processDeviceEnrollment(
-                DeviceEnrollmentInfo(
-                    iat = enrollmentIat,
-                    serverURL = serverUrl,
-                    state = state,
-                ),
-            ).fold(
-                onSuccess = { consentUrl ->
-                    // Second OAuth call (consent) - keep session from enrollment
-                    navigator.navigate(
-                        LoginScreenState.OauthAuthentication(
-                            selectedServer = consentUrl,
-                        ),
-                    )
-                },
-                onFailure = { error ->
-                    stopListeningForOAuthCallbacks()
-                    _credentialsScreenState.update {
-                        it.copy(
-                            errorMessage = error.message,
-                            loginState = LoginState.Enabled,
+        enrollmentJob =
+            launchUseCase {
+                _credentialsScreenState.update {
+                    it.copy(loginState = LoginState.Running)
+                }
+
+                processDeviceEnrollment(
+                    DeviceEnrollmentInfo(
+                        iat = enrollmentIat,
+                        serverURL = serverUrl,
+                        state = state,
+                    ),
+                ).fold(
+                    onSuccess = { consentUrl ->
+                        // Second OAuth call (consent) - keep session from enrollment
+                        navigator.navigate(
+                            LoginScreenState.OauthAuthentication(
+                                selectedServer = consentUrl,
+                            ),
                         )
-                    }
-                },
-            )
-        }
+                    },
+                    onFailure = { error ->
+                        abortOAuthFlow(errorMessage = error.message)
+                    },
+                )
+            }
     }
 
     fun updateUsername(username: String) {

--- a/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/LoginViewModel.kt
+++ b/login/src/commonMain/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/LoginViewModel.kt
@@ -16,6 +16,7 @@ import org.dhis2.mobile.login.main.domain.model.ServerValidationResult
 import org.dhis2.mobile.login.main.domain.usecase.GetInitialScreen
 import org.dhis2.mobile.login.main.domain.usecase.ImportDatabase
 import org.dhis2.mobile.login.main.domain.usecase.ValidateServer
+import org.dhis2.mobile.login.main.ui.navigation.AppLinkNavigation
 import org.dhis2.mobile.login.main.ui.navigation.Navigator
 import org.dhis2.mobile.login.main.ui.state.DatabaseImportState
 import org.dhis2.mobile.login.main.ui.state.ServerValidationUiState
@@ -26,6 +27,7 @@ class LoginViewModel(
     private val importDatabase: ImportDatabase,
     private val validateServer: ValidateServer,
     private val networkStatusProvider: NetworkStatusProvider,
+    private val appLinkNavigation: AppLinkNavigation,
     private val renewSession: Boolean = false,
 ) : ViewModel() {
     private val _serverValidationState = MutableStateFlow(ServerValidationUiState())
@@ -110,6 +112,11 @@ class LoginViewModel(
 
     private fun stopValidation() {
         _serverValidationState.update { it.copy(validationRunning = false) }
+    }
+
+    // Reports a redirect that a browser with Auth Tab support handed back directly, as an activity result.
+    fun onOauthRedirect(url: String) {
+        appLinkNavigation.emit(url)
     }
 
     fun onOauthLoginCancelled() {

--- a/login/src/commonTest/kotlin/org/dhis2/mobile/login/main/LoginScreenIntegrationTest.kt
+++ b/login/src/commonTest/kotlin/org/dhis2/mobile/login/main/LoginScreenIntegrationTest.kt
@@ -18,6 +18,7 @@ import org.dhis2.mobile.login.main.domain.usecase.GetInitialScreen
 import org.dhis2.mobile.login.main.domain.usecase.ImportDatabase
 import org.dhis2.mobile.login.main.domain.usecase.ProcessDeviceEnrollment
 import org.dhis2.mobile.login.main.domain.usecase.ValidateServer
+import org.dhis2.mobile.login.main.ui.navigation.AppLinkNavigation
 import org.dhis2.mobile.login.main.ui.navigation.Navigator
 import org.dhis2.mobile.login.main.ui.viewmodel.LoginViewModel
 import org.dhis2.mobile.login.pin.data.SessionRepository
@@ -232,6 +233,7 @@ class LoginScreenIntegrationTest {
                 importDatabase = importDatabase,
                 validateServer = validateServer,
                 networkStatusProvider = networkStatusProvider,
+                appLinkNavigation = AppLinkNavigation(),
             )
     }
 

--- a/login/src/commonTest/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/LoginViewModelTest.kt
+++ b/login/src/commonTest/kotlin/org/dhis2/mobile/login/main/ui/viewmodel/LoginViewModelTest.kt
@@ -13,12 +13,14 @@ import org.dhis2.mobile.login.main.domain.model.ServerValidationResult
 import org.dhis2.mobile.login.main.domain.usecase.GetInitialScreen
 import org.dhis2.mobile.login.main.domain.usecase.ImportDatabase
 import org.dhis2.mobile.login.main.domain.usecase.ValidateServer
+import org.dhis2.mobile.login.main.ui.navigation.AppLinkNavigation
 import org.dhis2.mobile.login.main.ui.navigation.Navigator
 import org.dhis2.mobile.login.main.ui.state.DatabaseImportState
 import org.dhis2.mobile.login.main.ui.state.ServerValidationUiState
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.BeforeTest
@@ -37,6 +39,7 @@ class LoginViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val networkStatusProvider: NetworkStatusProvider = mock()
     private val mockNetworkStatusFlow = MutableStateFlow(true)
+    private val appLinkNavigation: AppLinkNavigation = mock()
 
     @BeforeTest
     fun setUp() {
@@ -63,6 +66,7 @@ class LoginViewModelTest {
                     importDatabase = importDatabase,
                     validateServer = validateServer,
                     networkStatusProvider = networkStatusProvider,
+                    appLinkNavigation = appLinkNavigation,
                 )
 
             verify(navigator).navigate(
@@ -97,6 +101,7 @@ class LoginViewModelTest {
                     importDatabase = importDatabase,
                     validateServer = validateServer,
                     networkStatusProvider = networkStatusProvider,
+                    appLinkNavigation = appLinkNavigation,
                 )
 
             viewModel.serverValidationState.test(timeout = 5.seconds) {
@@ -122,6 +127,49 @@ class LoginViewModelTest {
             }
         }
 
+    private suspend fun initViewModel(): LoginViewModel {
+        whenever(getInitialScreen()).thenReturn(
+            LoginScreenState.ServerValidation(
+                currentServer = "https://test.dhis2.org",
+                availableServers = listOf("https://test.dhis2.org"),
+                hasAccounts = false,
+            ),
+        )
+        return LoginViewModel(
+            navigator = navigator,
+            getInitialScreen = getInitialScreen,
+            importDatabase = importDatabase,
+            validateServer = validateServer,
+            networkStatusProvider = networkStatusProvider,
+            appLinkNavigation = appLinkNavigation,
+        ).also { viewModel = it }
+    }
+
+    @Test
+    fun `every oauth leg closes its browser destination when the tab reports closing`() =
+        runTest {
+            initViewModel()
+
+            // A tab that handed its redirect to the app is finished either way, so each leg pops
+            // here and the redirect that follows pushes the next one.
+            viewModel.onOauthLoginCancelled()
+            viewModel.onOauthLoginCancelled()
+            viewModel.onOauthLoginCancelled()
+
+            verify(navigator, times(3)).navigateUp()
+        }
+
+    @Test
+    fun `an auth tab redirect is routed to the same handler as an app link redirect`() =
+        runTest {
+            initViewModel()
+            val redirectUri = "dhis2oauth://oauth?code=auth-code&state=state"
+
+            viewModel.onOauthRedirect(redirectUri)
+
+            verify(appLinkNavigation).emit(redirectUri)
+        }
+
     @Test
     fun `cancel server validation stops the validation job`() =
         runTest {
@@ -140,6 +188,7 @@ class LoginViewModelTest {
                     importDatabase = importDatabase,
                     validateServer = validateServer,
                     networkStatusProvider = networkStatusProvider,
+                    appLinkNavigation = appLinkNavigation,
                 )
 
             viewModel.serverValidationState.test {
@@ -173,6 +222,7 @@ class LoginViewModelTest {
                     importDatabase = importDatabase,
                     validateServer = validateServer,
                     networkStatusProvider = networkStatusProvider,
+                    appLinkNavigation = appLinkNavigation,
                 )
 
             viewModel.importDatabaseState.test {
@@ -199,6 +249,7 @@ class LoginViewModelTest {
                     importDatabase = importDatabase,
                     validateServer = validateServer,
                     networkStatusProvider = networkStatusProvider,
+                    appLinkNavigation = appLinkNavigation,
                 )
 
             viewModel.importDatabaseState.test {

--- a/login/src/desktopMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.desktop.kt
+++ b/login/src/desktopMain/kotlin/org/dhis2/mobile/login/main/ui/screen/WebAuthenticator.desktop.kt
@@ -8,15 +8,14 @@ import java.net.URI
 @Composable
 actual fun WebAuthenticator(
     url: String,
+    redirectScheme: String,
+    onAuthCallback: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
     LaunchedEffect(url) {
         if (Desktop.isDesktopSupported()) {
             try {
                 Desktop.getDesktop().browse(URI(url))
-                // There is no direct way to know when the browser is dismissed on desktop,
-                // so we call onDismiss immediately.
-                // If you need to wait for a callback, a local server approach would be needed.
                 onDismiss()
             } catch (e: Exception) {
                 // Handle case where a browser is not available or other error


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7733).


- Added `<queries>` to the Android manifest to allow browser discovery for Custom Tabs and Auth Tab support on Android 11+.
- Implemented `AuthTabIntent` in `WebAuthenticator` to intercept OAuth redirects directly as activity results when supported by the browser.
- Unified redirect handling by routing direct Auth Tab callbacks through the same `AppLinkNavigation` flow used by standard App Links.
- Added concurrency guards in `CredentialsViewModel` to prevent exchanging the same single-use authorization code or enrollment token multiple times if duplicate callbacks arrive.
- Ensured proper navigation state by popping the browser destination via `onDismiss` while allowing the next leg of the flow to be pushed by the redirect handler.
- Refactored `WebAuthenticator` signature to include the redirect scheme and a callback for direct URI results.
- Added unit tests to verify handling of concurrent redirects and correct navigation behavior during multi-leg OAuth flows.