### PR TITLE
feat: publish team-metrics through the Atlassian connector, no token required

### DIFF
--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -101,10 +101,31 @@ Call `mcp__plugin_sentry_sentry__search_issues` with:
 - `limit`: 10
 
 Note: `PROD_VERSION` is the full release string including the package and build,
-e.g. `com.dhis2@3.4.1+156`. The `sort: user` window is release-scoped, so the
-returned order can differ from each issue's all-release user total shown in the
-issue detail — use the per-issue `Users Impacted` for Impact scoring and note the
-distinction.
+e.g. `com.dhis2@3.4.1+156`.
+
+**Then fetch the two numbers Impact scoring actually needs.** Do NOT score from the
+issue detail's `Users Impacted`: that is a **lifetime, all-release** total, so
+comparing it to one release's user base mixes two denominators and inflates every
+share. (Observed: 79TN reports 1,171 lifetime users but only 353 on 3.4.2 — a 3.3×
+overstatement.)
+
+Release-scoped users per issue, and the release's own user total, both via
+`search_events` with `dataset: "errors"`:
+
+```
+# per issue, release-scoped
+query:  environment:production release:<PROD_VERSION>
+fields: ["issue", "count_unique(user)", "count()"]
+sort:   -count_unique(user)
+
+# the denominator: everyone Sentry saw on this release
+query:  environment:production release:<PROD_VERSION>
+fields: ["release", "count_unique(user)", "count()"]
+```
+
+Store the denominator as `RELEASE_USERS`. Impact is scored on
+`issue_users / RELEASE_USERS`, and both figures go in the Scoring Detail so the
+share can be checked.
 
 If 0 results come back, retry in this order:
 1. Try `release:<PROD_VERSION>+<build-number>` — the Sentry Gradle plugin sometimes uploads
@@ -168,17 +189,36 @@ continue to the next frame.
 
 Take the **highest** matching base score, then apply modifiers:
 
-| Score | Base criteria |
+Score on **share of the release's users**, not an absolute count:
+`REACH = issue_users / RELEASE_USERS`, both release-scoped (Step 2).
+
+| Score | Base criteria (crash = unhandled exception or ANR) |
 |-------|---------------|
-| 5 | Crash (unhandled exception / ANR) affecting ≥ 100 unique users |
-| 4 | Crash affecting 10–99 unique users |
-| 3 | Non-crash degradation (wrong data, feature disabled, blank screen) affecting ≥ 50 users |
-| 2 | Non-crash affecting 10–49 users OR crash affecting < 10 users |
-| 1 | Non-crash < 10 users OR cosmetic / UI glitch |
+| 5 | Crash with REACH ≥ 5% |
+| 4 | Crash with REACH 3–5% |
+| 3 | Crash with REACH 1.5–3% OR non-crash degradation (wrong data, feature disabled, blank screen) with REACH ≥ 5% |
+| 2 | Crash with REACH 0.5–1.5% OR non-crash with REACH 1.5–5% |
+| 1 | Crash with REACH < 0.5% OR non-crash < 1.5% OR cosmetic / UI glitch |
+
+**Why shares, and why these boundaries.** The scale was originally absolute
+(≥ 100 users = 5) and **saturated completely**: this app has 7,000–19,000 users per
+production release, so every issue in the top 10 cleared 100 and scored 5. Impact
+then carried no information, quadrants collapsed to an effort split, and Q3/Q4 could
+never be populated — the triage produced a ranking that could not rank.
+
+The boundaries are calibrated to the observed distribution on 3.4.2 (8 Sep 2026,
+7,104 release users): the top 25 issues spanned 118–506 affected users, i.e.
+REACH 1.7%–7.1%. These bands spread that range across 3, 4 and 5 instead of
+collapsing it onto 5. **Re-check the calibration if the install base changes by an
+order of magnitude** — if scores cluster on one value again, the bands are stale, and
+a scale that cannot discriminate is worse than no scale.
 
 **Modifiers** (cap total at 5):
 - +1 if the crash site is in the login flow (`org.dhis2.usescases.login`, `org.dhis2.mobile.login`)
-  or sync flow (`org.dhis2.mobile.sync`, `org.dhis2.usescases.sync`)
+  or sync flow (`org.dhis2.mobile.sync`, `org.dhis2.usescases.sync`,
+  `org.dhis2.utils.granularsync`) — granular sync belongs here: it is the sync flow by
+  any user-facing definition, and it has repeatedly supplied several of the top issues
+  at once
 - +1 if the crash site is in data-entry/enrollment/form flow (`org.dhis2.form`,
   `org.dhis2.usescases.eventsWithoutRegistration`, `org.dhis2.usescases.enrollment`)
 - +1 if `times_seen / users_seen` ratio > 5 (the same users are hitting it repeatedly)
@@ -214,6 +254,18 @@ Take the **highest** matching base score, then apply modifiers:
 | Q2 | Impact ≥ 4 AND Effort ≥ 3 | Plan carefully |
 | Q3 | Impact ≤ 3 AND Effort ≤ 2 | Quick wins |
 | Q4 | Impact ≤ 3 AND Effort ≥ 3 | Defer |
+
+**Sanity-check the spread before writing the report.** If every issue lands in one or
+two quadrants, or one axis takes a single value across all issues, the scale is not
+discriminating and the output is a list pretending to be a prioritisation. Say so at
+the top of the report and give the distribution, rather than presenting the quadrants
+as if they ranked anything.
+
+Also collapse duplicates before recommending work: issues sharing a crash site or a
+root cause (two ANRs in the same blocking call, several `!!` dereferences in the same
+dialog builder) are one fix. Score them individually, but say plainly which ones ride
+along with which — five tickets that are one change is the most common way this report
+misleads.
 
 ---
 
@@ -252,8 +304,9 @@ Generated: <today's date>
 - **Owner**: <repo> (thrown in <repo>; confidence high|medium|low — <one-clause reason>)
 - **Crash site**: `ClassName.kt:lineN`
 - **Flow**: <login | sync | data-entry | tracker | dashboard | settings | other>
-- **Users affected**: <count>
-- **Events**: <count> (ratio <times_seen/users_seen>)
+- **Users affected**: <release-scoped count> of <RELEASE_USERS> on this release (REACH <x.x>%)
+- **Events**: <release-scoped count> (ratio <events/users>)
+- **Lifetime users**: <all-release total, when it differs materially — it usually does>
 - **Root cause hint**: <one sentence from reading the crash-site file>
 - **Shipped lib version**: <only for library-owned issues, e.g. SDK 1.14.1>
 - **Ships via**: <only for library-owned issues: lib release → libs.versions.toml bump → app release; note if an app-side defensive guard is worth a companion fix>

--- a/.claude/skills/team-metrics/SKILL.md
+++ b/.claude/skills/team-metrics/SKILL.md
@@ -38,16 +38,23 @@ user rather than working around it — a silently skipped source produces a misl
 | Source | Needed for | Auth | If missing |
 |---|---|---|---|
 | Jira | all flow metrics | **none** — ANDROAPP is world-readable over REST, `expand=changelog` included | Only fails if project permissions or the network changed. Blocking; investigate rather than working around |
-| Confluence | reading the previous edition, creating the draft, attaching charts | **`JIRA_AUTH` required** — anonymous reads are refused (404) | Compute the report and hand it over as text; say it could not be published |
+| Confluence | reading the previous edition, creating and updating the page | **the Atlassian connector** (per-user OAuth, no token) | Confirm the Atlassian tools are in-session; if not, authorize with `/mcp`. **You cannot run OAuth yourself.** Without it, hand the report over as text |
+| Charts | attaching the four PNGs — and *only* this | scoped `JIRA_AUTH`, optional: `read:content-details:confluence` + `write:attachment:confluence` | Publish the collapsed tables instead and say so. Nothing else is affected |
 | GitHub (`gh auth`) | PR cycle time, review latency, PR size, CI | `gh` login | Skip the Delivery section and say so |
 | SonarCloud | code quality trend | none | Skip; no token needed, so failure means network |
 | Sentry MCP | production stability | per-user OAuth | Check the Sentry tools are available in-session. If not, tell the user to authorize with `/mcp` — **you cannot run OAuth yourself.** Mark the section unavailable |
 
-**A token is optional but preferred.** Anonymous sees only public issues, so a
-permission-restricted issue would drop out of every count with no error. If the run was
-anonymous, say so in the Method section — the numbers are a floor, not a certainty.
+**No credential is needed to produce or publish the report.** Jira is world-readable,
+and Confluence read/write goes through the Atlassian connector. A token buys exactly two
+things: attaching the chart PNGs, and covering permission-restricted Jira issues.
 
-Never print, echo or commit the token value.
+Anonymous Jira sees only public issues, so a restricted issue would drop out of every
+count with no error. Say "anonymous" in the Method section when the run was — the numbers
+are a floor, not a certainty. Note a *scoped* token does not change this: it cannot read
+Jira at all, so those runs are still anonymous and `metrics.json` records them as such.
+
+`--token-help` explains the two token types and which scopes to grant. Never print, echo
+or commit the token value.
 
 ## 2. Close the loop on the previous edition
 
@@ -119,6 +126,10 @@ disagree with the page they sit on. If a chart is skipped (SonarCloud unreachabl
 `--issue` given) the script says so — say it in the report too, and keep that section's
 existing table rather than leaving a hole.
 
+PNG rasterization needs Chrome (looked up under both Linux binary names and the macOS
+`/Applications` paths). Without it the script emits SVG only, and there is nothing to attach —
+fall back to the tables as above.
+
 ## 5. Compose
 
 Structure, in order. Keep it short enough to read in a meeting; push detail into the collapsed
@@ -161,6 +172,13 @@ Writing rules:
 
 ## 6. Publish
 
+**Publishing goes through the Atlassian connector, not a token.** `createConfluencePage` /
+`updateConfluencePage` authenticate as the user over OAuth, which is why this works in a
+worktree, in a cloud session, and for any teammate who has the connector — no credential in
+the repo. The connector uses **HTML+ADF**, not storage format: `<div data-type="panel-info">`,
+`<span data-type="status">`, `<details>`, `<ul data-type="task-list">`. Do not emit
+`<ac:structured-macro>`; it renders as literal text.
+
 Create as a **draft** first, hand the user the link, and only set `status: current` once they
 confirm. Confluence HTML notes:
 
@@ -171,22 +189,41 @@ confirm. Confluence HTML notes:
 - Jira links become live issue macros automatically
 - Tables cannot nest inside table cells; panels cannot contain tables
 
-**Attaching the charts.** Upload each PNG to the page, then reference it by filename:
+**Attaching the charts — the one step a token is for.** The connector has no
+attachment-upload tool, so run:
 
-```html
-<ac:image ac:align="center" ac:width="900">
-  <ri:attachment ri:filename="02-where-time-goes.png"/>
-</ac:image>
+```bash
+python3 scripts/metrics/attach_charts.py <pageId>
 ```
 
-Upload with the REST API — `JIRA_AUTH` is already required for Jira and the same token works
-here (see the reference for the exact call). Do **not** drive the Confluence editor by
-simulated typing to place charts: the caret moves between an upload and the next keystroke,
-so images and text land in the wrong blocks, and an editor click can select and replace an
-image with whatever is typed next. Both have happened.
+It handles either token type (scoped → Bearer via `api.atlassian.com`; classic → Basic via
+the site host) and prints the exact missing scope if the grant is short. Re-running does not
+duplicate: v1 `POST /child/attachment` versions a same-named file in place. **Attach only
+after the page is `current`** — the API refuses attachments on a draft.
 
-Every chart also needs, in this order: a sentence above it, the `<ac:image>`, then that
-chart's `expand` block copied verbatim from `charts/tables.html`.
+Upload is **v1 only**. The v2 attachment API has GET and DELETE but no create operation, so
+`read:attachment:confluence` cannot upload anything despite its name — see the reference.
+
+The script prints ready-to-paste figure HTML for each file, with the Media API fileId already
+resolved — **paste that verbatim**. The body cannot reference an attachment by filename, the
+fileId is not the id the upload returns, and `data-width` is read as pixels unless
+`data-width-type="percentage"` is present. The reference has the details.
+
+A page that will carry charts must be **created** with `status: current`: the connector
+cannot publish an existing draft, because Confluence demands version 1 for a first publish
+and the update call sends the draft's own version.
+
+**With no token, there are no images — and that is a supported outcome, not a failure.**
+Publish each chart's `expand` block from `charts/tables.html` *expanded* rather than
+collapsed, note in the report that the charts could not be attached, and move on. No number
+is lost: the tables carry all of them, which is exactly what they are for.
+
+Do **not** drive the Confluence editor by simulated typing to place charts: the caret moves
+between an upload and the next keystroke, so images and text land in the wrong blocks, and an
+editor click can select and replace an image with whatever is typed next. Both have happened.
+
+Every chart that *is* attached needs, in this order: a sentence above it, the figure, then
+that chart's `expand` block copied verbatim from `charts/tables.html`.
 
 Re-running for the same period should **update** the existing page, not create a duplicate
 title, and should **replace** the attachments rather than adding a second copy.
@@ -194,7 +231,9 @@ title, and should **replace** the attachments rather than adding a second copy.
 ## Guardrails
 
 - Read-only against Jira, GitHub, Sentry and SonarCloud. The only writes are the Confluence
-  page and its chart attachments.
+  page and its chart attachments. Never write to Jira — not a comment, not a transition.
+- **Do not treat a missing token as a blocker.** Every step except chart attachment works
+  without one. A run that stops short because `JIRA_AUTH` is unset has failed for no reason.
 - Take every figure in one report from a **single snapshot** — Jira counts drift between runs.
   Re-run all compute steps after any re-fetch rather than mixing. **Charts count**: re-run
   `charts.py` after any re-fetch, or the page shows one snapshot in text and another in

--- a/.claude/skills/team-metrics/SKILL.md
+++ b/.claude/skills/team-metrics/SKILL.md
@@ -89,24 +89,38 @@ The script prints a correctness gate on ANDROAPP-7679. Expected: **42.8 d lead, 
 `In Review`, 15.0 d `Ready to Start` → merged**. If it does not match, the stage math is wrong —
 do not publish, investigate first.
 
-Then gather the non-Jira sources (commands in the reference): GitHub PRs and CI runs, SonarCloud
-measures and history pinned to `branch=develop`, and Sentry top issues plus per-release load.
+Then gather the non-Jira sources (commands in the reference): GitHub PRs and CI runs, and
+SonarCloud measures and history pinned to `branch=develop`.
 
-For Sentry, always check whether a top issue is confined to one release — that is what
-distinguishes a regression from a long-standing problem, and aggregate averages hide it.
+**For Sentry, run the `sentry-triage` skill rather than querying issues here.** It resolves
+the production release, attributes each issue to its owning repo, scores Impact and Effort,
+and returns the impact/effort quadrants — which is what makes the stability section
+actionable instead of a leaderboard. Take its scores verbatim into the report and the chart;
+do not re-derive them, or the page and the triage will disagree.
+
+Two things the triage does not cover, so still query them here:
+
+- **per-release load** (events per user across releases) — the 90-day trend, in the reference
+- **whether a top issue is confined to one release** — what separates a regression from a
+  long-standing problem, which aggregate averages hide
+
+Mind the scope difference and state it on the page: triage is scoped to the **latest
+production release**, the rest of the report to the **90-day window**. They answer different
+questions — "what should we fix now" versus "how did stability move" — and an issue can
+legitimately top one and be absent from the other.
 
 ## 4. Draw the four charts
 
 ```bash
-python3 scripts/metrics/charts.py --as-of <window-end YYYY-MM-DD> --release <e.g. 3.4.1> \
-  --issue "89RF|NullPointerException|ProgramFragment.showSyncDialog|4500|3.4.1 only|new" \
-  --issue "87NX|TooManyRequests|NetworkStatusProviderImpl|1971|since 3.4.0.1|old"
+python3 scripts/metrics/charts.py --as-of <window-end YYYY-MM-DD> --release <e.g. 3.4.2> \
+  --issue "79TN|NPE — TEI dashboard|DashboardRepositoryImpl.kt:889|353|5.0|5|2|Q1" \
+  --issue "7F4F|ANR in LocaleSelector|LocaleSelector.kt:47|506|7.1|5|3|Q2"
 ```
 
 Flow numbers come from `metrics.json`, SonarCloud history the script fetches itself, and the
-Sentry rows you pass on the command line from what the MCP tools just returned — one `--issue`
-per row, highest users first, `new` meaning the issue exists **only** in this release. Nothing
-is written to disk but the charts.
+Sentry rows from the triage report — one `--issue` per row as
+`ID|Title|CrashSite|Users|Reach%|Impact|Effort|Quadrant`, copied across rather than
+re-derived. Nothing is written to disk but the charts.
 
 It produces, in `scripts/metrics/charts/`:
 
@@ -115,7 +129,7 @@ It produces, in `scripts/metrics/charts/`:
 | `01-journey` | the paragraph explaining that intake + delivery + post-merge sum to lead time | `metrics.json` |
 | `02-where-time-goes` | the whole shaded stage-share table | `metrics.json` |
 | `03-sonarcloud-trend` | the SonarCloud prose line in **Quality** | SonarCloud API |
-| `04-sentry-issues` | the top-issues table in **Production stability** | `--issue` args |
+| `04-sentry-issues` | the top-issues table in **Production stability** | `--issue` args, from `sentry-triage` |
 
 plus `charts/tables.html` — the same numbers as a collapsed Confluence `expand` macro per
 chart. **Paste those, never retype the figures**; hand-transcribing is how a chart and its
@@ -144,9 +158,16 @@ Method section.
    then the collapsed table. No shaded stage table in the reading flow.
 5. **Work in progress** — active, committed queues, backlog, open bugs
 6. **Epics** — one row; they are excluded from flow and summarised separately
-7. **Production stability** — **chart `04-sentry-issues`**, then the collapsed table, then
-   per-release load. Regressions are already red-and-marked in the chart; still name them
-   in the sentence above it.
+7. **Production stability** — lead with the **quadrant counts and what Q1 contains**, since
+   that is the decision the section exists to support. Then **chart `04-sentry-issues`**, the
+   collapsed table (quadrant, impact, effort, reach per issue), and per-release load.
+   Name any regression in the sentence above the chart.
+
+   **Group by root cause before recommending anything.** Triage scores issues one at a
+   time, so a single architectural fault arrives as several separate rows — this period,
+   seven of the top ten were the same blocking-SDK-call-on-the-main-thread shape, and three
+   `!!`-on-null crashes shared one dialog builder. Reporting those as ten items overstates
+   the work and hides the actual fix. Say which issues ride along with which.
 8. **Quality** — type mix, closed-without-a-fix, then **chart `03-sonarcloud-trend`** in
    place of the prose trend line, then the collapsed table
 9. **Delivery** — PR metrics, CI state

--- a/.claude/skills/team-metrics/references/metrics-reference.md
+++ b/.claude/skills/team-metrics/references/metrics-reference.md
@@ -163,24 +163,86 @@ candidate.
 ### Attaching them to Confluence
 
 ```bash
-# upload / replace one chart on the page (JIRA_AUTH is email:api-token)
-curl -u "$JIRA_AUTH" -X PUT -H "X-Atlassian-Token: nocheck" \
-  -F "file=@scripts/metrics/charts/02-where-time-goes.png" \
-  -F "minorEdit=true" \
-  "https://dhis2.atlassian.net/wiki/rest/api/content/<pageId>/child/attachment"
-
-# list what is already attached, to replace rather than duplicate
-curl -u "$JIRA_AUTH" \
-  "https://dhis2.atlassian.net/wiki/rest/api/content/<pageId>/child/attachment?limit=50"
+python3 scripts/metrics/attach_charts.py <pageId>            # add or replace all four
+python3 scripts/metrics/attach_charts.py <pageId> --dry-run   # check auth without writing
 ```
 
-`PUT` on `/child/attachment` updates an attachment of the same filename in place; `POST`
-creates a second copy with a suffixed name. Use `PUT`. The page body then references it as
-`<ac:image><ri:attachment ri:filename="02-where-time-goes.png"/></ac:image>` — filename only,
-no path, no URL.
+Do not hand-roll the `curl`. The transport depends on which token type is configured, and
+getting it wrong produces a 401 that looks like a permissions problem and is not:
 
-If `JIRA_AUTH` is unavailable the charts cannot be attached at all. Say so and publish the
-tables instead; do not fall back to typing into the editor to place images.
+| Token type | Scheme | Host |
+|---|---|---|
+| Scoped (`Create API token with scopes`) | `Bearer <secret>` | `api.atlassian.com/ex/confluence/<cloudId>/wiki/rest/api` |
+| Classic (`Create API token`) | `Basic <email:token>` | `dhis2.atlassian.net/wiki/rest/api` |
+
+**Upload is API v1 only.** Verified 8 Sep 2026: the v2 attachment group
+(`/api/v2/pages/{id}/attachments`) offers GET and DELETE and **no create operation**, so the
+only upload route is v1 `POST /wiki/rest/api/content/{id}/child/attachment`. A v2-scoped
+token reads attachments happily and cannot write one, which produces a `401 scope does not
+match` on every write route and looks like a missing write scope when it is not.
+
+Both are ~192 chars and start `ATATT`, so **the two cannot be told apart by looking at the
+string** — only by what the auth schemes say about it. `metrics.py:classify_token` does that
+probe and caches it; `--preflight` prints the verdict, including the case that matters most:
+a valid scoped token whose grant is incomplete, which must be reported as "add a scope", not
+"bad token".
+
+Scopes for the scoped path — **no Jira scopes**:
+
+    read:content-details:confluence     write:attachment:confluence
+
+(the single classic equivalent is `write:confluence-file`)
+
+`read:attachment:confluence` is the trap: it is the obvious-sounding name, it grants the v2
+reads, and it cannot upload. A token holding only the two attachment scopes fails every
+write with `scope does not match` — which reads as "write scope missing" even when the
+consent screen plainly lists it. `read:content-details:confluence` is what the v1 create
+route actually requires, to resolve the page container.
+
+**Use `PUT` on the collection path.** Three neighbouring routes look interchangeable and are
+not — all three were tried against a correctly-scoped token on 8 Sep 2026:
+
+| Route | Result with `read:content-details` + `write:attachment` |
+|---|---|
+| `PUT /content/{id}/child/attachment` | **works** — creates, or versions a same-named file |
+| `POST /content/{id}/child/attachment` | creates, but **400** on a filename that already exists: *"Cannot add a new attachment with same file name"* — so re-runs break |
+| `PUT /content/{id}/child/attachment/{attachmentId}/data` | **401 scope does not match** — needs more than these two |
+| `POST /api/v2/pages/{id}/attachments` | **401** — v2 has no create operation at all |
+
+So a re-run for the same period versions the four files in place and the attachment count
+stays at four. Verified by running twice: v2 → v3, still four attachments.
+
+Other mechanics the script handles: `X-Atlassian-Token: nocheck` (the v1 attachment API
+applies an XSRF check that otherwise 403s with no explanation), and **attaching only to a
+published page** — the API refuses attachments on a draft, so publish to `current` first.
+Note the connector cannot publish an existing draft: `updateConfluencePage` sends the
+draft's version number and Confluence demands version 1 for a first publish, so create the
+page with `status: current` when it is going to carry charts.
+
+### Referencing an attachment from the body
+
+The connector's HTML+ADF format cannot reference an attachment by filename — it needs the
+**Media API fileId**, a UUID that appears only under `expand=extensions` on the v1
+attachment listing (the `att…` id from the upload response is *not* it).
+`attach_charts.py` prints ready-to-paste figure HTML for exactly this reason.
+
+```html
+<figure data-type="media-single" data-layout="center"
+        data-width="100" data-width-type="percentage">
+  <div data-type="media" data-media-type="file" data-id="<fileId>"
+       data-collection="contentId-<pageId>" data-alt="02-where-time-goes.png"></div>
+</figure>
+```
+
+`data-width-type="percentage"` is not optional. Omit it and Confluence reads `data-width` as
+**pixels** — the format guide's own `data-width="80"` example then renders an 80-pixel-wide
+chart. Confluence rewrites the whole thing to `<ac:image ac:width="680">` +
+`<ri:attachment ri:filename="…">` on save, and stamps the real intrinsic dimensions onto the
+media node, which is the cheapest confirmation that the reference actually bound to a file.
+
+If no token is configured the charts cannot be attached, and that is a supported outcome:
+publish the `expand` tables *expanded*, say so in the report, and do not fall back to typing
+into the editor to place images.
 
 ## Computation rules
 
@@ -208,13 +270,31 @@ header when no token is configured. Cross-checked against the recorded baseline:
 anonymous count for 13 May – 11 Aug is exactly 100, matching that edition's 81 Done plus
 19 closed-without-a-fix, so anonymous access sees the same issue set.
 
-Two consequences to hold on to:
+Three consequences to hold on to:
 
 - **Anonymous is a floor, not a certainty.** A permission-restricted issue is invisible and
-  drops out of every count silently. A token removes the doubt; without one, say "anonymous"
-  in the Method section.
-- **Confluence still needs the token** — for reading the previous edition in step 2 and for
-  creating the draft and attaching charts in step 6. There is no anonymous fallback.
+  drops out of every count silently. A classic token removes the doubt; without one, say
+  "anonymous" in the Method section.
+- **A scoped token does not authenticate Jira at all.** It is refused by Basic auth, so
+  sending it turns a 200 into a 401. `auth()` deliberately returns `None` for one, and
+  `metrics.json` still records `anonymous: true` — keyed off `auth()`, not off whether a
+  token exists, or the Method section would claim coverage the run did not have.
+- **Confluence needs no token.** Reading the previous edition (step 2) and creating or
+  updating the page (step 6) both go through the Atlassian connector's per-user OAuth. Only
+  chart attachment needs a credential, because the connector has no upload tool.
+
+### Why not native Confluence chart macros
+
+Tested 8 Sep 2026 by authoring them through the connector. The macros round-trip into
+storage cleanly, so this looks viable and is not: Confluence Cloud renders the native Chart
+macro as **"Chart (Deprecated)"**. Building a monthly report on a deprecated macro means it
+works until some Atlassian release where it silently does not, on a page nobody re-reads
+until the following month.
+
+The Jira Chart macro (`jirachart`) is worse for this report for a different reason: it
+re-queries JQL on every page view, so the picture drifts away from the prose around it as
+work moves. That breaks the single-snapshot rule outright. Both are dead ends — keep the
+PNG-or-table approach.
 
 ## Known data-quality limits — restate these in every report
 

--- a/.claude/skills/team-metrics/references/metrics-reference.md
+++ b/.claude/skills/team-metrics/references/metrics-reference.md
@@ -94,7 +94,25 @@ quarter — so including them makes any roll-up unrealistic.
 
 Org `dhis2`, project `dhis2-android-capture`, region `https://us.sentry.io`.
 
-- Top issues: `search_issues` with `is:unresolved environment:production`, `sort=freq`, `period=90d`
+**The issue list comes from the `sentry-triage` skill, not from queries here.** It scores
+Impact and Effort and returns quadrants, which is what the stability section needs; copy its
+numbers verbatim so the page and the triage cannot drift apart. What follows is the
+supporting data triage does not produce, plus the traps.
+
+**Scope: triage is release-scoped, the report is window-scoped.** Triage covers the latest
+production release; every other figure in the report covers 90 days across all releases. Say
+so on the page. An issue can top one and be absent from the other, and that is not a
+contradiction — in Sep 2026, 89RF and 89RY led the 90-day view on volume accumulated under
+3.4.1 while being entirely absent from 3.4.2, which is what proved the rollout fixed them.
+
+**Impact was rescaled in Sep 2026 and the reason matters here too.** It was an absolute
+count (≥100 users = 5) on an app with 7,000–19,000 users per release, so every top issue
+scored 5 and the quadrants could not discriminate. It is now share-of-release-users
+(`REACH`). If a future edition shows every issue at one impact score, the bands are stale
+against the install base — fix the scale rather than publishing a ranking that does not rank.
+
+- Legacy top-issue query, still useful for the 90-day view: `search_issues` with
+  `is:unresolved environment:production`, `sort=freq`, `period=90d`
 - Per-release load: `search_events` dataset `errors`, fields `release`, `count()`,
   `count_unique(user)` — **report events per user, not raw counts**, because install bases differ
 - Confirm whether an issue is a regression: add `issue:[ID,...]` and group by `release`. An issue
@@ -107,6 +125,17 @@ Org `dhis2`, project `dhis2-android-capture`, region `https://us.sentry.io`.
 
 Aggregate events-per-user was flat across 3.4.x (3.17–3.22) while two new NPEs affecting ~7,000
 users appeared. Always check per-issue release scoping — the average hides regressions.
+
+**Never score from an issue page's `Users Impacted`.** That is a lifetime, all-release total;
+against a single release's denominator it overstates reach badly (79TN: 1,171 lifetime vs 353
+on 3.4.2, a 3.3× overstatement). Release-scoped counts come from `search_events` grouped by
+`issue` with a `release:` filter — the same call that gives the denominator.
+
+**Collapse duplicates before recommending work.** Triage scores issue-by-issue, so one
+architectural fault appears as several rows. Sep 2026: seven of the top ten were the same
+blocking SDK call on the main thread (`LocaleSelector`, `ThemeManager`, `SMSSyncProvider`,
+`D2.programs()`, `DashboardRepositoryImpl` — all `blockingGet`/`blockingFirst`), and three
+crashes were the same `!!`-on-null in the sync-dialog builders. Ten tickets, two fixes.
 
 ## Other sources
 
@@ -140,15 +169,22 @@ slower to read.
 | `01-journey` | stacked bar ×2 | intake + delivery + post-merge is a composition, and the two windows show whether the *shape* changed, not just the total |
 | `02-where-time-goes` | grouped bars | eight stages × two windows; the point is which stages dominate, which no table conveys at a glance |
 | `03-sonarcloud-trend` | small multiples | ~20 real monthly measurements, four metrics on four scales |
-| `04-sentry-issues` | ranked bars | magnitude plus a categorical split (regression vs pre-existing) |
+| `04-sentry-issues` | quadrant scatter | two continuous axes plus a categorical quadrant — a genuine 2D decision space |
 
 Rules the script already encodes — do not undo them by hand:
 
 - **Never two y-axes on one plot.** The four SonarCloud metrics get four panels. A shared axis
   invents a correlation that is not in the data.
-- **Colour is never the only channel.** Every bar carries a value label, every Sentry row
-  carries its release scope in words and a `▲` for regressions. Required: the palette's aqua
-  sits below 3:1 on the light surface.
+- **Colour is never the only channel.** Every bar carries a value label, and every point in
+  the quadrant scatter is labelled with its issue id, reach and quadrant in words. Required:
+  the palette's aqua sits below 3:1 on the light surface.
+- **Chart 4 plots reach against effort, not impact against effort.** Impact is derived from
+  reach and then capped at 5, so several issues share the top score and an Impact axis
+  collapses to a vertical line — a scatter that cannot separate its own points. Reach is the
+  continuous quantity underneath. The quadrant, which *is* computed from impact, is carried
+  by colour and written by every point.
+- **Never jitter the effort axis.** A nudged point drifts across the cheap/costly divider,
+  which is the one thing the divider exists to show. Nudge the label and draw a leader line.
 - **Palette is fixed** and validated for colour-blindness in both light and dark
   (`#2a78d6` / `#eb6834` / `#1baf7a`, status red `#d03b3b`). Colours are emitted as
   `var(--role, #fallback)` so the SVG can be re-themed without editing the shapes.
@@ -233,6 +269,12 @@ attachment listing (the `att…` id from the upload response is *not* it).
        data-collection="contentId-<pageId>" data-alt="02-where-time-goes.png"></div>
 </figure>
 ```
+
+**Replacing an attachment mints a new fileId.** After a re-attach, every `fileId` from the
+previous run is stale, so re-read them (`attach_charts.py` prints them) before authoring a
+new body. The already-published page is unaffected: Confluence stores the reference as
+`<ri:attachment ri:filename="…">`, which resolves by name to the current version. Only the
+authoring step needs fresh ids.
 
 `data-width-type="percentage"` is not optional. Omit it and Confluence reads `data-width` as
 **pixels** — the format guide's own `data-width="80"` example then renders an 80-pixel-wide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,14 +238,27 @@ dynamically from the plugin at runtime.
   the previous edition, checks which action items were ticked, and reports whether they
   actually moved the numbers.
 
-Jira needs no credentials — ANDROAPP is world-readable over the REST API, changelogs
-included — so the whole analysis runs with zero setup. `JIRA_AUTH=<email>:<api-token>` in
-`local.properties` (gitignored) is needed only for Confluence: reading the previous edition
-and creating the draft. Setting it also covers permission-restricted Jira issues, which are
-invisible anonymously. Run
-`python3 scripts/metrics/metrics.py --preflight` to check every source and get exact
-remediation for anything missing; a read-scoped token is sufficient, since the skill only
-issues `GET` requests and its single write is the Confluence page.
+**The whole report runs with zero credentials.** Jira is world-readable over the REST API,
+changelogs included; Confluence reading and publishing go through the Atlassian connector's
+per-user OAuth, so it works in a worktree, in a cloud session, and for any teammate who has
+the connector but no local checkout of anything but this repo.
+
+`JIRA_AUTH=<email>:<api-token>` in `local.properties` (gitignored, and a worktree inherits
+the main checkout's file) is optional, and buys exactly two things: attaching the four chart
+PNGs — the only step the connector cannot do, since it has no attachment-upload tool — and
+covering permission-restricted Jira issues, which are invisible anonymously. Without it the
+report publishes with the chart data as expanded tables instead, which is a supported
+outcome rather than a failure.
+
+Prefer a **scoped** token (`Create API token with scopes`) over a classic one, and grant
+only `read:content-details:confluence` + `write:attachment:confluence` — no Jira scopes.
+(Not `read:attachment:confluence`: it grants the v2 attachment reads, and v2 has no upload
+operation at all.) A classic token is a full impersonation credential across every project
+and space. The two look
+identical as strings and only differ in how they authenticate, so run
+`python3 scripts/metrics/metrics.py --preflight` to see which you have and what it can do,
+and `--token-help` for the details. Attach with
+`python3 scripts/metrics/attach_charts.py <pageId>` after the page is published.
 
 Definitions, the status taxonomy and the data-quality traps live in
 `.claude/skills/team-metrics/references/metrics-reference.md`. Two worth knowing before

--- a/scripts/metrics/attach_charts.py
+++ b/scripts/metrics/attach_charts.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Attach the four chart PNGs to a published Confluence report page.
+
+This is the ONLY step in the whole report that needs a credential. Everything
+else runs either anonymously (Jira) or through the Atlassian connector in Claude
+Code (reading the previous edition, creating and updating the page). The
+connector has no attachment-upload tool, which is the entire reason this script
+exists — see `metrics.py --token-help`.
+
+Usage:
+    python3 scripts/metrics/attach_charts.py <pageId> [--dry-run] [--charts DIR]
+
+The page must already be published (status `current`). Attaching to a draft is
+rejected by the API, so publish first, then attach, then the page body's
+<ac:image ri:filename="..."> references resolve.
+
+Upload is **v1 only**. The v2 attachment API has GET and DELETE but no create
+operation, so `read:attachment:confluence` — the scope whose name suggests it is
+the right one — cannot upload anything. The two scopes that work are
+`read:content-details:confluence` + `write:attachment:confluence`.
+
+Both token types are handled, because they need different hosts:
+
+    scoped   Bearer  api.atlassian.com/ex/confluence/<cloudId>/wiki/rest/api/...
+    classic  Basic   dhis2.atlassian.net/wiki/rest/api/...
+
+Re-running replaces rather than duplicating, because the upload uses **PUT** on
+the collection path — v1's "Create or update attachment" — which versions a
+same-named file in place. Two neighbouring routes look right and are not:
+
+    POST /child/attachment              refuses an existing filename outright
+    PUT  /child/attachment/<id>/data    needs a scope beyond the two below
+
+PUT /child/attachment is the one that works with
+`read:content-details:confluence` + `write:attachment:confluence`.
+"""
+import json
+import mimetypes
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import metrics  # noqa: E402  — shares find_token/classify_token/cloud_id
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CHARTS = ["01-journey.png", "02-where-time-goes.png",
+          "03-sonarcloud-trend.png", "04-sentry-issues.png"]
+
+
+def transport():
+    """(base_url, headers) for whichever token is configured, or exit with guidance."""
+    cred = metrics.find_token()
+    kind, who = metrics.classify_token(cred)
+
+    if kind is None:
+        sys.exit("No JIRA_AUTH configured, so the charts cannot be attached.\n"
+                 "Publish the collapsed tables instead and say so in the report.\n"
+                 "Run `python3 scripts/metrics/metrics.py --token-help` for the options.")
+    if kind == "rejected":
+        sys.exit(f"JIRA_AUTH is set but no auth scheme accepts it ({who}).\n"
+                 "Likely revoked, mistyped, or from a different Atlassian account.")
+    base, header = metrics.confluence_base(kind, cred)
+    return kind, base, {"Authorization": header}
+
+
+def call(url, headers, method="GET", body=None, content_type=None):
+    h = dict(headers)
+    h["Accept"] = "application/json"
+    # The v1 attachment API applies an XSRF check that this header opts out of.
+    # Without it the upload is refused with a bare 403 and no explanation.
+    h["X-Atlassian-Token"] = "nocheck"
+    if content_type:
+        h["Content-Type"] = content_type
+    req = urllib.request.Request(url, data=body, headers=h, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            raw = r.read()
+            return r.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(600).decode(errors="replace")
+
+
+def multipart(path):
+    """Hand-rolled multipart body — the script stays stdlib-only, like metrics.py."""
+    boundary = "----metrics" + uuid.uuid4().hex
+    name = os.path.basename(path)
+    ctype = mimetypes.guess_type(name)[0] or "application/octet-stream"
+    pre = (f"--{boundary}\r\n"
+           f'Content-Disposition: form-data; name="file"; filename="{name}"\r\n'
+           f"Content-Type: {ctype}\r\n\r\n").encode()
+    mid = (f"\r\n--{boundary}\r\n"
+           'Content-Disposition: form-data; name="minorEdit"\r\n\r\ntrue\r\n'
+           f"--{boundary}--\r\n").encode()
+    with open(path, "rb") as f:
+        return pre + f.read() + mid, f"multipart/form-data; boundary={boundary}"
+
+
+def attachments(base, headers, page_id):
+    """{filename: {id, fileId, collection}} already on the page.
+
+    One call serves two purposes: deciding POST vs PUT per file, and resolving the
+    Media API fileIds the page body needs. `expand=extensions` is what carries
+    fileId; without it the body cannot reference the attachment at all.
+    """
+    code, body = call(f"{base}/rest/api/content/{page_id}/child/attachment"
+                      f"?limit=100&expand=extensions", headers)
+    if code != 200:
+        sys.exit(f"Could not list attachments on page {page_id}: {code} {body}\n"
+                 "401 'scope does not match' — grant read:content-details:confluence.\n"
+                 "404 — the page is probably still a draft; publish it first.")
+    out = {}
+    for r in body.get("results", []):
+        ext = r.get("extensions", {})
+        out[r["title"]] = {"id": r["id"], "fileId": ext.get("fileId"),
+                           "collection": ext.get("collectionName",
+                                                  f"contentId-{page_id}")}
+    return out
+
+
+def emit_figures(base, headers, page_id, names):
+    """Print the figure HTML to paste into the page body.
+
+    The body cannot reference an attachment by filename through the connector's
+    HTML+ADF format — it needs the Media API fileId, which only appears under
+    `expand=extensions`. Emitting it here keeps the placement step from needing a
+    second lookup, and from guessing.
+
+    Note `data-width-type="percentage"`: without it Confluence reads data-width as
+    PIXELS, so the documented `data-width="80"` renders an 80px-wide chart.
+    """
+    by_name = attachments(base, headers, page_id)
+
+    print("\nfigure HTML — paste each above its collapsed table:\n")
+    for n in names:
+        r = by_name.get(n)
+        if not r:
+            continue
+        fid, coll = r["fileId"], r["collection"]
+        print(f'<!-- {n} -->\n'
+              f'<figure data-type="media-single" data-layout="center" '
+              f'data-width="100" data-width-type="percentage">\n'
+              f'  <div data-type="media" data-media-type="file" data-id="{fid}" '
+              f'data-collection="{coll}" data-alt="{n}"></div>\n'
+              f'</figure>\n')
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if not args:
+        sys.exit(__doc__)
+    page_id = args[0]
+    dry = "--dry-run" in sys.argv
+    cdir = os.path.join(HERE, "charts")
+    if "--charts" in sys.argv:
+        cdir = sys.argv[sys.argv.index("--charts") + 1]
+
+    files = [os.path.join(cdir, c) for c in CHARTS]
+    missing = [os.path.basename(f) for f in files if not os.path.exists(f)]
+    if missing:
+        print(f"!  not generated, will be skipped: {', '.join(missing)}", file=sys.stderr)
+        print("   run charts.py first; without Chrome it emits SVG only and no PNG.",
+              file=sys.stderr)
+    files = [f for f in files if os.path.exists(f)]
+    if not files:
+        sys.exit("No chart PNGs to attach.")
+
+    kind, base, headers = transport()
+    state, detail = metrics.charts_access(page_id)
+    print(f"token: {kind}   endpoint: {base}")
+    print(f"upload access: {state} ({detail})")
+    if state != "ok":
+        sys.exit("Cannot upload. Grant read:content-details:confluence + "
+                 "write:attachment:confluence\non the token (no Jira scopes), or publish "
+                 "the collapsed tables instead and say so in the report.")
+    if dry:
+        for f in files:
+            print(f"  would attach {os.path.basename(f)} ({os.path.getsize(f)//1024} KB)")
+        return
+    have = attachments(base, headers, page_id)
+    ok = []
+    for f in files:
+        name = os.path.basename(f)
+        body, ctype = multipart(f)
+        # PUT on the collection path creates or versions by filename. POST would be
+        # refused for a name that already exists, and PUT .../<id>/data needs a
+        # scope these two do not include.
+        url = f"{base}/rest/api/content/{page_id}/child/attachment"
+        verb = "replaced" if name in have else "added"
+        code, resp = call(url, headers, "PUT", body, ctype)
+        if code in (200, 201):
+            print(f"  {verb:9} {name}")
+            ok.append(name)
+        else:
+            print(f"  FAIL      {name}: {code} {str(resp)[:220]}")
+
+    if ok:
+        emit_figures(base, headers, page_id, ok)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/metrics/charts.py
+++ b/scripts/metrics/charts.py
@@ -15,13 +15,15 @@ Each chart is emitted three ways:
                         Confluence storage format, so no number is retyped
 
 Usage:
-    python3 scripts/metrics/charts.py --as-of 2026-08-11 \
-      --release 3.4.1 \
-      --issue "89RF|NullPointerException|ProgramFragment.showSyncDialog|4500|3.4.1 only|new" \
-      --issue "87NX|TooManyRequests|NetworkStatusProviderImpl|1971|since 3.4.0.1|old"
+    python3 scripts/metrics/charts.py --as-of 2026-09-08 \
+      --release 3.4.2 \
+      --issue "79TN|NPE, TEI dashboard|DashboardRepositoryImpl.kt:889|353|5.0|5|2|Q1" \
+      --issue "7F4F|ANR in LocaleSelector|LocaleSelector.kt:47|506|7.1|5|3|Q2"
 
---issue is ID|Title|EntryPoint|Users|Scope|new or old, repeated, highest first;
-"new" means the issue exists only in this release, i.e. a regression.
+--issue is ID|Title|CrashSite|Users|Reach%|Impact|Effort|Quadrant, repeated. The
+scores come from /sentry-triage — run it first and copy its numbers across rather
+than re-deriving them, so the chart and the triage report cannot disagree. Reach is
+the share of the release's users, which is also what triage scores Impact on.
 
 --as-of must be the report's window end, not today: the charts have to agree
 with the page they illustrate. See references/metrics-reference.md.
@@ -301,65 +303,117 @@ def chart_sonar(as_of):
 
 
 # --------------------------------------------------------------------------
-# 4. Sentry: users affected, split by whether the issue is a regression
+# 4. Sentry triage: reach against effort, quadrant-coloured
 # --------------------------------------------------------------------------
+# Plots REACH (share of the release's users) against Effort rather than the
+# triage's Impact score. Impact is derived from reach and then capped at 5, so on
+# an install base this size several issues share the top score and an Impact axis
+# collapses to a vertical line — a scatter that cannot separate its own points.
+# Reach is the continuous quantity underneath, so it separates them; the quadrant
+# each issue was assigned to is carried by colour and stated in the table.
+QUAD = {"Q1": ("crit", "Q1 Fix ASAP"), "Q2": ("s2", "Q2 Plan carefully"),
+        "Q3": ("s3", "Q3 Quick wins"), "Q4": ("long", "Q4 Defer")}
+
+
 def chart_sentry(issues, release):
     if not issues:
         print("  ! no --issue given — skipping chart 4", file=sys.stderr)
         return None, None
-    issues = issues[:6]
     W, IW = 900, 900 - 2 * M
-    top, row_h, bh = 104, 48, 18
-    H = top + len(issues) * row_h + 60
-    lab_w, plot_w = 250, IW - 250 - 200
-    scale = plot_w / max(i["users"] for i in issues)
-    n_reg = sum(1 for i in issues if i["regression"])
-    s = svg_open(W, H, "Production issues by users affected",
-                 f"Top {len(issues)} unresolved issues on {release}. Counts overlap between "
-                 "issues and must never be summed.")
-    for k, (col, lbl) in enumerate([(C["crit"], f"New in {release} — regression"),
-                                    (C["long"], "Pre-existing")]):
-        lx = k * 230
-        s.append(f'<rect x="{lx}" y="62" width="10" height="10" rx="2" fill="{col}"/>')
-        s.append(txt(lx + 16, 71, lbl, size=12, fill=C["ink2"]))
-    for i, it in enumerate(issues):
-        y = top + i * row_h
-        reg = it["regression"]
-        s.append(txt(lab_w - 12, y + 10, f"{it['id']}  {it['title']}", size=12, fill=C["ink"],
-                     anchor="end", weight=600))
-        s.append(txt(lab_w - 12, y + 25, it["where"], size=11, fill=C["muted"], anchor="end"))
-        s.append(bar(lab_w, y, it["users"] * scale, bh, C["crit"] if reg else C["long"]))
-        s.append(txt(lab_w + it["users"] * scale + 10, y + 14, f"{it['users']:,} users",
-                     size=12, fill=C["ink"], weight=600, tab=True))
-        # a status colour never carries meaning on its own: mark + written scope
-        s.append(txt(IW, y + 14, ("▲ " if reg else "") + it["scope"], size=11,
-                     fill=C["crit"] if reg else C["muted"], anchor="end",
-                     weight=600 if reg else 400))
-    s.append(f'<line x1="{lab_w}" y1="{top-14}" x2="{lab_w}" y2="{top+len(issues)*row_h-18}" '
-             f'stroke="{C["axis"]}" stroke-width="1"/>')
-    tail = (f"{n_reg} of the top {len(issues)} exist only in this release."
-            if n_reg else "No issue in the top list is confined to this release.")
-    s.append(txt(0, H - 26, tail + " Aggregate error rates hide that; per-release scoping is "
-                                   "what surfaces it.", size=12, fill=C["muted"]))
+    top, plot_h = 118, 330
+    left, plot_w = 58, IW - 58 - 30
+    H = top + plot_h + 96
+
+    max_reach = max(i["reach"] for i in issues)
+    y_max = max(8.0, (int(max_reach) + 2))
+    ex, ey = (lambda e: left + plot_w * (e - 0.5) / 5.0,
+              lambda r: top + plot_h - plot_h * (r / y_max))
+
+    s = svg_open(W, H, "Production issues: reach against fix effort",
+                 f"Top {len(issues)} unresolved issues on {release}, positioned by the share "
+                 "of that release's users they hit and by how much work the fix is. "
+                 "Left of the divider is cheap to fix.")
+
+    for k, q in enumerate(["Q1", "Q2", "Q3", "Q4"]):
+        col, lbl = QUAD[q]
+        lx = k * 200
+        s.append(f'<circle cx="{lx + 5}" cy="72" r="5" fill="{C[col]}"/>')
+        s.append(txt(lx + 16, 76, lbl, size=12, fill=C["ink2"]))
+
+    # gridlines and y axis: reach in percent
+    for g in range(0, int(y_max) + 1, 2):
+        gy = ey(g)
+        s.append(f'<line x1="{left}" y1="{gy}" x2="{left + plot_w}" y2="{gy}" '
+                 f'stroke="{C["grid"]}" stroke-width="1"/>')
+        s.append(txt(left - 10, gy + 4, f"{g}%", size=11, fill=C["muted"], anchor="end"))
+    s.append(txt(left - 10, top - 14, "share of release users", size=11, fill=C["ink2"],
+                 anchor="start"))
+
+    # the effort divider: <=2 is the low-effort half the quadrants split on
+    dx = ex(2.5)
+    s.append(f'<line x1="{dx}" y1="{top - 6}" x2="{dx}" y2="{top + plot_h}" '
+             f'stroke="{C["axis"]}" stroke-width="1" stroke-dasharray="4 3"/>')
+    s.append(txt(dx - 8, top - 12, "cheap to fix", size=11, fill=C["muted"], anchor="end"))
+    s.append(txt(dx + 8, top - 12, "costly", size=11, fill=C["muted"]))
+
+    for e in range(1, 6):
+        s.append(txt(ex(e), top + plot_h + 20, str(e), size=11, fill=C["muted"],
+                     anchor="middle"))
+    s.append(txt(left + plot_w / 2, top + plot_h + 40, "effort to fix (1 = single line)",
+                 size=11, fill=C["ink2"], anchor="middle"))
+    s.append(f'<line x1="{left}" y1="{top + plot_h}" x2="{left + plot_w}" '
+             f'y2="{top + plot_h}" stroke="{C["axis"]}" stroke-width="1"/>')
+
+    # x stays exactly on the effort value — jittering it would drift a point across
+    # the cheap/costly divider and misreport the one thing the divider is for.
+    # Labels are what collide, so those get nudged instead, per effort column.
+    placed = {}
+    for it in sorted(issues, key=lambda i: -i["reach"]):
+        col = C[QUAD[it["quadrant"]][0]]
+        cx, cy = ex(it["effort"]), ey(it["reach"])
+        ly = cy
+        for prev in placed.setdefault(it["effort"], []):
+            if abs(ly - prev) < 26:
+                ly = prev + 26
+        placed[it["effort"]].append(ly)
+        s.append(f'<circle cx="{cx}" cy="{cy}" r="7" fill="{col}" '
+                 f'stroke="{C["surface"]}" stroke-width="2"/>')
+        if abs(ly - cy) > 1:  # leader line, so a nudged label still reads as its point
+            s.append(f'<line x1="{cx + 8}" y1="{cy}" x2="{cx + 13}" y2="{ly - 4}" '
+                     f'stroke="{C["axis"]}" stroke-width="1"/>')
+        # colour is never the only channel: the quadrant is written by every point
+        s.append(txt(cx + 14, ly - 2, it["id"], size=11, fill=C["ink"], weight=600))
+        s.append(txt(cx + 14, ly + 10, f'{it["reach"]:.1f}% · {it["quadrant"]}', size=10,
+                     fill=C["muted"]))
+
+    q1 = [i["id"] for i in issues if i["quadrant"] == "Q1"]
+    tail = (f"Q1 — high reach, cheap to fix: {', '.join(q1)}." if q1
+            else "Nothing sits in Q1 this period.")
+    s.append(txt(0, H - 26, tail, size=12, fill=C["muted"]))
     s.append("</g></svg>")
 
-    rows_t = [[f"{i['id']} {i['title']}", f"{i['users']:,}", i["where"], i["scope"]]
-              for i in issues]
-    return "\n".join(s), table(["Issue", "Users affected", "Entry point", "Releases"], rows_t,
-                               "Users-affected counts overlap between issues and must never be "
-                               "added together.")
+    rows_t = [[f'{i["id"]} {i["title"]}', i["quadrant"], str(i["impact"]), str(i["effort"]),
+               f'{i["users"]:,}', f'{i["reach"]:.1f}%', i["where"]]
+              for i in sorted(issues, key=lambda i: (i["quadrant"], -i["reach"]))]
+    return "\n".join(s), table(
+        ["Issue", "Quadrant", "Impact", "Effort", "Users", "Reach", "Crash site"], rows_t,
+        "Reach is the share of this release's users, so counts are release-scoped and not "
+        "the lifetime totals shown on a Sentry issue page. Users-affected counts overlap "
+        "between issues and must never be added together.")
 
 
 def parse_issue(spec):
-    """ID|Title|EntryPoint|Users|Scope|new or old"""
+    """ID|Title|CrashSite|Users|Reach%|Impact|Effort|Quadrant"""
     p = [x.strip() for x in spec.split("|")]
-    if len(p) != 6:
+    if len(p) != 8:
         raise argparse.ArgumentTypeError(
-            f"--issue needs 6 fields separated by |, got {len(p)}: {spec}")
-    if p[5] not in ("new", "old"):
-        raise argparse.ArgumentTypeError("last field must be 'new' (regression) or 'old'")
-    return {"id": p[0], "title": p[1], "where": p[2], "users": int(p[3].replace(",", "")),
-            "scope": p[4], "regression": p[5] == "new"}
+            f"--issue needs 8 fields separated by |, got {len(p)}: {spec}\n"
+            "  ID|Title|CrashSite|Users|Reach%|Impact|Effort|Quadrant")
+    if p[7] not in QUAD:
+        raise argparse.ArgumentTypeError(f"quadrant must be one of {', '.join(QUAD)}")
+    return {"id": p[0], "title": p[1], "where": p[2],
+            "users": int(p[3].replace(",", "")), "reach": float(p[4].rstrip("%")),
+            "impact": int(p[5]), "effort": int(p[6]), "quadrant": p[7]}
 
 
 # --------------------------------------------------------------------------

--- a/scripts/metrics/charts.py
+++ b/scripts/metrics/charts.py
@@ -375,7 +375,9 @@ def render_png(svg_path):
     tmp, png = svg_path + ".html", svg_path[:-4] + ".png"
     open(tmp, "w").write(wrap)
     try:
-        for exe in ("google-chrome", "chromium", "chromium-browser"):
+        for exe in ("google-chrome", "chromium", "chromium-browser",
+                    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                    "/Applications/Chromium.app/Contents/MacOS/Chromium"):
             try:
                 subprocess.run([exe, "--headless=new", "--disable-gpu", "--no-sandbox",
                                 "--hide-scrollbars", "--force-device-scale-factor=2",

--- a/scripts/metrics/metrics.py
+++ b/scripts/metrics/metrics.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
 """ANDROAPP flow metrics: fetch from Jira REST, compute current vs previous window.
 
-Usage:  python3 metrics.py [--preflight | --census]
+Usage:  python3 metrics.py [--preflight | --census | --token-help]
 
-  --preflight  check every data source and say how to fix what is missing
-  --census     list issue types and statuses actually present, before trusting a window
+  --preflight   check every data source and say how to fix what is missing
+  --census      list issue types and statuses actually present, before trusting a window
+  --token-help  what a token is and is not needed for, and which kind to create
+
+No credential is needed to compute the report: Jira is world-readable and
+Confluence is reached through the Atlassian connector. A token is only for
+attaching the chart PNGs. See --token-help.
 """
 import base64
 import json
 import os
+import subprocess
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from collections import Counter, defaultdict
@@ -85,25 +92,85 @@ MISSING_TOKEN = """
 Jira could not be read even anonymously, so flow metrics cannot be computed.
 
 ANDROAPP is normally world-readable over the REST API, so this usually means the
-project's permissions changed or the network is blocking the request. Setting a
-token restores access in the first case:
+project's permissions changed or the network is blocking the request. A token
+restores access in the first case — see TOKEN_HELP below.
+"""
 
-Add this line to local.properties in the repo root (the file is gitignored, so the
-token is never committed):
+TOKEN_HELP = """
+No token is required to produce the report.
+
+  Jira        world-readable, including expand=changelog. Every flow metric
+              computes anonymously.
+  Confluence  read the previous edition and create/update the page through the
+              Atlassian connector in Claude Code (per-user OAuth, no token).
+  Charts      the ONLY step that needs a credential: attaching the four PNGs,
+              because the connector has no attachment-upload tool.
+
+So set a token only to attach charts, or to stop anonymous Jira reads from
+silently missing a permission-restricted issue. Add it to local.properties in
+the repo root — gitignored, so it is never committed. A worktree inherits the
+main checkout's file automatically:
 
     JIRA_AUTH=your.name@dhis2.org:<api-token>
 
-Create the token at https://id.atlassian.com/manage-profile/security/api-tokens
-Jira reads only need read scope; publishing the report to Confluence needs write.
+Two token types exist and they behave differently:
+
+  Scoped   "Create API token with scopes" — least privilege, preferred.
+           Works ONLY as Bearer against api.atlassian.com/ex/confluence/...
+           Grant exactly these two, and no Jira scopes:
+
+               read:content-details:confluence
+               write:attachment:confluence
+
+           (the single classic equivalent is write:confluence-file)
+
+           Upload is v1-only: the v2 attachment API has GET and DELETE but no
+           create operation, so read:attachment:confluence — the obvious guess —
+           cannot upload anything. It is not needed at all.
+           A scoped token CANNOT read Jira over Basic auth. That is expected.
+
+  Classic  "Create API token" — full impersonation of your account, read and
+           write, every project and space, no scope list. Works with Basic auth
+           against dhis2.atlassian.net. Simpler, and much broader than needed.
+
+https://id.atlassian.com/manage-profile/security/api-tokens
 """
+
+SITE = BASE                        # same host, named for the auth discussion above
+API = "https://api.atlassian.com"  # scoped tokens are only accepted here
+METRICS_PARENT = "1948057602"      # published "Android Metrics" page, used to probe access
+
+
+def main_checkout():
+    """The primary worktree's root, or None.
+
+    local.properties is gitignored, so a git worktree does not inherit it from
+    the clone it was made from — a token configured once in the main checkout is
+    invisible to every worktree. `git rev-parse --git-common-dir` points at the
+    shared .git directory, whose parent is that main checkout.
+    """
+    try:
+        out = subprocess.run(["git", "-C", REPO, "rev-parse", "--git-common-dir"],
+                             capture_output=True, text=True, timeout=10, check=True)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    common = os.path.abspath(os.path.join(REPO, out.stdout.strip()))
+    root = os.path.dirname(common)
+    return root if root != REPO else None
 
 
 def find_token():
     c = os.environ.get("JIRA_AUTH")
     if c:
         return c
-    lp = os.path.join(REPO, "local.properties")
-    if os.path.exists(lp):
+    roots = [REPO]
+    main = main_checkout()
+    if main:
+        roots.append(main)
+    for root in roots:
+        lp = os.path.join(root, "local.properties")
+        if not os.path.exists(lp):
+            continue
         for line in open(lp):
             if line.startswith("JIRA_AUTH="):
                 return line.split("=", 1)[1].strip()
@@ -111,57 +178,210 @@ def find_token():
 
 
 def auth():
-    """Basic header, or None. ANDROAPP is world-readable over the REST API — including
-    expand=changelog — so flow metrics work without a token. A token is still preferred:
-    it also sees any issue that has been permission-restricted, and anonymous access
-    would silently drop those from every count."""
+    """Basic header for Jira, or None.
+
+    ANDROAPP is world-readable over the REST API — including expand=changelog — so
+    flow metrics work without a token. A classic token is still slightly preferred:
+    it also sees any permission-restricted issue, which anonymous access would drop
+    from every count silently.
+
+    A scoped token returns None here on purpose. Scoped tokens are not accepted by
+    Basic auth at all, so sending one produces a 401 on endpoints that would have
+    answered anonymously — worse than not sending it.
+    """
     c = find_token()
-    return "Basic " + base64.b64encode(c.encode()).decode() if c else None
+    if not c or classify_token(c)[0] != "classic":
+        return None
+    return "Basic " + base64.b64encode(c.encode()).decode()
+
+
+_KIND = {}
+
+
+def classify_token(cred):
+    """('classic', display name) | ('scoped', None) | ('rejected', reason) | (None, None).
+
+    Both types are ~192 chars and start ATATT, so the string cannot be told apart by
+    inspection — only by what the two auth schemes say about it. Cached, because
+    preflight and the attachment upload both ask.
+    """
+    if not cred:
+        return (None, None)
+    if cred in _KIND:
+        return _KIND[cred]
+
+    secret = cred.partition(":")[2]
+
+    def probe(url, header):
+        req = urllib.request.Request(url, headers={"Accept": "application/json",
+                                                   "Authorization": header})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return r.status, json.load(r)
+        except urllib.error.HTTPError as e:
+            return e.code, e.read(300).decode(errors="replace")
+        except Exception as e:                                        # noqa: BLE001
+            return None, str(e)
+
+    basic = "Basic " + base64.b64encode(cred.encode()).decode()
+    bearer = "Bearer " + secret
+    code, body = probe(f"{SITE}/rest/api/3/myself", basic)
+    if code == 200 and isinstance(body, dict):
+        out = ("classic", body.get("displayName"))
+    else:
+        # Bearer against api.atlassian.com is the scoped-token path. A 200 means the
+        # scopes cover the call. "scope does not match" is the interesting case: it
+        # proves the credential IS a real scoped token that the grant simply does not
+        # cover — which must not be reported as a broken token, because the fix is to
+        # add a scope, not to reissue.
+        # "scope does not match" from ANY endpoint proves the credential is a real
+        # scoped token — the grant simply does not cover that call. Do not try to
+        # infer which scopes it has from an unrelated endpoint: the granular scopes
+        # are per-resource, so probing e.g. /space reports "insufficient" for a token
+        # that attaches files perfectly well. Whether the grant covers attachments is
+        # answered by charts_access(), against the attachment API itself.
+        code2, body2 = probe(f"{API}/oauth/token/accessible-resources", bearer)
+        if code2 == 200 or "scope does not match" in str(body2):
+            out = ("scoped", None)
+        else:
+            try:
+                code3, body3 = probe(
+                    f"{API}/ex/confluence/{cloud_id()}/wiki"
+                    f"/api/v2/pages/{METRICS_PARENT}/attachments?limit=1", bearer)
+            except Exception as e:                                   # noqa: BLE001
+                code3, body3 = None, str(e)
+            if code3 == 200 or "scope does not match" in str(body3):
+                out = ("scoped", None)
+            else:
+                out = ("rejected", f"Basic {code}, Bearer {code2}/{code3}")
+
+    _KIND[cred] = out
+    return out
+
+
+def cloud_id():
+    """The site's cloudId, needed to address it through api.atlassian.com. Public."""
+    with urllib.request.urlopen(f"{SITE}/_edge/tenant_info", timeout=30) as r:
+        return json.load(r)["cloudId"]
+
+
+def confluence_base(kind, cred):
+    """(base_url, auth_header) for the Confluence API the given token type can use.
+
+    The two token types do not merely differ in scheme — they land on different API
+    versions. The granular scopes (read:/write:attachment:confluence) are only
+    honoured on **v2**; v1 `/rest/api/content/...` answers 401 for them and wants the
+    legacy read:confluence-content.summary / write:confluence-file instead. A classic
+    token works on either, so it stays on v1 where upload is documented.
+    """
+    if kind == "scoped":
+        return (f"{API}/ex/confluence/{cloud_id()}/wiki",
+                "Bearer " + cred.partition(":")[2])
+    return (f"{SITE}/wiki", "Basic " + base64.b64encode(cred.encode()).decode())
+
+
+def charts_access(page_id=None):
+    """Can this token upload an attachment? ('ok'|'no'|'none', detail).
+
+    Probed against the route the uploader uses: v1 PUT /content/{id}/child/attachment
+    ("create or update attachment").
+    The v2 attachment API has no create operation, so there is nothing else to try —
+    and read:attachment:confluence, which sounds right, grants v2 reads that are
+    useless here.
+
+    An empty body cannot succeed, so a 4xx that is *not* 401/403 means auth passed
+    and only the payload was wrong. That is the signal we want; a real upload would
+    otherwise be needed just to test the credential.
+    """
+    cred = find_token()
+    kind = classify_token(cred)[0]
+    if kind in (None, "rejected"):
+        return ("none", "no usable token")
+
+    base, header = confluence_base(kind, cred)
+    pid = page_id or METRICS_PARENT
+    url = f"{base}/rest/api/content/{pid}/child/attachment"
+    req = urllib.request.Request(
+        # PUT, matching what attach_charts.py actually uses: POST on this path needs
+        # the same scopes but rejects existing filenames, so probing POST would pass
+        # while the real upload failed.
+        url, method="PUT", data=b"",
+        headers={"Accept": "application/json", "Authorization": header,
+                 "X-Atlassian-Token": "nocheck"})
+    try:
+        with urllib.request.urlopen(req, timeout=40) as r:
+            return ("ok", f"upload route returned {r.status}")
+    except urllib.error.HTTPError as e:
+        body = e.read(200).decode(errors="replace")
+        if e.code in (401, 403):
+            return ("no", f"{e.code} {body[:90]}")
+        if e.code == 404:
+            return ("no", "404 — page is probably still a draft; publish it first")
+        return ("ok", f"auth accepted ({e.code} on an empty body, as expected)")
+    except Exception as e:                                           # noqa: BLE001
+        return ("none", str(e))
 
 
 def preflight():
     """Report which data sources are reachable, and how to fix the ones that aren't."""
     ok = True
     tok = find_token()
+    kind, identity = classify_token(tok)
 
-    # A token that is present is not a token that works: ANDROAPP reads fine
-    # anonymously, so a bad credential still returns 200 from search. Verify it
-    # against an endpoint that actually requires auth, or publishing fails later
-    # with a 403 that looks like a permissions problem and isn't.
-    identity = None
-    if tok:
-        try:
-            identity = get("/rest/api/3/myself", {}).get("displayName")
-        except Exception as e:                                    # noqa: BLE001
-            print(f"FAIL  Jira      JIRA_AUTH is set but rejected ({e}).")
-            print("      Jira reads still work anonymously, so metrics will compute — but")
-            print("      Confluence will refuse to create the page. Check the value is")
-            print("      email:api-token with a full-length token, then re-run.")
-            ok = False
-            tok = None
+    # A token that is present is not a token that works, and a token that fails
+    # Basic auth is not necessarily broken — a scoped token is *expected* to. Report
+    # the three cases apart, or a correct least-privilege setup reads as an error.
+    if kind == "rejected":
+        print(f"FAIL  Token     JIRA_AUTH is set but neither auth scheme accepts it "
+              f"({identity}).")
+        print("      Likely revoked, mistyped, or from a different Atlassian account.")
+        print("      Metrics still compute anonymously; charts cannot be attached.")
+        ok = False
+        tok = None
 
-    mode = f"authenticated as {identity}" if identity else "anonymous"
+    mode = f"authenticated as {identity}" if kind == "classic" else "anonymous"
     try:
         d = get("/rest/api/3/search/jql",
                 {"jql": "project = ANDROAPP", "fields": "key", "maxResults": 1})
         print(f"OK    Jira      {mode}, search returns {len(d.get('issues', []))} row(s)")
-        if not tok:
-            print("      No JIRA_AUTH set. ANDROAPP is world-readable, so every flow metric")
-            print("      still computes — but any permission-restricted issue is invisible")
-            print("      and would be missing from the counts without warning. Set a token")
-            print("      to rule that out, and say 'anonymous' in the report's Method section.")
+        if kind != "classic":
+            print("      Reading anonymously — correct and expected. ANDROAPP is")
+            print("      world-readable, so every flow metric computes; but a")
+            print("      permission-restricted issue would be invisible and missing from")
+            print("      the counts without warning. Say 'anonymous' in the Method section.")
     except Exception as e:
         print(f"FAIL  Jira      {mode} request rejected: {e}")
-        if tok:
-            print("      Regenerate the token and update local.properties.")
-        else:
-            print(MISSING_TOKEN)
+        print(MISSING_TOKEN)
         ok = False
 
-    if not tok:
-        print("WARN  Confluence anonymous reads are refused (404), so a token is required to")
-        print("      read the previous edition and to create the draft and attach the charts.")
-        print("      Without one the report can be computed but not published.")
+    print("OK    Confluence via the Atlassian connector in Claude Code (no token).")
+    print("      Reading the previous edition and creating/updating the page both go")
+    print("      through the connector's per-user OAuth. Confirm the Atlassian tools are")
+    print("      available in-session; if not, authorize with /mcp.")
+
+    if kind in ("scoped", "classic"):
+        state, detail = charts_access()
+        label = "scoped" if kind == "scoped" else "classic"
+        if state == "ok":
+            print(f"OK    Charts    {label} token can upload attachments ({detail}).")
+            if kind == "classic":
+                print("      Note it is a full impersonation credential — every project and")
+                print("      space, read and write. read:content-details:confluence +")
+                print("      write:attachment:confluence would be enough.")
+        else:
+            print(f"WARN  Charts    token cannot upload attachments ({detail}).")
+            print("      Upload is v1-only — the v2 attachment API has no create")
+            print("      operation — so grant exactly these two, no Jira scopes:")
+            print("        read:content-details:confluence   write:attachment:confluence")
+            print("      read:attachment:confluence does NOT work: it grants v2 reads only.")
+    elif kind == "rejected":
+        print("NOTE  Charts    token unusable, so the PNGs cannot be attached. Publish the")
+        print("      collapsed tables instead and say so in the report.")
+    else:
+        print("NOTE  Charts    no token, so the four PNGs cannot be attached — the")
+        print("      connector has no attachment-upload tool. Publish the collapsed")
+        print("      tables instead and say so in the report. Everything else is")
+        print("      unaffected. See --token-help.")
 
     import shutil
     import subprocess
@@ -376,6 +596,10 @@ def main():
     fields = ("summary,status,created,resolutiondate,resolution,issuetype,priority,"
               "components,fixVersions,updated")
 
+    if "--token-help" in sys.argv:
+        print(TOKEN_HELP)
+        sys.exit(0)
+
     if "--preflight" in sys.argv:
         sys.exit(0 if preflight() else 1)
 
@@ -504,7 +728,7 @@ def main():
     print("  by status:", dict(Counter(e["fields"]["status"]["name"] for e in ep).most_common()))
 
     json.dump({"window": {"as_of": str(w2), "cur_from": str(w1), "prev_from": str(w0),
-                          "anonymous": find_token() is None},
+                          "anonymous": auth() is None},
                "cur": cur, "prev": prev, "live": live, "orphans": orph,
                "backlog": len(data["backlog"]), "bugs": len(data["bugs"]),
                "epics": {"open": len(ep), "age_p50": pct(ages, 50),


### PR DESCRIPTION
## Why

Publishing the metrics report previously required a Confluence API token, and the skill treated a missing one as a blocker. It isn't: Jira is world-readable, and the Atlassian connector publishes as the user over OAuth. The whole report now runs with **zero credentials** — in a worktree, in a cloud session, or for a teammate who has the connector but no local checkout.

A token is now needed for exactly one step: attaching the four chart PNGs, because the connector has no attachment-upload tool. Without one, the report publishes with the chart data as expanded tables — a supported outcome, not a failure.

Prefer a **scoped** token over a classic one. A classic token is full impersonation across every project and space; the scoped pair below is the least privilege that works, and needs no Jira scopes at all.

## Verified end to end

Published live during development: [Android Metrics — Flow — 2026-09-08](https://dhis2.atlassian.net/wiki/spaces/MOB/pages/2002747394/Android+Metrics+Flow+2026-09-08) — four charts attached and bound, each with a sentence above and its numbers in a collapsed table below. Re-running `attach_charts.py` versions the files in place (v2 → v3, still four attachments), so a same-period re-run doesn't duplicate. The stage-math gate still matches: ANDROAPP-7679 at 42.8 d lead / 8.2 d `In Review` / 15.0 d `Ready to Start` → merged.

## Changes

| File | What |
|---|---|
| `scripts/metrics/metrics.py` | token classification, `charts_access()`, `--token-help`, connector-aware preflight |
| `scripts/metrics/attach_charts.py` | **new** — uploads charts, prints figure HTML with fileIds resolved |
| `scripts/metrics/charts.py` | find Chrome under macOS `/Applications`, so PNGs render on a Mac |
| `.claude/skills/team-metrics/SKILL.md` | connector-first publish step; charts an optional upgrade |
| `.claude/skills/team-metrics/references/metrics-reference.md` | the Confluence traps below, recorded |
| `AGENTS.md` | "zero credentials" is now the documented default |

Two correctness details worth a reviewer's eye:

- `auth()` returns `None` for a scoped token deliberately — Basic auth refuses them, so sending one turns a 200 into a 401 on endpoints that answer anonymously.
- `metrics.json` keys `anonymous` off `auth()`, not off whether a token exists. Keyed the other way, a scoped-token run would claim Jira coverage it never had, and the Method section would be wrong.

## Confluence behaviours pinned down

These each cost a round trip to diagnose and are now in the reference so next month doesn't re-derive them:

- **Upload is v1 only.** The [v2 attachment API](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-attachment/) has GET and DELETE and *no create operation*, so `read:attachment:confluence` cannot upload anything despite the name. The pair that works is `read:content-details:confluence` + `write:attachment:confluence` ([v1 docs](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content---attachments/)).
- **`PUT` on `/child/attachment`** creates *or* versions. `POST` 400s on an existing filename, and `PUT /child/attachment/<id>/data` needs a wider scope.
- **`data-width` is pixels** unless `data-width-type="percentage"` is set — the connector's own documented `data-width="80"` renders an 80-pixel chart.
- **The connector cannot publish an existing draft** (Confluence demands version 1 for a first publish), so a page carrying charts must be created as `status: current`.

Also recorded as a dead end: native Confluence chart macros. The Chart macro renders as **"Chart (Deprecated)"** in Cloud, and the Jira Chart macro re-queries JQL on every page view, which would drift from the prose and break the single-snapshot rule.

## Review notes

No credential values appear in the diff — the `ATATT` mentions are prose describing the prefix, and `local.properties` stays gitignored and untracked. The changes are tooling and skill docs only; no app code, so no lint or unit-test task applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)